### PR TITLE
chore(ci): enhance cleanup steps in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
         run: |
           merobox --version
           merobox --help
+          echo "🧹 Performing initial cleanup..."
+          merobox stop --all || true
+          merobox nuke -f || true
           # Run only essential workflows on PRs for faster feedback
           ESSENTIAL_WORKFLOWS=(
             "workflow-examples/workflow-example.yml"
@@ -95,7 +98,8 @@ jobs:
           for f in "${ESSENTIAL_WORKFLOWS[@]}"; do \
             echo "Running workflow: $f"; \
             merobox bootstrap run "$f" --verbose; \
-            echo "Nuking merobox data between workflows..."; \
+            echo "Cleaning up after workflow..."; \
+            merobox stop --all || true; \
             merobox nuke -f || true; \
           done
 
@@ -104,11 +108,16 @@ jobs:
         run: |
           merobox --version
           merobox --help
+          # Initial cleanup to ensure no containers from previous runs
+          echo "Performing initial cleanup..."
+          merobox stop --all || true
+          merobox nuke -f || true
           # Run all workflows on master for comprehensive testing
           for f in workflow-examples/*.yml; do \
             echo "Running workflow: $f"; \
             merobox bootstrap run "$f" --verbose; \
-            echo "Nuking merobox data between workflows..."; \
+            echo "Cleaning up after workflow..."; \
+            merobox stop --all || true; \
             merobox nuke -f || true; \
           done
 
@@ -147,6 +156,10 @@ jobs:
 
       - name: Run merobox integration tests
         run: |
+          # Initial cleanup to ensure no containers from previous runs
+          echo "Performing initial cleanup..."
+          merobox stop --all || true
+          merobox nuke -f || true
           cd example-project
           echo "🧪 Running merobox integration test suite..."
 
@@ -154,5 +167,6 @@ jobs:
           python -m pytest tests/test_merobox_integration.py -v --tb=short
 
           echo "✅ All merobox integration tests completed successfully!"
-          echo "🧹 Nuking merobox data after integration tests..."
-          cd .. && merobox nuke -f || true
+          echo "Cleaning up after integration tests..."
+          cd .. && merobox stop --all || true
+          merobox nuke -f || true


### PR DESCRIPTION
## Problem
CI workflows on master were randomly failing with Docker errors:
```
✗ Failed to initialize node calimero-node-1: 500 Server Error
Bind for 0.0.0.0:2428 failed: port is already allocated
```

This occurred because containers from previous workflow runs weren't fully stopped before the next workflow started, causing port conflicts.

## Solution
Add explicit cleanup between workflow runs:
- Run `merobox stop --all` before initial tests
- Run `merobox stop --all` before `merobox nuke -f` between each workflow
- Applied to all test jobs (PR, master, and integration tests)

This mirrors the local development workflow where we run `merobox stop --all` to free ports.

## Testing
- [ ] Verify CI passes on this PR
- [ ] Monitor master branch for reduced port conflict errors
