### PR TITLE
chore: Bump version to 0.1.13 after merge to master

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 __author__ = "Merobox Team"
 __email__ = "team@merobox.com"

--- a/merobox/cli.py
+++ b/merobox/cli.py
@@ -23,7 +23,7 @@ from merobox.commands import (
 
 
 @click.group()
-@click.version_option(version="0.1.12")
+@click.version_option(version="0.1.13")
 def cli():
     """Merobox CLI - Manage Calimero nodes in Docker containers."""
     pass

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="merobox",
-    version="0.1.12",
+    version="0.1.13",
     author="Merobox Team",
     author_email="team@merobox.com",
     description="A Python CLI tool for managing Calimero nodes in Docker containers",


### PR DESCRIPTION
- Update version in __init__.py, setup.py, and cli.py
- Aligns with PyPI release 0.1.13 that was already published