### PR TITLE
chore: update workflow-proposals-example.yml to force pull Docker images

### DIFF
--- a/workflow-examples/workflow-proposals-example.yml
+++ b/workflow-examples/workflow-proposals-example.yml
@@ -1,9 +1,8 @@
 description: Comprehensive e2e test for Proposals API methods on NEAR protocol with repeat step support
 name: Proposals API Comprehensive Test
 
-# Use --no-docker mode with native merod processes
-no_docker: true
-force_pull_image: false
+# Force pull Docker images even if they exist locally
+force_pull_image: true
 
 nodes:
   chain_id: calimero-testnet


### PR DESCRIPTION
Updated this , as most of the CI test were failing at proposal step ,as it being the only one that was no docker , with this update it fixed the CI

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable forced Docker image pulls and drop `no_docker` in `workflow-examples/workflow-proposals-example.yml`.
> 
> - **Workflow config**:
>   - In `workflow-examples/workflow-proposals-example.yml`:
>     - Enable `force_pull_image: true`.
>     - Remove `no_docker` and the previous `force_pull_image: false` setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d03da40bcef543e4c4332ac32f48b0a6d5ab309d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->