### PR TITLE
chore: update calimero-client-py dependency to version 0.2.5 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "docker>=6.0.0",
     "rich>=13.0.0",
     "PyYAML>=6.0.0",
-    "calimero-client-py==0.2.4",
+    "calimero-client-py==0.2.5",
     "aiohttp>=3.9.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click>=8.0.0
 docker>=6.0.0
 rich>=13.0.0
 PyYAML>=6.0.0
-calimero-client-py==0.2.4
+calimero-client-py==0.2.5
 aiohttp>=3.9.0
 
 # Development dependencies


### PR DESCRIPTION
update calimero-client-py dependency to version 0.2.5