### PR TITLE
ci: add Docker testing job for merobox CLI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,12 @@ jobs:
           merobox stop --all || true
           merobox nuke -f || true
           # Run all workflows with Docker for comprehensive testing
+          # Skip workflow-example-binary.yml as it has no_docker: true in YAML (tested in test-merobox job)
           for f in workflow-examples/*.yml; do \
+            if [[ "$f" == "workflow-examples/workflow-example-binary.yml" ]]; then \
+              echo "Skipping $f (binary-mode only, requires merod binary)"; \
+              continue; \
+            fi; \
             echo "Running workflow with Docker: $f"; \
             merobox bootstrap run "$f" --verbose; \
             echo "Cleaning up after workflow..."; \


### PR DESCRIPTION
Adds a new CI job `test-merobox-docker` that runs all workflow examples with Docker enabled, complementing the existing `test-merobox` job that runs workflows with `--no-docker`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CI job that runs merobox workflow examples with Docker, complementing the existing no-docker run.
> 
> - **CI / GitHub Actions** (`.github/workflows/ci.yml`):
>   - **New Job `test-merobox-docker`**:
>     - Sets up Docker (buildx) and starts daemon.
>     - Installs repo deps and merobox in editable mode.
>     - Runs all `workflow-examples/*.yml` with Docker (`merobox bootstrap run ... --verbose`).
>     - Skips `workflow-examples/workflow-example-binary.yml` (binary-mode only).
>     - Cleans up between runs with `merobox stop --all` and `merobox nuke -f`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0b559caac8c1113835473328338d2f707014aa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->