### PR TITLE
feat: add node validation and extraction methods in WorkflowExecutor

### DIFF
--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -565,13 +565,15 @@ class WorkflowExecutor:
             if isinstance(count, int) and count >= 0:
                 prefix = nodes_config.get("prefix", "calimero-node")
                 return {f"{prefix}-{i+1}" for i in range(count)}
-
-        if isinstance(nodes_config, dict):
-            return set(nodes_config.keys())
-        elif isinstance(nodes_config, list):
-            return set(nodes_config)
-
-        return set()
+            else:
+                return set()
+        else:
+            if isinstance(nodes_config, dict):
+                return set(nodes_config.keys())
+            elif isinstance(nodes_config, list):
+                return set(nodes_config)
+            else:
+                return set()
 
     def _extract_node_references_from_step(self, step: dict[str, Any]) -> set[str]:
         """Extract all node references from a step, including nested steps."""


### PR DESCRIPTION
## Fix: Validate workflow node references (#84)

### Problem
Workflows were not failing when steps referenced nodes that weren't defined in the workflow configuration. For example, if a workflow specified `count: 1` with `prefix: calimero-node` (creating only `calimero-node-1`), but a step referenced `calimero-node-2`, the workflow would continue executing without error, even though the referenced node shouldn't exist.

### Solution
Added validation that runs before executing workflow steps to:
- Extract all node references from workflow steps (including nested steps in repeat blocks)
- Compare referenced nodes against the valid nodes defined in the workflow configuration
- Fail early with clear error messages when invalid nodes are referenced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds node reference validation to WorkflowExecutor, extracting referenced nodes from steps and failing early if they don't exist per configuration.
> 
> - **WorkflowExecutor (`merobox/commands/bootstrap/run/executor.py`)**:
>   - **Validation**: Add `_validate_node_references` to ensure all step `node` references exist based on config.
>     - Utilities: `_get_valid_node_names` (derive valid node names from `nodes` config) and `_extract_node_references_from_step` (collect refs, including within `repeat`).
>     - Error reporting: Lists invalid/valid nodes and clarifies `count`/`prefix` ranges.
>   - **Execution Flow**: Invoke validation in `_execute_workflow_steps` to fail early before running steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa366f3380d808184e845067fdb7ff4e08fe8f28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->