### PR TITLE
feat: add support for Linux capabilities in DockerManager 

### DIFF
--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -636,6 +636,7 @@ class WorkflowExecutor:
                 node_use_image_entrypoint = node_cfg.get(
                     "use_image_entrypoint", use_image_entrypoint
                 )
+                node_cap_add = node_cfg.get("cap_add")
             else:
                 port = base_port
                 rpc_port = base_rpc_port
@@ -644,6 +645,7 @@ class WorkflowExecutor:
                 data_dir = None
                 node_config_path = config_path
                 node_use_image_entrypoint = use_image_entrypoint
+                node_cap_add = None
 
             # Check if node is running
             is_running = self._is_node_running(node_name)
@@ -704,6 +706,8 @@ class WorkflowExecutor:
                         run_node_kwargs["use_image_entrypoint"] = (
                             node_use_image_entrypoint
                         )
+                    if node_cap_add is not None:
+                        run_node_kwargs["cap_add"] = node_cap_add
 
                     if not self.manager.run_node(**run_node_kwargs):
                         return False
@@ -737,6 +741,8 @@ class WorkflowExecutor:
                 }
                 if not self.is_binary_mode:
                     run_node_kwargs["use_image_entrypoint"] = node_use_image_entrypoint
+                if node_cap_add is not None:
+                    run_node_kwargs["cap_add"] = node_cap_add
 
                 if not self.manager.run_node(**run_node_kwargs):
                     return False

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -307,6 +307,7 @@ class DockerManager:
         near_devnet_config: dict = None,
         bootstrap_nodes: list[str] = None,  # bootstrap nodes to connect to
         use_image_entrypoint: bool = False,  # preserve Docker image's entrypoint
+        cap_add: list[str] = None,  # Linux capabilities to add (e.g., ["SYS_ADMIN"])
     ) -> bool:
         """Run a Calimero node container."""
         try:
@@ -485,6 +486,20 @@ class DockerManager:
                     "chain.id": chain_id,
                 },
             }
+
+            # Add Linux capabilities for profiling images or if explicitly configured
+            # Auto-detect profiling images by checking if image name contains "-profiling"
+            if cap_add is not None:
+                container_config["cap_add"] = cap_add
+                console.print(
+                    f"[cyan]Adding Linux capabilities to {node_name}: {', '.join(cap_add)}[/cyan]"
+                )
+            elif "-profiling" in image_to_use:
+                # Auto-detect profiling images and add SYS_ADMIN capability
+                container_config["cap_add"] = ["SYS_ADMIN"]
+                console.print(
+                    f"[cyan]Auto-detected profiling image for {node_name}, adding SYS_ADMIN capability[/cyan]"
+                )
 
             # Near Devnet, Mock relayer, and E2E mode support
             if near_devnet_config or mock_relayer or e2e_mode:


### PR DESCRIPTION
## Add `--cap-add SYS_ADMIN` support for profiling containers

Automatically adds `SYS_ADMIN` capability for profiling images (auto-detects `-profiling` suffix) or via explicit `cap_add` config. Enables `perf` to access kernel performance counters for CPU profiling and flamegraph generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables configuring Linux capabilities for node containers and auto-applies `SYS_ADMIN` for profiling images.
> 
> - Adds `cap_add` parameter to `DockerManager.run_node` and applies it to Docker `container_config`; auto-detects `-profiling` images to add `SYS_ADMIN` if not explicitly set
> - `WorkflowExecutor` now reads per-node `cap_add` from `nodes` config and forwards it to `run_node`
> - Minor console logs to surface applied capabilities and profiling auto-detection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dca224a3d99240e3bde60be88d9a8fbeda4d554d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->