### PR TITLE
feat: enhance DockerManager to support Docker host URLs for local development

### DIFF
--- a/merobox/commands/constants.py
+++ b/merobox/commands/constants.py
@@ -111,3 +111,25 @@ ERROR_INVALID_URL = "Invalid URL: {url}"
 ERROR_INVALID_PORT = "Port must be between 1 and 65535"
 ERROR_FILE_NOT_FOUND = "File not found: {path}"
 ERROR_CONTAINER_DATA_DIR_NOT_FOUND = "Container data directory not found: {dir}"
+
+# Local devnet ports
+# These are the default ports used by local blockchain devnets
+ANVIL_DEFAULT_PORT = 8545  # Anvil (Ethereum local devnet) default RPC port
+DFX_DEFAULT_PORT = 4943  # dfx (ICP local devnet) default RPC port
+
+# Ethereum local devnet configuration (Anvil defaults)
+# Reference: https://getfoundry.sh/anvil/overview#getting-started
+# Anvil provides 10 default accounts with pre-funded balances for testing
+# These are the first account's credentials from Anvil's default account list
+ETHEREUM_LOCAL_CONTRACT_ID = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+# Anvil default account #0 (first account)
+# Address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+# Private key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+ETHEREUM_LOCAL_ACCOUNT_ID = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+ETHEREUM_LOCAL_SECRET_KEY = (
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+)
+
+# ICP local devnet configuration (dfx defaults)
+# Reference: dfx local devnet uses this canister ID for the default context config
+ICP_LOCAL_CONTRACT_ID = "bkyz2-fmaaa-aaaaa-qaaaq-cai"

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -16,6 +16,15 @@ from rich.console import Console
 from rich.table import Table
 
 from merobox.commands.config_utils import apply_near_devnet_config_to_file
+from merobox.commands.constants import (
+    ANVIL_DEFAULT_PORT,
+    DFX_DEFAULT_PORT,
+    ETHEREUM_LOCAL_ACCOUNT_ID,
+    ETHEREUM_LOCAL_CONTRACT_ID,
+    ETHEREUM_LOCAL_SECRET_KEY,
+    ICP_LOCAL_CONTRACT_ID,
+    NETWORK_LOCAL,
+)
 
 console = Console()
 
@@ -1534,8 +1543,8 @@ class DockerManager:
                 config = toml.load(f)
 
             # Use Docker host URLs when nodes run in Docker (they always do with --image flag)
-            eth_rpc_url = self._get_docker_host_url(8545)  # Anvil runs on port 8545
-            icp_rpc_url = self._get_docker_host_url(4943)  # dfx runs on port 4943
+            eth_rpc_url = self._get_docker_host_url(ANVIL_DEFAULT_PORT)
+            icp_rpc_url = self._get_docker_host_url(DFX_DEFAULT_PORT)
 
             # Apply e2e-style defaults for reliable testing
             e2e_config = {
@@ -1551,16 +1560,16 @@ class DockerManager:
                 "sync.interval_ms": 500,
                 # 1s periodic checks (ensures rapid sync in tests)
                 "sync.frequency_ms": 1000,
-                # Ethereum local devnet configuration
-                "context.config.ethereum.network": "local",
-                "context.config.ethereum.contract_id": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+                # Ethereum local devnet configuration (uses Anvil default account #0)
+                "context.config.ethereum.network": NETWORK_LOCAL,
+                "context.config.ethereum.contract_id": ETHEREUM_LOCAL_CONTRACT_ID,
                 "context.config.ethereum.signer": "self",
                 "context.config.signer.self.ethereum.local.rpc_url": eth_rpc_url,
-                "context.config.signer.self.ethereum.local.account_id": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                "context.config.signer.self.ethereum.local.secret_key": "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+                "context.config.signer.self.ethereum.local.account_id": ETHEREUM_LOCAL_ACCOUNT_ID,
+                "context.config.signer.self.ethereum.local.secret_key": ETHEREUM_LOCAL_SECRET_KEY,
                 # ICP local devnet configuration (for consistency)
-                "context.config.icp.network": "local",
-                "context.config.icp.contract_id": "bkyz2-fmaaa-aaaaa-qaaaq-cai",
+                "context.config.icp.network": NETWORK_LOCAL,
+                "context.config.icp.contract_id": ICP_LOCAL_CONTRACT_ID,
                 "context.config.icp.signer": "self",
                 "context.config.signer.self.icp.local.rpc_url": icp_rpc_url,
             }


### PR DESCRIPTION
# Fix Docker Networking for Ethereum and ICP E2E Workflows

## Problem

When merobox runs workflows with `--e2e-mode` and nodes run in Docker containers, the nodes cannot connect to blockchain devnets (Anvil for Ethereum, dfx for ICP) running on the host machine because they use `127.0.0.1` which refers to the container itself, not the host.

### Root Causes

1. **Incorrect Network Name**: Ethereum configuration used `"sepolia"` network name with local devnet RPC URL (`http://127.0.0.1:8545`), which is semantically incorrect and doesn't work with the merod fix in core that applies Docker host detection when `network_name == "local"`.

2. **Missing Docker Host Detection**: RPC URLs were hardcoded to `127.0.0.1`, which doesn't work from inside Docker containers.

3. **Incomplete ICP Configuration**: ICP e2e defaults were missing, causing similar networking issues for ICP workflows.

## Solution

### Changes Made

1. **Added Docker Host URL Helper Method** (`_get_docker_host_url`)
   - Returns `http://host.docker.internal:{port}` for Docker containers to reach host services
   - Works on Mac/Windows Docker Desktop; Linux Docker handles resolution automatically

2. **Fixed Ethereum E2E Defaults**
   - Changed network name from `"sepolia"` to `"local"` (semantically correct for local devnet)
   - Updated all config keys to use `"local"` instead of `"sepolia"`
   - Uses `host.docker.internal:8545` for Anvil RPC URL instead of `127.0.0.1:8545`

3. **Added ICP E2E Defaults**
   - Added ICP local devnet configuration for consistency
   - Uses `host.docker.internal:4943` for dfx RPC URL

### Related Issues

Fixes Docker networking issues when running E2E workflows with `--e2e-mode` flag where nodes run in Docker containers and need to connect to blockchain devnets on the host machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use Docker host URLs and local devnet defaults for Ethereum and ICP in e2e mode, backed by new constants.
> 
> - **DockerManager**:
>   - Add `host.docker.internal` to `extra_hosts` when `e2e_mode` (in addition to Near devnet and mock relayer).
>   - New `_get_docker_host_url(port)` helper; e2e defaults now use Docker host URLs for Anvil (`8545`) and dfx (`4943`).
>   - Update e2e Ethereum config to `network` = `local`, use `ETHEREUM_LOCAL_CONTRACT_ID`, and Anvil default `account_id`/`secret_key` via constants.
>   - Add ICP e2e defaults: `network` = `local`, `ICP_LOCAL_CONTRACT_ID`, and Docker host RPC URL.
> - **Constants**:
>   - Add devnet ports `ANVIL_DEFAULT_PORT`, `DFX_DEFAULT_PORT`.
>   - Add Ethereum local defaults: `ETHEREUM_LOCAL_CONTRACT_ID`, `ETHEREUM_LOCAL_ACCOUNT_ID`, `ETHEREUM_LOCAL_SECRET_KEY`.
>   - Add ICP local default: `ICP_LOCAL_CONTRACT_ID`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec47487b8787e575ffbf8d6104bbe184aba5b271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->