### PR TITLE
feat(Auth): Implement auth service

### DIFF
--- a/merobox/commands/bootstrap/bootstrap.py
+++ b/merobox/commands/bootstrap/bootstrap.py
@@ -37,7 +37,8 @@ def bootstrap():
 @bootstrap.command()
 @click.argument("config_file", type=click.Path(exists=True), required=True)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-def run(config_file, verbose):
+@click.option("--auth-service", is_flag=True, help="Enable authentication service with Traefik proxy")
+def run(config_file, verbose, auth_service):
     """
     Execute a Calimero workflow from a YAML configuration file.
 
@@ -48,7 +49,7 @@ def run(config_file, verbose):
     4. Handle dynamic variable resolution
     5. Export results and captured values
     """
-    success = run_workflow_sync(config_file, verbose)
+    success = run_workflow_sync(config_file, verbose, auth_service)
     if not success:
         sys.exit(1)
 

--- a/merobox/commands/bootstrap/bootstrap.py
+++ b/merobox/commands/bootstrap/bootstrap.py
@@ -37,7 +37,11 @@ def bootstrap():
 @bootstrap.command()
 @click.argument("config_file", type=click.Path(exists=True), required=True)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-@click.option("--auth-service", is_flag=True, help="Enable authentication service with Traefik proxy")
+@click.option(
+    "--auth-service",
+    is_flag=True,
+    help="Enable authentication service with Traefik proxy",
+)
 def run(config_file, verbose, auth_service):
     """
     Execute a Calimero workflow from a YAML configuration file.

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -43,6 +43,7 @@ def create_sample_workflow_config(output_path: str = "workflow-example.yml"):
         "stop_all_nodes": True,  # Stop all existing nodes before starting
         "wait_timeout": 60,  # Wait up to 60 seconds for nodes to be ready
         "force_pull_image": False,  # Force pull Docker images even if they exist locally
+        "auth_service": False,  # Enable authentication service with Traefik proxy
         "nodes": {
             "count": 2,
             "prefix": "calimero-node",

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -31,9 +31,11 @@ from merobox.commands.bootstrap.steps import (
 class WorkflowExecutor:
     """Executes Calimero workflows based on YAML configuration."""
 
-    def __init__(self, config: Dict[str, Any], manager: CalimeroManager):
+    def __init__(self, config: Dict[str, Any], manager: CalimeroManager, auth_service: bool = False):
         self.config = config
         self.manager = manager
+        # Auth service can be enabled by CLI flag or workflow config (CLI takes precedence)
+        self.auth_service = auth_service or config.get("auth_service", False)
         self.workflow_results = {}
         self.dynamic_values = {}  # Store dynamic values for later use
 
@@ -200,7 +202,7 @@ class WorkflowExecutor:
                     f"Starting {count} nodes with prefix '{prefix}' (restart mode)..."
                 )
                 if not self.manager.run_multiple_nodes(
-                    count, base_port, base_rpc_port, chain_id, prefix, image
+                    count, base_port, base_rpc_port, chain_id, prefix, image, self.auth_service
                 ):
                     return False
             else:
@@ -232,6 +234,7 @@ class WorkflowExecutor:
                                 chain_id,
                                 None,
                                 image,
+                                self.auth_service,
                             ):
                                 return False
                     except docker.errors.NotFound:
@@ -245,6 +248,7 @@ class WorkflowExecutor:
                             chain_id,
                             None,
                             image,
+                            self.auth_service,
                         ):
                             return False
 
@@ -289,6 +293,7 @@ class WorkflowExecutor:
                                     node_chain_id,
                                     data_dir,
                                     node_image,
+                                    self.auth_service,
                                 ):
                                     return False
                             else:
@@ -316,6 +321,7 @@ class WorkflowExecutor:
                             node_chain_id,
                             data_dir,
                             node_image,
+                            self.auth_service,
                         ):
                             return False
                 else:
@@ -341,6 +347,7 @@ class WorkflowExecutor:
                                     chain_id,
                                     None,
                                     image,
+                                    self.auth_service,
                                 ):
                                     return False
                             else:
@@ -356,7 +363,7 @@ class WorkflowExecutor:
                         # Node doesn't exist, create it
                         console.print(f"Starting node '{node_config}'...")
                         if not self.manager.run_node(
-                            node_config, base_port, base_rpc_port, chain_id, None, image
+                            node_config, base_port, base_rpc_port, chain_id, None, image, self.auth_service
                         ):
                             return False
 

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -31,7 +31,12 @@ from merobox.commands.bootstrap.steps import (
 class WorkflowExecutor:
     """Executes Calimero workflows based on YAML configuration."""
 
-    def __init__(self, config: Dict[str, Any], manager: CalimeroManager, auth_service: bool = False):
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        manager: CalimeroManager,
+        auth_service: bool = False,
+    ):
         self.config = config
         self.manager = manager
         # Auth service can be enabled by CLI flag or workflow config (CLI takes precedence)
@@ -202,7 +207,13 @@ class WorkflowExecutor:
                     f"Starting {count} nodes with prefix '{prefix}' (restart mode)..."
                 )
                 if not self.manager.run_multiple_nodes(
-                    count, base_port, base_rpc_port, chain_id, prefix, image, self.auth_service
+                    count,
+                    base_port,
+                    base_rpc_port,
+                    chain_id,
+                    prefix,
+                    image,
+                    self.auth_service,
                 ):
                     return False
             else:
@@ -363,7 +374,13 @@ class WorkflowExecutor:
                         # Node doesn't exist, create it
                         console.print(f"Starting node '{node_config}'...")
                         if not self.manager.run_node(
-                            node_config, base_port, base_rpc_port, chain_id, None, image, self.auth_service
+                            node_config,
+                            base_port,
+                            base_rpc_port,
+                            chain_id,
+                            None,
+                            image,
+                            self.auth_service,
                         ):
                             return False
 

--- a/merobox/commands/bootstrap/run/run.py
+++ b/merobox/commands/bootstrap/run/run.py
@@ -15,7 +15,9 @@ from merobox.commands.bootstrap.config import load_workflow_config
 from merobox.commands.utils import console
 
 
-async def run_workflow(config_file: str, verbose: bool = False, auth_service: bool = False) -> bool:
+async def run_workflow(
+    config_file: str, verbose: bool = False, auth_service: bool = False
+) -> bool:
     """
     Execute a Calimero workflow from a YAML configuration file.
 
@@ -59,7 +61,9 @@ async def run_workflow(config_file: str, verbose: bool = False, auth_service: bo
         return False
 
 
-def run_workflow_sync(config_file: str, verbose: bool = False, auth_service: bool = False) -> bool:
+def run_workflow_sync(
+    config_file: str, verbose: bool = False, auth_service: bool = False
+) -> bool:
     """
     Synchronous wrapper for workflow execution.
 

--- a/merobox/commands/bootstrap/run/run.py
+++ b/merobox/commands/bootstrap/run/run.py
@@ -15,13 +15,14 @@ from merobox.commands.bootstrap.config import load_workflow_config
 from merobox.commands.utils import console
 
 
-async def run_workflow(config_file: str, verbose: bool = False) -> bool:
+async def run_workflow(config_file: str, verbose: bool = False, auth_service: bool = False) -> bool:
     """
     Execute a Calimero workflow from a YAML configuration file.
 
     Args:
         config_file: Path to the workflow configuration file
         verbose: Whether to enable verbose output
+        auth_service: Whether to enable authentication service integration
 
     Returns:
         True if workflow completed successfully, False otherwise
@@ -35,7 +36,7 @@ async def run_workflow(config_file: str, verbose: bool = False) -> bool:
 
         manager = CalimeroManager()
 
-        executor = WorkflowExecutor(config, manager)
+        executor = WorkflowExecutor(config, manager, auth_service)
 
         # Execute workflow
         success = await executor.execute_workflow()
@@ -58,15 +59,16 @@ async def run_workflow(config_file: str, verbose: bool = False) -> bool:
         return False
 
 
-def run_workflow_sync(config_file: str, verbose: bool = False) -> bool:
+def run_workflow_sync(config_file: str, verbose: bool = False, auth_service: bool = False) -> bool:
     """
     Synchronous wrapper for workflow execution.
 
     Args:
         config_file: Path to the workflow configuration file
         verbose: Whether to enable verbose output
+        auth_service: Whether to enable authentication service integration
 
     Returns:
         True if workflow completed successfully, False otherwise
     """
-    return asyncio.run(run_workflow(config_file, verbose))
+    return asyncio.run(run_workflow(config_file, verbose, auth_service))

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -202,49 +202,46 @@ class CalimeroManager:
 
             # Add auth service configuration if enabled
             if auth_service:
-                console.print(f"[cyan]Configuring {node_name} for auth service integration...[/cyan]")
-                
+                console.print(
+                    f"[cyan]Configuring {node_name} for auth service integration...[/cyan]"
+                )
+
                 # Ensure auth service stack is running
                 if not self._start_auth_service_stack():
-                    console.print("[yellow]⚠️  Warning: Auth service stack failed to start, but continuing with node setup[/yellow]")
-                
+                    console.print(
+                        "[yellow]⚠️  Warning: Auth service stack failed to start, but continuing with node setup[/yellow]"
+                    )
+
                 # Add Traefik labels for auth service integration
                 auth_labels = {
                     "traefik.enable": "true",
-                    
                     # API routes (protected when auth is available)
                     f"traefik.http.routers.{node_name}-api.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && (PathPrefix(`/jsonrpc`) || PathPrefix(`/admin-api/`))",
                     f"traefik.http.routers.{node_name}-api.entrypoints": "web",
                     f"traefik.http.routers.{node_name}-api.service": f"{node_name}-core",
                     f"traefik.http.routers.{node_name}-api.middlewares": f"cors,auth-{node_name}",
-                    
                     # WebSocket (protected when auth is available)
                     f"traefik.http.routers.{node_name}-ws.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && PathPrefix(`/ws`)",
                     f"traefik.http.routers.{node_name}-ws.entrypoints": "web",
                     f"traefik.http.routers.{node_name}-ws.service": f"{node_name}-core",
                     f"traefik.http.routers.{node_name}-ws.middlewares": f"cors,auth-{node_name}",
-                    
                     # Admin dashboard (publicly accessible)
                     f"traefik.http.routers.{node_name}-dashboard.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && PathPrefix(`/admin-dashboard`)",
                     f"traefik.http.routers.{node_name}-dashboard.entrypoints": "web",
                     f"traefik.http.routers.{node_name}-dashboard.service": f"{node_name}-core",
                     f"traefik.http.routers.{node_name}-dashboard.middlewares": "cors",
-                    
                     # Auth service route for this node's subdomain (both /auth/ and /admin/)
                     f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && (PathPrefix(`/auth/`) || PathPrefix(`/admin/`))",
                     f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.entrypoints": "web",
                     f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.service": "auth-service",
                     f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.middlewares": "cors,auth-headers",
                     f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.priority": "200",
-                    
                     # Forward Auth middleware
                     f"traefik.http.middlewares.auth-{node_name}.forwardauth.address": "http://auth:3001/auth/validate",
                     f"traefik.http.middlewares.auth-{node_name}.forwardauth.trustForwardHeader": "true",
                     f"traefik.http.middlewares.auth-{node_name}.forwardauth.authResponseHeaders": "X-Auth-User,X-Auth-Permissions",
-                    
                     # Define the service
                     f"traefik.http.services.{node_name}-core.loadbalancer.server.port": "2528",
-                    
                     # Shared middlewares (from docker-compose)
                     "traefik.http.middlewares.cors.headers.accesscontrolallowmethods": "GET,OPTIONS,PUT,POST,DELETE",
                     "traefik.http.middlewares.cors.headers.accesscontrolallowheaders": "*",
@@ -253,10 +250,10 @@ class CalimeroManager:
                     "traefik.http.middlewares.cors.headers.addvaryheader": "true",
                     "traefik.http.middlewares.cors.headers.accesscontrolexposeheaders": "X-Auth-Error",
                 }
-                
+
                 # Add auth labels to container config
                 container_config["labels"].update(auth_labels)
-                
+
                 # Try to ensure the auth service networks exist and connect to them
                 self._ensure_auth_networks()
 
@@ -316,7 +313,7 @@ class CalimeroManager:
             # Set primary network for auth service
             if auth_service:
                 run_config["network"] = "calimero_web"
-            
+
             container = self.client.containers.run(**run_config)
             self.nodes[node_name] = container
 
@@ -326,10 +323,16 @@ class CalimeroManager:
                     # Connect to internal network for secure backend communication
                     internal_network = self.client.networks.get("calimero_internal")
                     internal_network.connect(container)
-                    console.print(f"[cyan]✓ {node_name} connected to internal network (secure backend)[/cyan]")
-                    console.print(f"[cyan]✓ {node_name} connected to web network (Traefik routing)[/cyan]")
+                    console.print(
+                        f"[cyan]✓ {node_name} connected to internal network (secure backend)[/cyan]"
+                    )
+                    console.print(
+                        f"[cyan]✓ {node_name} connected to web network (Traefik routing)[/cyan]"
+                    )
                 except Exception as e:
-                    console.print(f"[yellow]⚠️  Warning: Could not connect {node_name} to auth networks: {str(e)}[/yellow]")
+                    console.print(
+                        f"[yellow]⚠️  Warning: Could not connect {node_name} to auth networks: {str(e)}[/yellow]"
+                    )
 
             # Wait a moment and check if container is still running
             time.sleep(3)
@@ -363,12 +366,16 @@ class CalimeroManager:
             console.print(f"  - RPC/Admin Port: {rpc_port}")
             console.print(f"  - Chain ID: {chain_id}")
             console.print(f"  - Data Directory: {data_dir}")
-            console.print(f"  - Non Auth Node URL: [link]http://localhost:{rpc_port}[/link]")
-            
+            console.print(
+                f"  - Non Auth Node URL: [link]http://localhost:{rpc_port}[/link]"
+            )
+
             if auth_service:
                 # Generate the hostname for nip.io URLs
-                hostname = node_name.replace('calimero-', '').replace('-', '')
-                console.print(f"  - Auth Node URL: [link]http://{hostname}.127.0.0.1.nip.io[/link]")
+                hostname = node_name.replace("calimero-", "").replace("-", "")
+                console.print(
+                    f"  - Auth Node URL: [link]http://{hostname}.127.0.0.1.nip.io[/link]"
+                )
             return True
 
         except Exception as e:
@@ -406,69 +413,79 @@ class CalimeroManager:
         try:
             networks_to_create = [
                 {"name": "calimero_web", "driver": "bridge"},
-                {"name": "calimero_internal", "driver": "bridge", "internal": True}
+                {"name": "calimero_internal", "driver": "bridge", "internal": True},
             ]
-            
+
             for network_spec in networks_to_create:
                 network_name = network_spec["name"]
                 try:
                     # Check if network already exists
                     self.client.networks.get(network_name)
-                    console.print(f"[cyan]✓ Network {network_name} already exists[/cyan]")
+                    console.print(
+                        f"[cyan]✓ Network {network_name} already exists[/cyan]"
+                    )
                 except docker.errors.NotFound:
                     # Create the network
                     console.print(f"[yellow]Creating network: {network_name}[/yellow]")
                     network_config = {
                         "name": network_name,
-                        "driver": network_spec["driver"]
+                        "driver": network_spec["driver"],
                     }
                     if network_spec.get("internal"):
                         network_config["internal"] = True
-                    
+
                     self.client.networks.create(**network_config)
                     console.print(f"[green]✓ Created network: {network_name}[/green]")
-                    
+
         except Exception as e:
-            console.print(f"[yellow]⚠️  Warning: Could not ensure auth networks: {str(e)}[/yellow]")
+            console.print(
+                f"[yellow]⚠️  Warning: Could not ensure auth networks: {str(e)}[/yellow]"
+            )
 
     def _start_auth_service_stack(self):
         """Start the Traefik proxy and auth service containers."""
         try:
-            console.print("[yellow]Starting auth service stack (Traefik + Auth)...[/yellow]")
-            
+            console.print(
+                "[yellow]Starting auth service stack (Traefik + Auth)...[/yellow]"
+            )
+
             # Check if auth service and traefik are already running
             auth_running = self._is_container_running("auth")
             traefik_running = self._is_container_running("proxy")
-            
+
             if auth_running and traefik_running:
                 console.print("[green]✓ Auth service stack is already running[/green]")
                 return True
-            
+
             # Ensure networks exist first
             self._ensure_auth_networks()
-            
+
             # Start Traefik proxy first
             if not traefik_running:
                 if not self._start_traefik_container():
                     return False
-            
+
             # Start Auth service
             if not auth_running:
                 if not self._start_auth_container():
                     return False
-            
+
             # Wait a bit for services to be ready
             console.print("[yellow]Waiting for services to be ready...[/yellow]")
             time.sleep(5)
-            
+
             # Verify services are running
-            if self._is_container_running("auth") and self._is_container_running("proxy"):
+            if self._is_container_running("auth") and self._is_container_running(
+                "proxy"
+            ):
                 console.print("[green]✓ Auth service stack is healthy[/green]")
                 return True
             else:
-                console.print("[yellow]⚠️  Auth service stack started but may not be fully ready[/yellow]")
+                console.print(
+                    "[yellow]⚠️  Auth service stack started but may not be fully ready[/yellow]"
+                )
                 return True
-                    
+
         except Exception as e:
             console.print(f"[red]✗ Error starting auth service stack: {str(e)}[/red]")
             return False
@@ -477,18 +494,18 @@ class CalimeroManager:
         """Start the Traefik proxy container."""
         try:
             console.print("[yellow]Starting Traefik proxy...[/yellow]")
-            
+
             # Remove existing container if it exists
             try:
                 existing = self.client.containers.get("proxy")
                 existing.remove(force=True)
             except docker.errors.NotFound:
                 pass
-            
+
             # Pull Traefik image
             if not self._ensure_image_pulled("traefik:v2.10"):
                 return False
-            
+
             # Create and start Traefik container
             traefik_config = {
                 "name": "proxy",
@@ -504,24 +521,29 @@ class CalimeroManager:
                     "--providers.docker.network=calimero_web",
                     "--serversTransport.forwardingTimeouts.dialTimeout=30s",
                     "--serversTransport.forwardingTimeouts.responseHeaderTimeout=30s",
-                    "--serversTransport.forwardingTimeouts.idleConnTimeout=30s"
+                    "--serversTransport.forwardingTimeouts.idleConnTimeout=30s",
                 ],
                 "ports": {"80/tcp": 80, "8080/tcp": 8080},
-                "volumes": {"/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "ro"}},
+                "volumes": {
+                    "/var/run/docker.sock": {
+                        "bind": "/var/run/docker.sock",
+                        "mode": "ro",
+                    }
+                },
                 "network": "calimero_web",
                 "restart_policy": {"Name": "unless-stopped"},
                 "labels": {
                     "traefik.enable": "true",
                     "traefik.http.routers.proxy-dashboard.rule": "Host(`proxy.127.0.0.1.nip.io`)",
                     "traefik.http.routers.proxy-dashboard.entrypoints": "web",
-                    "traefik.http.routers.proxy-dashboard.service": "api@internal"
-                }
+                    "traefik.http.routers.proxy-dashboard.service": "api@internal",
+                },
             }
-            
+
             container = self.client.containers.run(**traefik_config)
             console.print("[green]✓ Traefik proxy started[/green]")
             return True
-            
+
         except Exception as e:
             console.print(f"[red]✗ Failed to start Traefik proxy: {str(e)}[/red]")
             return False
@@ -530,25 +552,27 @@ class CalimeroManager:
         """Start the Auth service container."""
         try:
             console.print("[yellow]Starting Auth service...[/yellow]")
-            
+
             # Remove existing container if it exists
             try:
                 existing = self.client.containers.get("auth")
                 existing.remove(force=True)
             except docker.errors.NotFound:
                 pass
-            
+
             # Pull Auth service image
             auth_image = "ghcr.io/calimero-network/mero-auth:edge"
             if not self._ensure_image_pulled(auth_image):
-                console.print("[yellow]⚠️  Warning: Could not pull auth image, trying with local image[/yellow]")
-            
+                console.print(
+                    "[yellow]⚠️  Warning: Could not pull auth image, trying with local image[/yellow]"
+                )
+
             # Create volume for auth data if it doesn't exist
             try:
                 self.client.volumes.get("calimero_auth_data")
             except docker.errors.NotFound:
                 self.client.volumes.create("calimero_auth_data")
-            
+
             # Create and start Auth service container
             auth_config = {
                 "name": "auth",
@@ -577,22 +601,26 @@ class CalimeroManager:
                     "traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist": "*",
                     "traefik.http.middlewares.cors.headers.accesscontrolmaxage": "100",
                     "traefik.http.middlewares.cors.headers.addvaryheader": "true",
-                    "traefik.http.middlewares.cors.headers.accesscontrolexposeheaders": "X-Auth-Error"
-                }
+                    "traefik.http.middlewares.cors.headers.accesscontrolexposeheaders": "X-Auth-Error",
+                },
             }
-            
+
             container = self.client.containers.run(**auth_config)
-            
+
             # Connect to the internal network as well
             try:
                 internal_network = self.client.networks.get("calimero_internal")
                 internal_network.connect(container)
-                console.print("[cyan]✓ Auth service connected to internal network[/cyan]")
+                console.print(
+                    "[cyan]✓ Auth service connected to internal network[/cyan]"
+                )
             except Exception as e:
-                console.print(f"[yellow]⚠️  Warning: Could not connect auth to internal network: {str(e)}[/yellow]")
+                console.print(
+                    f"[yellow]⚠️  Warning: Could not connect auth to internal network: {str(e)}[/yellow]"
+                )
             console.print("[green]✓ Auth service started[/green]")
             return True
-            
+
         except Exception as e:
             console.print(f"[red]✗ Failed to start Auth service: {str(e)}[/red]")
             return False
@@ -611,7 +639,7 @@ class CalimeroManager:
         """Stop the Traefik proxy and auth service containers."""
         try:
             console.print("[yellow]Stopping auth service stack...[/yellow]")
-            
+
             success = True
             # Stop auth service
             try:
@@ -622,9 +650,11 @@ class CalimeroManager:
             except docker.errors.NotFound:
                 console.print("[cyan]• Auth service was not running[/cyan]")
             except Exception as e:
-                console.print(f"[yellow]⚠️  Warning: Could not stop auth service: {str(e)}[/yellow]")
+                console.print(
+                    f"[yellow]⚠️  Warning: Could not stop auth service: {str(e)}[/yellow]"
+                )
                 success = False
-            
+
             # Stop Traefik proxy
             try:
                 proxy_container = self.client.containers.get("proxy")
@@ -634,18 +664,21 @@ class CalimeroManager:
             except docker.errors.NotFound:
                 console.print("[cyan]• Traefik proxy was not running[/cyan]")
             except Exception as e:
-                console.print(f"[yellow]⚠️  Warning: Could not stop Traefik proxy: {str(e)}[/yellow]")
+                console.print(
+                    f"[yellow]⚠️  Warning: Could not stop Traefik proxy: {str(e)}[/yellow]"
+                )
                 success = False
-            
+
             if success:
-                console.print("[green]✓ Auth service stack stopped successfully[/green]")
-            
+                console.print(
+                    "[green]✓ Auth service stack stopped successfully[/green]"
+                )
+
             return success
-            
+
         except Exception as e:
             console.print(f"[red]✗ Error stopping auth service stack: {str(e)}[/red]")
             return False
-
 
     def run_multiple_nodes(
         self,
@@ -678,7 +711,14 @@ class CalimeroManager:
             port = p2p_ports[i]
             rpc_port = rpc_ports[i]
 
-            if self.run_node(node_name, port, rpc_port, chain_id, image=image, auth_service=auth_service):
+            if self.run_node(
+                node_name,
+                port,
+                rpc_port,
+                chain_id,
+                image=image,
+                auth_service=auth_service,
+            ):
                 success_count += 1
             else:
                 console.print(

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -6,6 +6,7 @@ import docker
 import time
 import os
 import sys
+
 from rich.console import Console
 from rich.table import Table
 from typing import Dict, List, Optional, Any
@@ -98,6 +99,7 @@ class CalimeroManager:
         chain_id: str = "testnet-1",
         data_dir: str = None,
         image: str = None,
+        auth_service: bool = False,
     ) -> bool:
         """Run a Calimero node container."""
         try:
@@ -198,6 +200,66 @@ class CalimeroManager:
                 },
             }
 
+            # Add auth service configuration if enabled
+            if auth_service:
+                console.print(f"[cyan]Configuring {node_name} for auth service integration...[/cyan]")
+                
+                # Ensure auth service stack is running
+                if not self._start_auth_service_stack():
+                    console.print("[yellow]⚠️  Warning: Auth service stack failed to start, but continuing with node setup[/yellow]")
+                
+                # Add Traefik labels for auth service integration
+                auth_labels = {
+                    "traefik.enable": "true",
+                    
+                    # API routes (protected when auth is available)
+                    f"traefik.http.routers.{node_name}-api.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && (PathPrefix(`/jsonrpc`) || PathPrefix(`/admin-api/`))",
+                    f"traefik.http.routers.{node_name}-api.entrypoints": "web",
+                    f"traefik.http.routers.{node_name}-api.service": f"{node_name}-core",
+                    f"traefik.http.routers.{node_name}-api.middlewares": f"cors,auth-{node_name}",
+                    
+                    # WebSocket (protected when auth is available)
+                    f"traefik.http.routers.{node_name}-ws.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && PathPrefix(`/ws`)",
+                    f"traefik.http.routers.{node_name}-ws.entrypoints": "web",
+                    f"traefik.http.routers.{node_name}-ws.service": f"{node_name}-core",
+                    f"traefik.http.routers.{node_name}-ws.middlewares": f"cors,auth-{node_name}",
+                    
+                    # Admin dashboard (publicly accessible)
+                    f"traefik.http.routers.{node_name}-dashboard.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && PathPrefix(`/admin-dashboard`)",
+                    f"traefik.http.routers.{node_name}-dashboard.entrypoints": "web",
+                    f"traefik.http.routers.{node_name}-dashboard.service": f"{node_name}-core",
+                    f"traefik.http.routers.{node_name}-dashboard.middlewares": "cors",
+                    
+                    # Auth service route for this node's subdomain (both /auth/ and /admin/)
+                    f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.rule": f"Host(`{node_name.replace('calimero-', '').replace('-', '')}.127.0.0.1.nip.io`) && (PathPrefix(`/auth/`) || PathPrefix(`/admin/`))",
+                    f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.entrypoints": "web",
+                    f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.service": "auth-service",
+                    f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.middlewares": "cors,auth-headers",
+                    f"traefik.http.routers.{node_name.replace('calimero-', '')}-auth.priority": "200",
+                    
+                    # Forward Auth middleware
+                    f"traefik.http.middlewares.auth-{node_name}.forwardauth.address": "http://auth:3001/auth/validate",
+                    f"traefik.http.middlewares.auth-{node_name}.forwardauth.trustForwardHeader": "true",
+                    f"traefik.http.middlewares.auth-{node_name}.forwardauth.authResponseHeaders": "X-Auth-User,X-Auth-Permissions",
+                    
+                    # Define the service
+                    f"traefik.http.services.{node_name}-core.loadbalancer.server.port": "2528",
+                    
+                    # Shared middlewares (from docker-compose)
+                    "traefik.http.middlewares.cors.headers.accesscontrolallowmethods": "GET,OPTIONS,PUT,POST,DELETE",
+                    "traefik.http.middlewares.cors.headers.accesscontrolallowheaders": "*",
+                    "traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist": "*",
+                    "traefik.http.middlewares.cors.headers.accesscontrolmaxage": "100",
+                    "traefik.http.middlewares.cors.headers.addvaryheader": "true",
+                    "traefik.http.middlewares.cors.headers.accesscontrolexposeheaders": "X-Auth-Error",
+                }
+                
+                # Add auth labels to container config
+                container_config["labels"].update(auth_labels)
+                
+                # Try to ensure the auth service networks exist and connect to them
+                self._ensure_auth_networks()
+
             # First, initialize the node
             console.print(f"[yellow]Initializing node {node_name}...[/yellow]")
 
@@ -251,8 +313,23 @@ class CalimeroManager:
                 "run",
             ]
 
+            # Set primary network for auth service
+            if auth_service:
+                run_config["network"] = "calimero_web"
+            
             container = self.client.containers.run(**run_config)
             self.nodes[node_name] = container
+
+            # Connect to auth service networks if enabled
+            if auth_service:
+                try:
+                    # Connect to internal network for secure backend communication
+                    internal_network = self.client.networks.get("calimero_internal")
+                    internal_network.connect(container)
+                    console.print(f"[cyan]✓ {node_name} connected to internal network (secure backend)[/cyan]")
+                    console.print(f"[cyan]✓ {node_name} connected to web network (Traefik routing)[/cyan]")
+                except Exception as e:
+                    console.print(f"[yellow]⚠️  Warning: Could not connect {node_name} to auth networks: {str(e)}[/yellow]")
 
             # Wait a moment and check if container is still running
             time.sleep(3)
@@ -286,6 +363,12 @@ class CalimeroManager:
             console.print(f"  - RPC/Admin Port: {rpc_port}")
             console.print(f"  - Chain ID: {chain_id}")
             console.print(f"  - Data Directory: {data_dir}")
+            console.print(f"  - Non Auth Node URL: [link]http://localhost:{rpc_port}[/link]")
+            
+            if auth_service:
+                # Generate the hostname for nip.io URLs
+                hostname = node_name.replace('calimero-', '').replace('-', '')
+                console.print(f"  - Auth Node URL: [link]http://{hostname}.127.0.0.1.nip.io[/link]")
             return True
 
         except Exception as e:
@@ -318,6 +401,252 @@ class CalimeroManager:
 
         return available_ports
 
+    def _ensure_auth_networks(self):
+        """Ensure the auth service networks exist for Traefik integration."""
+        try:
+            networks_to_create = [
+                {"name": "calimero_web", "driver": "bridge"},
+                {"name": "calimero_internal", "driver": "bridge", "internal": True}
+            ]
+            
+            for network_spec in networks_to_create:
+                network_name = network_spec["name"]
+                try:
+                    # Check if network already exists
+                    self.client.networks.get(network_name)
+                    console.print(f"[cyan]✓ Network {network_name} already exists[/cyan]")
+                except docker.errors.NotFound:
+                    # Create the network
+                    console.print(f"[yellow]Creating network: {network_name}[/yellow]")
+                    network_config = {
+                        "name": network_name,
+                        "driver": network_spec["driver"]
+                    }
+                    if network_spec.get("internal"):
+                        network_config["internal"] = True
+                    
+                    self.client.networks.create(**network_config)
+                    console.print(f"[green]✓ Created network: {network_name}[/green]")
+                    
+        except Exception as e:
+            console.print(f"[yellow]⚠️  Warning: Could not ensure auth networks: {str(e)}[/yellow]")
+
+    def _start_auth_service_stack(self):
+        """Start the Traefik proxy and auth service containers."""
+        try:
+            console.print("[yellow]Starting auth service stack (Traefik + Auth)...[/yellow]")
+            
+            # Check if auth service and traefik are already running
+            auth_running = self._is_container_running("auth")
+            traefik_running = self._is_container_running("proxy")
+            
+            if auth_running and traefik_running:
+                console.print("[green]✓ Auth service stack is already running[/green]")
+                return True
+            
+            # Ensure networks exist first
+            self._ensure_auth_networks()
+            
+            # Start Traefik proxy first
+            if not traefik_running:
+                if not self._start_traefik_container():
+                    return False
+            
+            # Start Auth service
+            if not auth_running:
+                if not self._start_auth_container():
+                    return False
+            
+            # Wait a bit for services to be ready
+            console.print("[yellow]Waiting for services to be ready...[/yellow]")
+            time.sleep(5)
+            
+            # Verify services are running
+            if self._is_container_running("auth") and self._is_container_running("proxy"):
+                console.print("[green]✓ Auth service stack is healthy[/green]")
+                return True
+            else:
+                console.print("[yellow]⚠️  Auth service stack started but may not be fully ready[/yellow]")
+                return True
+                    
+        except Exception as e:
+            console.print(f"[red]✗ Error starting auth service stack: {str(e)}[/red]")
+            return False
+
+    def _start_traefik_container(self):
+        """Start the Traefik proxy container."""
+        try:
+            console.print("[yellow]Starting Traefik proxy...[/yellow]")
+            
+            # Remove existing container if it exists
+            try:
+                existing = self.client.containers.get("proxy")
+                existing.remove(force=True)
+            except docker.errors.NotFound:
+                pass
+            
+            # Pull Traefik image
+            if not self._ensure_image_pulled("traefik:v2.10"):
+                return False
+            
+            # Create and start Traefik container
+            traefik_config = {
+                "name": "proxy",
+                "image": "traefik:v2.10",
+                "detach": True,
+                "command": [
+                    "--api.insecure=true",
+                    "--providers.docker=true",
+                    "--entrypoints.web.address=:80",
+                    "--accesslog=true",
+                    "--log.level=DEBUG",
+                    "--providers.docker.exposedByDefault=false",
+                    "--providers.docker.network=calimero_web",
+                    "--serversTransport.forwardingTimeouts.dialTimeout=30s",
+                    "--serversTransport.forwardingTimeouts.responseHeaderTimeout=30s",
+                    "--serversTransport.forwardingTimeouts.idleConnTimeout=30s"
+                ],
+                "ports": {"80/tcp": 80, "8080/tcp": 8080},
+                "volumes": {"/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "ro"}},
+                "network": "calimero_web",
+                "restart_policy": {"Name": "unless-stopped"},
+                "labels": {
+                    "traefik.enable": "true",
+                    "traefik.http.routers.proxy-dashboard.rule": "Host(`proxy.127.0.0.1.nip.io`)",
+                    "traefik.http.routers.proxy-dashboard.entrypoints": "web",
+                    "traefik.http.routers.proxy-dashboard.service": "api@internal"
+                }
+            }
+            
+            container = self.client.containers.run(**traefik_config)
+            console.print("[green]✓ Traefik proxy started[/green]")
+            return True
+            
+        except Exception as e:
+            console.print(f"[red]✗ Failed to start Traefik proxy: {str(e)}[/red]")
+            return False
+
+    def _start_auth_container(self):
+        """Start the Auth service container."""
+        try:
+            console.print("[yellow]Starting Auth service...[/yellow]")
+            
+            # Remove existing container if it exists
+            try:
+                existing = self.client.containers.get("auth")
+                existing.remove(force=True)
+            except docker.errors.NotFound:
+                pass
+            
+            # Pull Auth service image
+            auth_image = "ghcr.io/calimero-network/mero-auth:edge"
+            if not self._ensure_image_pulled(auth_image):
+                console.print("[yellow]⚠️  Warning: Could not pull auth image, trying with local image[/yellow]")
+            
+            # Create volume for auth data if it doesn't exist
+            try:
+                self.client.volumes.get("calimero_auth_data")
+            except docker.errors.NotFound:
+                self.client.volumes.create("calimero_auth_data")
+            
+            # Create and start Auth service container
+            auth_config = {
+                "name": "auth",
+                "image": auth_image,
+                "detach": True,
+                "user": "root",
+                "volumes": {"calimero_auth_data": {"bind": "/data", "mode": "rw"}},
+                "environment": ["RUST_LOG=debug"],
+                "network": "calimero_web",  # Connect to web network first
+                "restart_policy": {"Name": "unless-stopped"},
+                "labels": {
+                    "traefik.enable": "true",
+                    # Auth service on localhost (both /auth/ and /admin/)
+                    "traefik.http.routers.auth-public.rule": "Host(`localhost`) && (PathPrefix(`/auth/`) || PathPrefix(`/admin/`))",
+                    "traefik.http.routers.auth-public.entrypoints": "web",
+                    "traefik.http.routers.auth-public.service": "auth-service",
+                    "traefik.http.routers.auth-public.middlewares": "cors,auth-headers",
+                    "traefik.http.routers.auth-public.priority": "100",
+                    # Add Node ID header for auth service
+                    "traefik.http.middlewares.auth-headers.headers.customrequestheaders.X-Node-ID": "auth",
+                    # Define the service
+                    "traefik.http.services.auth-service.loadbalancer.server.port": "3001",
+                    # CORS middleware
+                    "traefik.http.middlewares.cors.headers.accesscontrolallowmethods": "GET,OPTIONS,PUT,POST,DELETE",
+                    "traefik.http.middlewares.cors.headers.accesscontrolallowheaders": "*",
+                    "traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist": "*",
+                    "traefik.http.middlewares.cors.headers.accesscontrolmaxage": "100",
+                    "traefik.http.middlewares.cors.headers.addvaryheader": "true",
+                    "traefik.http.middlewares.cors.headers.accesscontrolexposeheaders": "X-Auth-Error"
+                }
+            }
+            
+            container = self.client.containers.run(**auth_config)
+            
+            # Connect to the internal network as well
+            try:
+                internal_network = self.client.networks.get("calimero_internal")
+                internal_network.connect(container)
+                console.print("[cyan]✓ Auth service connected to internal network[/cyan]")
+            except Exception as e:
+                console.print(f"[yellow]⚠️  Warning: Could not connect auth to internal network: {str(e)}[/yellow]")
+            console.print("[green]✓ Auth service started[/green]")
+            return True
+            
+        except Exception as e:
+            console.print(f"[red]✗ Failed to start Auth service: {str(e)}[/red]")
+            return False
+
+    def _is_container_running(self, container_name: str) -> bool:
+        """Check if a container is running."""
+        try:
+            container = self.client.containers.get(container_name)
+            return container.status == "running"
+        except docker.errors.NotFound:
+            return False
+        except Exception:
+            return False
+
+    def stop_auth_service_stack(self):
+        """Stop the Traefik proxy and auth service containers."""
+        try:
+            console.print("[yellow]Stopping auth service stack...[/yellow]")
+            
+            success = True
+            # Stop auth service
+            try:
+                auth_container = self.client.containers.get("auth")
+                auth_container.stop()
+                auth_container.remove()
+                console.print("[green]✓ Auth service stopped[/green]")
+            except docker.errors.NotFound:
+                console.print("[cyan]• Auth service was not running[/cyan]")
+            except Exception as e:
+                console.print(f"[yellow]⚠️  Warning: Could not stop auth service: {str(e)}[/yellow]")
+                success = False
+            
+            # Stop Traefik proxy
+            try:
+                proxy_container = self.client.containers.get("proxy")
+                proxy_container.stop()
+                proxy_container.remove()
+                console.print("[green]✓ Traefik proxy stopped[/green]")
+            except docker.errors.NotFound:
+                console.print("[cyan]• Traefik proxy was not running[/cyan]")
+            except Exception as e:
+                console.print(f"[yellow]⚠️  Warning: Could not stop Traefik proxy: {str(e)}[/yellow]")
+                success = False
+            
+            if success:
+                console.print("[green]✓ Auth service stack stopped successfully[/green]")
+            
+            return success
+            
+        except Exception as e:
+            console.print(f"[red]✗ Error stopping auth service stack: {str(e)}[/red]")
+            return False
+
+
     def run_multiple_nodes(
         self,
         count: int,
@@ -326,6 +655,7 @@ class CalimeroManager:
         chain_id: str = "testnet-1",
         prefix: str = "calimero-node",
         image: str = None,
+        auth_service: bool = False,
     ) -> bool:
         """Run multiple Calimero nodes with automatic port allocation."""
         console.print(f"[bold]Starting {count} Calimero nodes...[/bold]")
@@ -348,7 +678,7 @@ class CalimeroManager:
             port = p2p_ports[i]
             rpc_port = rpc_ports[i]
 
-            if self.run_node(node_name, port, rpc_port, chain_id, image=image):
+            if self.run_node(node_name, port, rpc_port, chain_id, image=image, auth_service=auth_service):
                 success_count += 1
             else:
                 console.print(

--- a/merobox/commands/run.py
+++ b/merobox/commands/run.py
@@ -35,7 +35,17 @@ console = Console()
     is_flag=True,
     help="Enable authentication service with Traefik proxy",
 )
-def run(count, base_port, base_rpc_port, chain_id, prefix, data_dir, image, force_pull, auth_service):
+def run(
+    count,
+    base_port,
+    base_rpc_port,
+    chain_id,
+    prefix,
+    data_dir,
+    image,
+    force_pull,
+    auth_service,
+):
     """Run Calimero node(s) in Docker containers."""
     calimero_manager = CalimeroManager()
 

--- a/merobox/commands/run.py
+++ b/merobox/commands/run.py
@@ -30,7 +30,12 @@ console = Console()
     is_flag=True,
     help="Force pull the Docker image even if it exists locally",
 )
-def run(count, base_port, base_rpc_port, chain_id, prefix, data_dir, image, force_pull):
+@click.option(
+    "--auth-service",
+    is_flag=True,
+    help="Enable authentication service with Traefik proxy",
+)
+def run(count, base_port, base_rpc_port, chain_id, prefix, data_dir, image, force_pull, auth_service):
     """Run Calimero node(s) in Docker containers."""
     calimero_manager = CalimeroManager()
 
@@ -52,12 +57,12 @@ def run(count, base_port, base_rpc_port, chain_id, prefix, data_dir, image, forc
         # Single node with custom data directory
         node_name = f"{prefix}-1"
         success = calimero_manager.run_node(
-            node_name, base_port, base_rpc_port, chain_id, data_dir, image
+            node_name, base_port, base_rpc_port, chain_id, data_dir, image, auth_service
         )
         sys.exit(0 if success else 1)
     else:
         # Multiple nodes or single node with default settings
         success = calimero_manager.run_multiple_nodes(
-            count, base_port, base_rpc_port, chain_id, prefix, image
+            count, base_port, base_rpc_port, chain_id, prefix, image, auth_service
         )
         sys.exit(0 if success else 1)

--- a/merobox/commands/stop.py
+++ b/merobox/commands/stop.py
@@ -9,15 +9,36 @@ from merobox.commands.manager import CalimeroManager
 
 @click.command()
 @click.argument("node_name", required=False)
-@click.option("--all", is_flag=True, help="Stop all running nodes")
-def stop(node_name, all):
+@click.option("--all", is_flag=True, help="Stop all running nodes and auth service stack")
+@click.option("--auth-service", is_flag=True, help="Stop auth service stack (Traefik + Auth)")
+def stop(node_name, all, auth_service):
     """Stop Calimero node(s)."""
     calimero_manager = CalimeroManager()
 
-    if all:
-        # Stop all nodes
-        success = calimero_manager.stop_all_nodes()
+    if auth_service:
+        # Stop auth service stack
+        success = calimero_manager.stop_auth_service_stack()
         sys.exit(0 if success else 1)
+    elif all:
+        # Stop all nodes
+        nodes_success = calimero_manager.stop_all_nodes()
+        
+        # Also stop auth service stack when stopping all nodes (if it's running)
+        auth_success = True  # Default to success if no auth services to stop
+        try:
+            # Check if auth service containers exist before trying to stop them
+            auth_container = calimero_manager.client.containers.get("auth")
+            proxy_container = calimero_manager.client.containers.get("proxy")
+            # If we get here, at least one auth service container exists
+            auth_success = calimero_manager.stop_auth_service_stack()
+        except:
+            # No auth service containers found, which is fine
+            from rich.console import Console
+            console = Console()
+            console.print("[cyan]• No auth service stack to stop[/cyan]")
+        
+        # Exit with success only if both operations succeeded
+        sys.exit(0 if (nodes_success and auth_success) else 1)
     elif node_name:
         # Stop specific node
         success = calimero_manager.stop_node(node_name)
@@ -27,9 +48,10 @@ def stop(node_name, all):
 
         console = Console()
         console.print(
-            "[red]Error: Please specify a node name or use --all to stop all nodes[/red]"
+            "[red]Error: Please specify a node name, --all, or --auth-service[/red]"
         )
         console.print("Examples:")
-        console.print("  python3 merobox_cli.py stop calimero-node-1")
-        console.print("  python3 merobox_cli.py stop --all")
+        console.print("  merobox stop calimero-node-1")
+        console.print("  merobox stop --all")
+        console.print("  merobox stop --auth-service")
         sys.exit(1)

--- a/merobox/commands/stop.py
+++ b/merobox/commands/stop.py
@@ -9,8 +9,12 @@ from merobox.commands.manager import CalimeroManager
 
 @click.command()
 @click.argument("node_name", required=False)
-@click.option("--all", is_flag=True, help="Stop all running nodes and auth service stack")
-@click.option("--auth-service", is_flag=True, help="Stop auth service stack (Traefik + Auth)")
+@click.option(
+    "--all", is_flag=True, help="Stop all running nodes and auth service stack"
+)
+@click.option(
+    "--auth-service", is_flag=True, help="Stop auth service stack (Traefik + Auth)"
+)
 def stop(node_name, all, auth_service):
     """Stop Calimero node(s)."""
     calimero_manager = CalimeroManager()
@@ -22,7 +26,7 @@ def stop(node_name, all, auth_service):
     elif all:
         # Stop all nodes
         nodes_success = calimero_manager.stop_all_nodes()
-        
+
         # Also stop auth service stack when stopping all nodes (if it's running)
         auth_success = True  # Default to success if no auth services to stop
         try:
@@ -34,9 +38,10 @@ def stop(node_name, all, auth_service):
         except:
             # No auth service containers found, which is fine
             from rich.console import Console
+
             console = Console()
             console.print("[cyan]• No auth service stack to stop[/cyan]")
-        
+
         # Exit with success only if both operations succeeded
         sys.exit(0 if (nodes_success and auth_success) else 1)
     elif node_name:

--- a/workflow-examples/workflow-auth-example.yml
+++ b/workflow-examples/workflow-auth-example.yml
@@ -1,0 +1,32 @@
+name: "Auth Service Example"
+description: "Single node workflow with authentication service enabled - demonstrates auth integration"
+
+# Enable auth service for this workflow
+auth_service: true
+
+# Node configuration
+nodes:
+  count: 1
+  base_port: 2428
+  base_rpc_port: 2528
+  chain_id: "testnet-1"
+  prefix: "calimero-node"
+  image: "ghcr.io/calimero-network/merod:edge"
+
+# Workflow steps
+steps:
+  - name: "Wait for node startup"
+    type: "wait"
+    seconds: 5
+    message: "Waiting for node to fully start with auth service..."
+
+# Expected URLs after running this workflow:
+# - Node: http://node1.127.0.0.1.nip.io
+# - Auth Login: http://node1.127.0.0.1.nip.io/auth/login  
+# - Admin Dashboard: http://node1.127.0.0.1.nip.io/admin-dashboard
+#
+# To run this workflow:
+# merobox bootstrap run workflow-examples/workflow-auth-example.yml
+#
+# Or enable auth service via CLI flag:
+# merobox bootstrap run --auth-service workflow-examples/workflow-example.yml


### PR DESCRIPTION
Implemented authentication service in front of the nodes using flag `--auth-service`.
Implemented workflow flag, example in `workflow-auth-example.yml`.

`merobox stop --all` turns everything off, including the auth service if turned off.
`merobox stop --auth-service` turns off the auth service.

Works with multiple nodes.

Added node URLs to output for auth and no auth modes.
