### PR TITLE
refactor: replace wait steps with wait_for_sync for improved synchronization

### DIFF
--- a/workflow-examples/workflow-blob-upload-example.yml
+++ b/workflow-examples/workflow-blob-upload-example.yml
@@ -96,8 +96,14 @@ steps:
       file_0_id: result
 
   - name: Wait for blob announcement to propagate
-    type: wait
-    seconds: 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 7a: Upload real image file to blob storage
   - name: Upload PNG to Blob Storage
@@ -160,8 +166,14 @@ steps:
       files_list_node1: result
 
   - name: Wait for file list to settle
-    type: wait
-    seconds: 1
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 10: Verify blobs are accessible from Node 2 (blob announcement worked)
   - name: List All Files (Node 2)
@@ -174,8 +186,14 @@ steps:
       files_list_node2: result
 
   - name: Wait for blob sync verification
-    type: wait
-    seconds: 1
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 11: Get specific file metadata
   - name: Get PDF File Metadata
@@ -250,8 +268,14 @@ steps:
       delete_result: result
 
   - name: Wait for deletion to propagate
-    type: wait
-    seconds: 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 17: Verify file was deleted
   - name: List Files After Delete
@@ -264,8 +288,14 @@ steps:
       files_after_delete: result
 
   - name: Wait for delete to propagate
-    type: wait
-    seconds: 1
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 18: Verify deletion is visible on Node 2
   - name: Verify Delete on Node 2
@@ -278,8 +308,14 @@ steps:
       files_node2_after_delete: result
 
   - name: Verify Node 2 sees deletion
-    type: wait
-    seconds: 1
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
 # Configuration
 stop_all_nodes: false

--- a/workflow-examples/workflow-custom-outputs-example.yml
+++ b/workflow-examples/workflow-custom-outputs-example.yml
@@ -18,8 +18,8 @@ steps:
     path: ./workflow-examples/res/kv_store.wasm
     dev: true
     outputs:
-      my_app_id: applicationId         # Export 'applicationId' field as 'my_app_id'
-      node_specific_id:                # Export 'applicationId' with node name replacement
+      my_app_id: applicationId # Export 'applicationId' field as 'my_app_id'
+      node_specific_id: # Export 'applicationId' with node name replacement
         field: applicationId
         target: app_id_{node_name}
 
@@ -27,11 +27,11 @@ steps:
   - name: Create Context with Custom Names
     type: create_context
     node: calimero-node-1
-    application_id: '{{my_app_id}}'    # Use custom output name
+    application_id: "{{my_app_id}}" # Use custom output name
     outputs:
-      my_context_id: contextId         # Export 'contextId' as 'my_context_id'
-      member_key: memberPublicKey      # Export 'memberPublicKey' as 'member_key'
-      node_context_id:                 # Export 'contextId' with node name
+      my_context_id: contextId # Export 'contextId' as 'my_context_id'
+      member_key: memberPublicKey # Export 'memberPublicKey' as 'member_key'
+      node_context_id: # Export 'contextId' with node name
         field: contextId
         target: context_id_{node_name}
 
@@ -40,8 +40,8 @@ steps:
     type: create_identity
     node: calimero-node-2
     outputs:
-      my_public_key: publicKey         # Export 'publicKey' as 'my_public_key'
-      node_public_key:                 # Export 'publicKey' with node name
+      my_public_key: publicKey # Export 'publicKey' as 'my_public_key'
+      node_public_key: # Export 'publicKey' with node name
         field: publicKey
         target: public_key_{node_name}
 
@@ -54,50 +54,56 @@ steps:
   - name: Invite Identity with Custom Names
     type: invite_identity
     node: calimero-node-1
-    context_id: '{{my_context_id}}'    # Use custom context ID
-    granter_id: '{{member_key}}'       # Use custom member key
-    grantee_id: '{{my_public_key}}'    # Use custom public key
+    context_id: "{{my_context_id}}" # Use custom context ID
+    granter_id: "{{member_key}}" # Use custom member key
+    grantee_id: "{{my_public_key}}" # Use custom public key
     capability: member
     outputs:
-      my_invitation: invitation        # Export 'invitation' as 'my_invitation'
+      my_invitation: invitation # Export 'invitation' as 'my_invitation'
 
   # Step 6: Join context using custom output names
   - name: Join Context with Custom Names
     type: join_context
     node: calimero-node-2
-    context_id: '{{my_context_id}}'    # Use custom context ID
-    invitee_id: '{{my_public_key}}'    # Use custom public key
-    invitation: '{{my_invitation}}'    # Use custom invitation
+    context_id: "{{my_context_id}}" # Use custom context ID
+    invitee_id: "{{my_public_key}}" # Use custom public key
+    invitation: "{{my_invitation}}" # Use custom invitation
 
   # Step 7: Execute contract call using custom output names
   - name: Execute Contract Call with Custom Names
     type: call
     node: calimero-node-1
-    context_id: '{{my_context_id}}'    # Use custom context ID
-    executor_public_key: '{{member_key}}'
+    context_id: "{{my_context_id}}" # Use custom context ID
+    executor_public_key: "{{member_key}}"
     method: set
     args:
       key: "hello"
       value: "world"
     outputs:
-      call_result: result              # Export 'result' as 'call_result'
+      call_result: result # Export 'result' as 'call_result'
 
   # Step 8: Wait for the set operation to complete
   - name: Wait for Set Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{my_context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 9: Execute view call using custom output names
   - name: Execute View Call with Custom Names
     type: call
     node: calimero-node-2
-    context_id: '{{my_context_id}}'    # Use custom context ID
-    executor_public_key: '{{my_public_key}}'
+    context_id: "{{my_context_id}}" # Use custom context ID
+    executor_public_key: "{{my_public_key}}"
     method: get
     args:
       key: "hello"
     outputs:
-      get_result: result               # Export 'result' as 'get_result'
+      get_result: result # Export 'result' as 'get_result'
 
   # Step 10: Execute script with custom outputs
   - name: Execute Script with Custom Names
@@ -105,39 +111,45 @@ steps:
     target: nodes
     script: ./workflow-examples/scripts/example-post-script.sh
     outputs:
-      script_result: output            # Export 'output' as 'script_result'
-      exit_code: exit_code            # Export 'exit_code' as 'exit_code'
-      execution_time: execution_time  # Export 'execution_time' as 'execution_time'
+      script_result: output # Export 'output' as 'script_result'
+      exit_code: exit_code # Export 'exit_code' as 'exit_code'
+      execution_time: execution_time # Export 'execution_time' as 'execution_time'
 
   # Step 11: Repeat operations with custom outputs
   - name: Repeat Operations with Custom Names
     type: repeat
     count: 3
     outputs:
-      current_iteration: iteration     # Export 'iteration' as 'current_iteration'
-      total_count: total_iterations   # Export 'total_iterations' as 'total_count'
+      current_iteration: iteration # Export 'iteration' as 'current_iteration'
+      total_count: total_iterations # Export 'total_iterations' as 'total_count'
     steps:
       - name: Set Key-Value Pair
         type: call
         node: calimero-node-1
-        context_id: '{{my_context_id}}'
-        executor_public_key: '{{member_key}}'
+        context_id: "{{my_context_id}}"
+        executor_public_key: "{{member_key}}"
         method: set
         args:
           key: "iteration_{{current_iteration}}"
           value: "value_{{current_iteration}}"
         outputs:
-          iteration_result: result     # Export 'result' as 'iteration_result'
-      
+          iteration_result: result # Export 'result' as 'iteration_result'
+
       - name: Wait Between Operations
-        type: wait
-        seconds: 1
-      
+        type: wait_for_sync
+        context_id: "{{my_context_id}}"
+        nodes:
+          - calimero-node-1
+          - calimero-node-2
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
+
       - name: Get Key-Value Pair
         type: call
         node: calimero-node-2
-        context_id: '{{my_context_id}}'
-        executor_public_key: '{{my_public_key}}'
+        context_id: "{{my_context_id}}"
+        executor_public_key: "{{my_public_key}}"
         method: get
         args:
           key: "iteration_{{current_iteration}}"
@@ -145,6 +157,6 @@ steps:
           iteration_get_result: result # Export 'result' as 'iteration_get_result'
 
 # Configuration options
-stop_all_nodes: true   # Stop all nodes at the end of workflow
-restart: false          # Don't restart nodes at the beginning of workflow
+stop_all_nodes: true # Stop all nodes at the end of workflow
+restart: false # Don't restart nodes at the beginning of workflow
 wait_timeout: 60

--- a/workflow-examples/workflow-example-binary.yml
+++ b/workflow-examples/workflow-example-binary.yml
@@ -137,8 +137,15 @@ steps:
 
   # Step 11: Wait for the set operation to complete and propagate
   - name: Wait for Set Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 12: Execute a view call to retrieve the stored value from node 2
   # Demonstrates cross-node execution using the joined context
@@ -181,8 +188,15 @@ steps:
 
   # Step 15: Wait for propagation
   - name: Wait for Node 3 Set Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 16: Verify the node 3 value can be read from other nodes
   - name: Verify Node 3 Value from Node 1
@@ -217,8 +231,15 @@ steps:
           iteration_set_result: result # Export 'result' as 'iteration_set_result'
 
       - name: Wait for Set Operation
-        type: wait
-        seconds: 2
+        type: wait_for_sync
+        context_id: "{{context_id}}"
+        nodes:
+          - calimero-node-1
+          - calimero-node-2
+          - calimero-node-3
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
 
       - name: Get Key-Value Pair from Node 2
         type: call

--- a/workflow-examples/workflow-mesh-example.yml
+++ b/workflow-examples/workflow-mesh-example.yml
@@ -45,8 +45,15 @@ steps:
       set_result: result
 
   - name: Wait for Set Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Execute View Call - Get Value from Node 2
     type: call
@@ -83,8 +90,15 @@ steps:
       update_result: result
 
   - name: Wait for Update Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Verify Update from Node 2
     type: call

--- a/workflow-examples/workflow-nuke-example.yml
+++ b/workflow-examples/workflow-nuke-example.yml
@@ -81,8 +81,14 @@ steps:
 
   # Wait for operation to propagate
   - name: Wait for Set Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Test contract call - get value
   - name: Get Value from KV Store

--- a/workflow-examples/workflow-open-invitation-example.yml
+++ b/workflow-examples/workflow-open-invitation-example.yml
@@ -98,8 +98,14 @@ steps:
 
   # Wait for consensus
   - name: Wait for Consensus
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - open-inv-node-1
+      - open-inv-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Verify all members can read initial state
   - name: Get State - Node 1 (Inviter)
@@ -145,8 +151,14 @@ steps:
 
   # Wait for broadcast
   - name: Wait for Broadcast
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - open-inv-node-1
+      - open-inv-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Verify all members see the update
   - name: Get Update - Node 1 (Inviter)

--- a/workflow-examples/workflow-proposals-example.yml
+++ b/workflow-examples/workflow-proposals-example.yml
@@ -95,8 +95,15 @@ steps:
 
   # Step 10: Wait for consensus after join
   - name: Wait for Consensus After Join
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # ============================================================================
   # Create Multiple Proposals for Testing
@@ -122,8 +129,15 @@ steps:
 
   # Step 12: Wait for proposal 1 to propagate
   - name: Wait After Proposal 1
-    type: wait
-    seconds: 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 13: Create second proposal - SetContextValue
   - name: Create Proposal 2 - SetContextValue
@@ -145,8 +159,15 @@ steps:
 
   # Step 14: Wait for proposal 2 to propagate
   - name: Wait After Proposal 2
-    type: wait
-    seconds: 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 15: Create third proposal - SetNumApprovals (changes approval requirement)
   - name: Create Proposal 3 - SetNumApprovals
@@ -167,8 +188,15 @@ steps:
 
   # Step 16: Wait for proposal 3 to propagate
   - name: Wait After Proposal 3
-    type: wait
-    seconds: 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 17: Approve proposal 3 to activate the num_approvals setting
   # This is critical - proposal 3 must execute before creating proposal 4
@@ -185,8 +213,15 @@ steps:
 
   # Step 18: Wait for proposal 3 to execute
   - name: Wait for Proposal 3 Execution
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 19: Create fourth proposal - will require 2 approvals (for testing approvers)
   - name: Create Proposal 4 - SetContextValue
@@ -208,8 +243,15 @@ steps:
 
   # Step 20: Wait for all proposals to propagate
   - name: Wait for All Proposals to Propagate
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # ============================================================================
   # Test Proposals API Method 1: list_proposals (cross-node consistency)
@@ -300,8 +342,15 @@ steps:
 
   # Step 30: Wait for message to broadcast
   - name: Wait for Message Broadcast
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 31: Get proposal messages from node 2
   - name: Get Proposal Messages from Node 2
@@ -369,8 +418,15 @@ steps:
 
   # Step 36: Wait for first approval to propagate
   - name: Wait for First Approval to Propagate
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # ============================================================================
   # Verify Approvers After Approval (Before Proposal Execution)
@@ -405,8 +461,15 @@ steps:
 
   # Step 40: Wait for proposal 4 to execute
   - name: Wait for Proposal 4 Execution
-    type: wait
-    seconds: 5
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - prop-test-1
+      - prop-test-2
+      - prop-test-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # ============================================================================
   # Test Repeat Step with Proposal API Methods
@@ -441,8 +504,15 @@ steps:
 
       # Wait for proposal to propagate
       - name: Wait After Creation
-        type: wait
-        seconds: 2
+        type: wait_for_sync
+        context_id: "{{context_id}}"
+        nodes:
+          - prop-test-1
+          - prop-test-2
+          - prop-test-3
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
 
       # Test get_proposal inside repeat block
       - name: Get Proposal Details

--- a/workflow-examples/workflow-repeat-example.yml
+++ b/workflow-examples/workflow-repeat-example.yml
@@ -80,8 +80,14 @@ steps:
           simple_set_result: result  # Export 'result' as 'simple_set_result'
       
       - name: Wait for Set Operation
-        type: wait
-        seconds: 1
+        type: wait_for_sync
+        context_id: "{{context_id}}"
+        nodes:
+          - calimero-node-1
+          - calimero-node-2
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
 
   # Step 8: Example 2 - Repeat with multiple nested steps and different operations
   - name: Complex Repeat Example
@@ -115,8 +121,14 @@ steps:
           complex_set_b_result: result  # Export 'result' as 'complex_set_b_result'
       
       - name: Wait Between Operations
-        type: wait
-        seconds: 2
+        type: wait_for_sync
+        context_id: "{{context_id}}"
+        nodes:
+          - calimero-node-1
+          - calimero-node-2
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
       
       - name: Retrieve First Key-Value Pair
         type: call
@@ -160,8 +172,14 @@ steps:
           iteration_set_result: result  # Export 'result' as 'iteration_set_result'
       
       - name: Wait for Propagation
-        type: wait
-        seconds: 1
+        type: wait_for_sync
+        context_id: "{{context_id}}"
+        nodes:
+          - calimero-node-1
+          - calimero-node-2
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
       
       - name: Verify Data from Different Node
         type: call

--- a/workflow-examples/workflow-restart-example.yml
+++ b/workflow-examples/workflow-restart-example.yml
@@ -74,8 +74,14 @@ steps:
 
   # Step 8: Wait for the set operation to complete and propagate
   - name: Wait for Set Operation
-    type: wait
-    seconds: 3
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   # Step 9: Execute a view call to retrieve the stored value
   - name: Execute View Call - Get Value


### PR DESCRIPTION
### Summary

Updated all workflow examples to replace wait steps with wait_for_sync wherever they were previously used for node propagation or synchronization. This change ensures that workflows actively verify node sync by comparing root hashes instead of relying on fixed delays, resulting in more reliable and potentially faster runs.

Also, I noticed that the CI was occasionally failing at the assert step due to node synchronization issues, so I made this update to resolve that problem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces time-based wait steps with `wait_for_sync` (with `context_id`, target `nodes`, and sync parameters) across all workflow examples to actively verify cross-node synchronization.
> 
> - **Workflows updated to active synchronization**
>   - `workflow-blob-upload-example.yml`: Replace waits after blob registration, file listing, and deletions with `wait_for_sync` using `context_id`, `nodes` (node-1/2), `timeout`, `check_interval`, `trigger_sync`.
>   - `workflow-custom-outputs-example.yml`: Swap waits after set and within repeat blocks for `wait_for_sync` (node-1/2) and normalize templating/outputs quoting.
>   - `workflow-example-binary.yml`: Replace waits after set operations and within repeat steps with `wait_for_sync` (node-1/2/3).
>   - `workflow-mesh-example.yml`: Replace waits after set/update with `wait_for_sync` (node-1/2/3).
>   - `workflow-nuke-example.yml`: Replace post-set wait with `wait_for_sync` (node-1/2).
>   - `workflow-open-invitation-example.yml`: Replace consensus/broadcast waits with `wait_for_sync` (open-inv-node-1/2).
>   - `workflow-proposals-example.yml`: Replace multiple propagation/execution waits (after joins, proposals, approvals, messages, repeat steps) with `wait_for_sync` (prop-test-1/2/3).
>   - `workflow-repeat-example.yml`: Replace waits within repeat sections with `wait_for_sync` (node-1/2).
>   - `workflow-restart-example.yml`: Replace post-set wait with `wait_for_sync` (node-1/2).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffcada0f369cad2d00d024047129b40d77d3a7f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->