### PR TITLE
fix: ensure proper file permissions for Docker-managed configurations

### DIFF
--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -638,6 +638,10 @@ class DockerManager:
 
                 # Apply e2e-style configuration for reliable testing (only if e2e_mode is enabled)
                 if e2e_mode:
+                    # Docker might create files as root; we need to own them to modify config.toml
+                    # Only fix permissions if not already fixed (when near_devnet_config is provided)
+                    if not near_devnet_config:
+                        self._fix_permissions(node_data_dir)
                     self._apply_e2e_defaults(config_file, node_name, workflow_id)
 
                 # Apply bootstrap nodes configuration (works regardless of e2e_mode)


### PR DESCRIPTION
## Fix: Permission Denied When Applying E2E Defaults in CI

Fixes `[Errno 13] Permission denied` error when applying e2e defaults in CI (Docker mode).

**Problem:** When `--e2e-mode` is enabled without `near_devnet_config`, Docker-created config files (owned by root) cannot be modified by the host user in CI environments.

**Solution:** Call `_fix_permissions()` before applying e2e defaults when `e2e_mode` is enabled and permissions haven't already been fixed.

**Changes:**
- `merobox/commands/manager.py`: Added permission fix before `_apply_e2e_defaults()` when needed

Fixes CI failures while maintaining backward compatibility.

Reference :
https://github.com/calimero-network/core/actions/runs/20331715436/job/58410329845?pr=1696
https://github.com/calimero-network/core/actions/runs/20331715436/job/58410329850?pr=1696

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes file ownership before applying e2e defaults when running in Docker without near_devnet_config to prevent permission errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74b91cf731d2fa130c676afcb77cece018094c97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->