### PR TITLE
fix: add missing aiohttp dependency and bump version to 0.1.22

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"
 __author__ = "Merobox Team"
 __email__ = "team@merobox.com"

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "rich>=13.0.0",
         "PyYAML>=6.0.0",
         "calimero-client-py==0.2.3",
+        "aiohttp>=3.8.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
- Added aiohttp>=3.8.0 to install_requires in setup.py
- Fixed ModuleNotFoundError when importing health module
- Bumped version from 0.1.21 to 0.1.22