### PR TITLE
chore: update image tag in open invitation workflow example

### DIFF
--- a/workflow-examples/workflow-open-invitation-example.yml
+++ b/workflow-examples/workflow-open-invitation-example.yml
@@ -8,7 +8,7 @@ force_pull_image: true
 nodes:
   chain_id: testnet-1
   count: 3
-  image: ghcr.io/calimero-network/merod:pr-1604
+  image: ghcr.io/calimero-network/merod:edge
   prefix: open-inv-node
 
 steps:


### PR DESCRIPTION
Updated the image tag in the open invitation example to used the latest merod image not the old one due to which CI is failing.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `workflow-examples/workflow-open-invitation-example.yml` to use `ghcr.io/calimero-network/merod:edge` image instead of `:pr-1604`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24647744d0b834bc731c84c9ce1a4672cd6dc9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->