### PR TITLE
chore: update dependencies and Python version constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ logs/
 
 # Data directories (can be large)
 data/
+contracts/
 *.db
 *.sqlite
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "merobox"
 dynamic = ["version"]
 description = "A Python CLI tool for managing Calimero nodes in Docker containers"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 license = {text = "MIT"}
 authors = [
     {name = "Calimero Ltd.", email = "engineering@calimero.network"}
@@ -29,6 +29,11 @@ dependencies = [
     "calimero-client-py==0.2.7",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
+    "base58>=2.1.0",
+    "ed25519>=1.5",
+    "py-near>=1.1.0",
+    "requests>=2.31.0",
+    "tqdm>=4.65.0",
 ]
 
 [project.optional-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,11 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.9,<3.12",
     install_requires=[
         "click>=8.0.0",
         "docker>=6.0.0",
@@ -53,6 +52,12 @@ setup(
         "PyYAML>=6.0.0",
         "calimero-client-py==0.2.7",
         "aiohttp>=3.8.0",
+        "toml>=0.10.2",
+        "base58>=2.1.0",
+        "ed25519>=1.5",
+        "py-near>=1.1.0",
+        "requests>=2.31.0",
+        "tqdm>=4.65.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Fix: Add missing dependencies and Python version constraint

### Problem
When installing merobox from source , the installation was failing with `ModuleNotFoundError` for missing dependencies:
- `base58` (used in `commands/near/client.py`)
- `ed25519` (used in `commands/near/client.py`)
- `py-near` (used in `commands/near/client.py`)
- `requests` (used in `commands/near/sandbox.py`)
- `tqdm` (used in `commands/near/sandbox.py`)

This occurred because these dependencies were only listed in `requirements.txt` but not in the package metadata (`pyproject.toml` and `setup.py`). When installing from source, pip uses package metadata, not `requirements.txt`.

Additionally, `ed25519` and `py-near` are incompatible with Python 3.12+ due to their use of `SafeConfigParser`, which was removed in Python 3.12. .

Reference : #107 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add missing runtime dependencies to package metadata and restrict supported Python to <3.12; ignore `contracts/` directory.
> 
> - **Packaging/Build**:
>   - Constrain Python version to `>=3.9,<3.12` in `pyproject.toml` and `setup.py`; remove Python 3.12 classifier in `setup.py`.
> - **Dependencies**:
>   - Add runtime deps to both `pyproject.toml` and `setup.py`: `base58`, `ed25519`, `py-near`, `requests`, `tqdm` (and include `toml` in `setup.py`).
> - **Repo Hygiene**:
>   - Ignore `contracts/` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68e0a1ba3864e063891727f53b728da6490724c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->