### PR TITLE
feat: Add --merod-args flag to bootstrap run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ merobox run --auth-service
 # Start with embedded auth (binary mode)
 merobox run --no-docker --binary-path /path/to/merod --auth-mode embedded
 
+# Pass extra arguments straight to `merod run` (binary mode only)
+merobox bootstrap run workflow.yml --no-docker --binary-path ./merod \
+  --merod-args="--sync-strategy delta --state-sync-strategy hash"
+
 # Check node status
 merobox health
 

--- a/merobox/commands/binary_manager.py
+++ b/merobox/commands/binary_manager.py
@@ -777,6 +777,7 @@ class BinaryManager(CleanupMixin):
         e2e_mode: bool = False,  # enable e2e-style defaults
         bootstrap_nodes: list[str] = None,  # bootstrap nodes to connect to
         auth_mode: Optional[str] = None,  # Authentication mode (embedded, proxy)
+        merod_args: Optional[str] = None,  # Additional arguments to pass to merod run
     ) -> bool:
         """
         Start multiple nodes with sequential naming.
@@ -793,6 +794,7 @@ class BinaryManager(CleanupMixin):
             log_level: RUST_LOG level
             rust_backtrace: RUST_BACKTRACE level
             auth_mode: Authentication mode ('embedded' or 'proxy')
+            merod_args: Additional arguments to pass to each `merod run` command
 
         Returns:
             True if all nodes started successfully
@@ -852,6 +854,7 @@ class BinaryManager(CleanupMixin):
                 e2e_mode=e2e_mode,
                 bootstrap_nodes=bootstrap_nodes,
                 auth_mode=auth_mode,
+                merod_args=merod_args,
             )
 
         with ThreadPoolExecutor(max_workers=count) as pool:

--- a/merobox/commands/binary_manager.py
+++ b/merobox/commands/binary_manager.py
@@ -4,6 +4,7 @@ Binary Manager - Manages Calimero nodes as native processes (no Docker).
 
 import os
 import re
+import shlex
 import shutil
 import signal
 import socket
@@ -191,6 +192,7 @@ class BinaryManager(CleanupMixin):
         config_path: Optional[str] = None,  # custom config.toml path
         bootstrap_nodes: list[str] = None,  # bootstrap nodes to connect to
         auth_mode: Optional[str] = None,  # Authentication mode (embedded, proxy)
+        merod_args: Optional[str] = None,  # Additional arguments to pass to merod run
     ) -> bool:
         """
         Run a Calimero node as a native binary process.
@@ -204,6 +206,8 @@ class BinaryManager(CleanupMixin):
             rust_backtrace: RUST_BACKTRACE level
             auth_mode: Authentication mode ('embedded' or 'proxy'). When 'embedded',
                 enables built-in auth with JWT protection on all endpoints.
+            merod_args: Additional arguments to pass to merod run command.
+                Example: "--sync-strategy delta --state-sync-strategy hash"
 
         Returns:
             True if successful, False otherwise
@@ -352,6 +356,10 @@ class BinaryManager(CleanupMixin):
                 node_name,
                 "run",
             ]
+
+            # Append additional merod arguments if provided
+            if merod_args:
+                cmd.extend(shlex.split(merod_args))
 
             if foreground:
                 # Start attached in foreground (inherit stdio)

--- a/merobox/commands/bootstrap/bootstrap.py
+++ b/merobox/commands/bootstrap/bootstrap.py
@@ -186,6 +186,13 @@ def bootstrap():
     help="Set custom path to merod binary (used with --no-docker). Defaults to searching PATH and common locations (/usr/local/bin, /usr/bin, ~/bin).",
 )
 @click.option(
+    "--merod-args",
+    type=str,
+    default=None,
+    help="Additional arguments to pass to merod run command (binary mode only). "
+    'Example: --merod-args="--sync-strategy delta"',
+)
+@click.option(
     "--e2e-mode",
     is_flag=True,
     help="Enable e2e test mode with aggressive sync settings and test isolation (disables bootstrap nodes, uses unique rendezvous namespaces)",
@@ -237,6 +244,7 @@ def run(
     rust_backtrace,
     no_docker,
     binary_path,
+    merod_args,
     e2e_mode,
     remote_node,
     remote_auth,
@@ -280,6 +288,14 @@ def run(
         )
         sys.exit(1)
 
+    # Warn if --merod-args is used without --no-docker
+    if merod_args and not no_docker:
+        console.print(
+            "[yellow]⚠ --merod-args is only supported with --no-docker (binary mode). "
+            "Flag will be ignored.[/yellow]"
+        )
+        merod_args = None
+
     # Parse remote node CLI options
     cli_remote_nodes = parse_remote_nodes(remote_node)
     cli_remote_nodes = parse_remote_auth(remote_auth, cli_remote_nodes, api_key)
@@ -296,6 +312,7 @@ def run(
         rust_backtrace=rust_backtrace,
         no_docker=no_docker,
         binary_path=binary_path,
+        merod_args=merod_args,
         e2e_mode=e2e_mode,
         cli_remote_nodes=cli_remote_nodes,
         auth_mode=auth_mode,

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -80,6 +80,8 @@ VALID_STEP_TYPES = frozenset(
         "upload_blob",
         "create_mesh",
         "fuzzy_test",
+        "stop_node",
+        "start_node",
     }
 )
 

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -1012,6 +1012,126 @@ class WorkflowExecutor:
         console.print("[green]✓ Node management completed[/green]")
         return True
 
+    async def _start_single_node(
+        self, node_name: str, node_config: dict | None = None, nodes_config: dict | None = None
+    ) -> bool:
+        """
+        Start a single node with proper configuration.
+        
+        This is a helper method for start_node step to start individual nodes
+        with all the proper configuration from the workflow.
+        
+        Args:
+            node_name: Name of the node to start
+            node_config: Optional node-specific config dict
+            nodes_config: Optional workflow nodes config dict
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.manager:
+            return False
+            
+        # Get base config from workflow
+        if nodes_config is None:
+            nodes_config = self.config.get("nodes", {})
+            
+        base_port = nodes_config.get("base_port", 2428) if isinstance(nodes_config, dict) else None
+        base_rpc_port = nodes_config.get("base_rpc_port", 2528) if isinstance(nodes_config, dict) else None
+        chain_id = nodes_config.get("chain_id", "testnet-1") if isinstance(nodes_config, dict) else "testnet-1"
+        image = self.image if self.image is not None else (nodes_config.get("image") if isinstance(nodes_config, dict) else None)
+        config_path = self._resolve_config_path(nodes_config.get("config_path") if isinstance(nodes_config, dict) else None)
+        use_image_entrypoint = nodes_config.get("use_image_entrypoint", False) if isinstance(nodes_config, dict) else False
+        
+        # Use node-specific config if provided, otherwise derive from base config
+        if node_config:
+            port = node_config.get("port", base_port)
+            rpc_port = node_config.get("rpc_port", base_rpc_port)
+            node_chain_id = node_config.get("chain_id", chain_id)
+            node_image = node_config.get("image", image)
+            data_dir = node_config.get("data_dir")
+            node_config_path = self._resolve_config_path(node_config.get("config_path", config_path))
+            node_use_image_entrypoint = node_config.get("use_image_entrypoint", use_image_entrypoint)
+        else:
+            # Try to extract from nodes_config if it's a dict with node-specific entries
+            if isinstance(nodes_config, dict) and node_name in nodes_config:
+                node_cfg = nodes_config[node_name]
+                port = node_cfg.get("port", base_port)
+                rpc_port = node_cfg.get("rpc_port", base_rpc_port)
+                node_chain_id = node_cfg.get("chain_id", chain_id)
+                node_image = node_cfg.get("image", image) if image else node_cfg.get("image")
+                data_dir = node_cfg.get("data_dir")
+                node_config_path = self._resolve_config_path(node_cfg.get("config_path", config_path))
+                node_use_image_entrypoint = node_cfg.get("use_image_entrypoint", use_image_entrypoint)
+            elif isinstance(nodes_config, dict) and "count" in nodes_config:
+                # Extract index from node name (e.g., "calimero-node-1" -> 1)
+                try:
+                    prefix = nodes_config.get("prefix", "calimero-node")
+                    if node_name.startswith(prefix):
+                        index = int(node_name.split("-")[-1]) - 1
+                        port = base_port + index if base_port is not None else None
+                        rpc_port = base_rpc_port + index if base_rpc_port is not None else None
+                    else:
+                        port = base_port
+                        rpc_port = base_rpc_port
+                except (ValueError, IndexError):
+                    port = base_port
+                    rpc_port = base_rpc_port
+                node_chain_id = chain_id
+                node_image = image
+                data_dir = None
+                node_config_path = config_path
+                node_use_image_entrypoint = use_image_entrypoint
+            else:
+                port = base_port
+                rpc_port = base_rpc_port
+                node_chain_id = chain_id
+                node_image = image
+                data_dir = None
+                node_config_path = config_path
+                node_use_image_entrypoint = use_image_entrypoint
+        
+        # Handle NEAR devnet config if enabled
+        node_near_config = None
+        if self.near_devnet:
+            creds = await self.sandbox.create_node_account(node_name)
+            node_near_config = {
+                "rpc_url": self.near_config["rpc_url"],
+                "contract_id": self.near_config["contract_id"],
+                **creds,
+            }
+        
+        # Build arguments for run_node
+        run_node_kwargs = {
+            "node_name": node_name,
+            "port": port,
+            "rpc_port": rpc_port,
+            "chain_id": node_chain_id,
+            "data_dir": data_dir,
+            "image": node_image,
+            "auth_service": self.auth_service,
+            "auth_image": self.auth_image,
+            "auth_use_cached": self.auth_use_cached,
+            "webui_use_cached": self.webui_use_cached,
+            "log_level": self.log_level,
+            "rust_backtrace": self.rust_backtrace,
+            "mock_relayer": self.mock_relayer,
+            "workflow_id": self.workflow_id,
+            "e2e_mode": self.e2e_mode,
+            "config_path": node_config_path,
+            "near_devnet_config": node_near_config,
+            "bootstrap_nodes": self.bootstrap_nodes,
+        }
+        if self.is_binary_mode:
+            if self.auth_mode:
+                run_node_kwargs["auth_mode"] = self.auth_mode
+            if self.merod_args:
+                run_node_kwargs["merod_args"] = self.merod_args
+        else:
+            run_node_kwargs["use_image_entrypoint"] = node_use_image_entrypoint
+        
+        return self.manager.run_node(**run_node_kwargs)
+
     async def _wait_for_nodes_ready(self) -> bool:
         """Wait for all local nodes to be ready and accessible.
 
@@ -1400,7 +1520,20 @@ class WorkflowExecutor:
             "auth_mode": self.auth_mode,
         }
 
-        if step_type == "install_application":
+        if step_type == "stop_node":
+            from merobox.commands.bootstrap.steps.stop_node import StopNodeStep
+
+            return StopNodeStep(step_config, **common_kwargs)
+        elif step_type == "start_node":
+            from merobox.commands.bootstrap.steps.start_node import StartNodeStep
+
+            return StartNodeStep(
+                step_config,
+                workflow_config=self.config,
+                executor=self,
+                **common_kwargs,
+            )
+        elif step_type == "install_application":
             return InstallApplicationStep(step_config, **common_kwargs)
         elif step_type == "create_context":
             return CreateContextStep(step_config, **common_kwargs)

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -830,6 +830,8 @@ class WorkflowExecutor:
                 if self.is_binary_mode:
                     if self.auth_mode:
                         run_multiple_kwargs["auth_mode"] = self.auth_mode
+                    if self.merod_args:
+                        run_multiple_kwargs["merod_args"] = self.merod_args
                 else:
                     run_multiple_kwargs["use_image_entrypoint"] = use_image_entrypoint
 
@@ -1049,11 +1051,6 @@ class WorkflowExecutor:
             if isinstance(nodes_config, dict)
             else None
         )
-        chain_id = (
-            nodes_config.get("chain_id", "testnet-1")
-            if isinstance(nodes_config, dict)
-            else "testnet-1"
-        )
         image = (
             self.image
             if self.image is not None
@@ -1072,7 +1069,6 @@ class WorkflowExecutor:
         if node_config:
             port = node_config.get("port", base_port)
             rpc_port = node_config.get("rpc_port", base_rpc_port)
-            node_chain_id = node_config.get("chain_id", chain_id)
             node_image = node_config.get("image", image)
             data_dir = node_config.get("data_dir")
             node_config_path = self._resolve_config_path(
@@ -1087,7 +1083,6 @@ class WorkflowExecutor:
                 node_cfg = nodes_config[node_name]
                 port = node_cfg.get("port", base_port)
                 rpc_port = node_cfg.get("rpc_port", base_rpc_port)
-                node_chain_id = node_cfg.get("chain_id", chain_id)
                 node_image = (
                     node_cfg.get("image", image) if image else node_cfg.get("image")
                 )
@@ -1114,7 +1109,6 @@ class WorkflowExecutor:
                 except (ValueError, IndexError):
                     port = base_port
                     rpc_port = base_rpc_port
-                node_chain_id = chain_id
                 node_image = image
                 data_dir = None
                 node_config_path = config_path
@@ -1122,28 +1116,18 @@ class WorkflowExecutor:
             else:
                 port = base_port
                 rpc_port = base_rpc_port
-                node_chain_id = chain_id
                 node_image = image
                 data_dir = None
                 node_config_path = config_path
                 node_use_image_entrypoint = use_image_entrypoint
 
-        # Handle NEAR devnet config if enabled
-        node_near_config = None
-        if self.near_devnet:
-            creds = await self.sandbox.create_node_account(node_name)
-            node_near_config = {
-                "rpc_url": self.near_config["rpc_url"],
-                "contract_id": self.near_config["contract_id"],
-                **creds,
-            }
-
-        # Build arguments for run_node
+        # Build arguments for run_node — kept in sync with the per-node kwargs
+        # built in _start_nodes() (neither manager's run_node() accepts
+        # chain_id / mock_relayer / near_devnet_config).
         run_node_kwargs = {
             "node_name": node_name,
             "port": port,
             "rpc_port": rpc_port,
-            "chain_id": node_chain_id,
             "data_dir": data_dir,
             "image": node_image,
             "auth_service": self.auth_service,
@@ -1152,11 +1136,9 @@ class WorkflowExecutor:
             "webui_use_cached": self.webui_use_cached,
             "log_level": self.log_level,
             "rust_backtrace": self.rust_backtrace,
-            "mock_relayer": self.mock_relayer,
             "workflow_id": self.workflow_id,
             "e2e_mode": self.e2e_mode,
             "config_path": node_config_path,
-            "near_devnet_config": node_near_config,
             "bootstrap_nodes": self.bootstrap_nodes,
         }
         if self.is_binary_mode:

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -1027,6 +1027,12 @@ class WorkflowExecutor:
         if not self.manager:
             return False
 
+        # Idempotent: a node that's already up doesn't need (re)starting — and
+        # DockerManager.run_node() would otherwise stop+remove the container.
+        if self._is_node_running(node_name):
+            console.print(f"[green]✓ Node '{node_name}' is already running[/green]")
+            return True
+
         # Get base config from workflow
         if nodes_config is None:
             nodes_config = self.config.get("nodes", {})
@@ -1099,6 +1105,11 @@ class WorkflowExecutor:
                         base_rpc_port + index if base_rpc_port is not None else None
                     )
                 except ValueError:
+                    console.print(
+                        f"[yellow]⚠ Node '{node_name}' doesn't match the "
+                        f"count-mode prefix '{prefix}-N'; using base ports "
+                        "(this may collide with other nodes).[/yellow]"
+                    )
                     port = base_port
                     rpc_port = base_rpc_port
                 node_image = image

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -114,6 +114,7 @@ class WorkflowExecutor:
         auth_username: Optional[str] = None,
         auth_password: Optional[str] = None,
         dry_run: bool = False,
+        merod_args: Optional[str] = None,
     ):
         self.config = config
         self.manager = manager
@@ -164,6 +165,9 @@ class WorkflowExecutor:
 
         # Auth mode for binary mode (can be set by CLI or workflow config, CLI takes precedence)
         self.auth_mode = auth_mode or config.get("auth_mode", None)
+
+        # Merod args for binary mode (CLI only, not from config)
+        self.merod_args = merod_args
 
         # Remote nodes configuration
         self.remote_nodes_config = config.get("remote_nodes", {})
@@ -868,6 +872,8 @@ class WorkflowExecutor:
                     if self.is_binary_mode:
                         if self.auth_mode:
                             run_node_kwargs["auth_mode"] = self.auth_mode
+                        if self.merod_args:
+                            run_node_kwargs["merod_args"] = self.merod_args
                     else:
                         run_node_kwargs["use_image_entrypoint"] = use_image_entrypoint
 
@@ -958,6 +964,8 @@ class WorkflowExecutor:
                     if self.is_binary_mode:
                         if self.auth_mode:
                             run_node_kwargs["auth_mode"] = self.auth_mode
+                        if self.merod_args:
+                            run_node_kwargs["merod_args"] = self.merod_args
                     else:
                         run_node_kwargs["use_image_entrypoint"] = (
                             node_use_image_entrypoint
@@ -993,6 +1001,8 @@ class WorkflowExecutor:
                 if self.is_binary_mode:
                     if self.auth_mode:
                         run_node_kwargs["auth_mode"] = self.auth_mode
+                    if self.merod_args:
+                        run_node_kwargs["merod_args"] = self.merod_args
                 else:
                     run_node_kwargs["use_image_entrypoint"] = node_use_image_entrypoint
 

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -776,6 +776,50 @@ class WorkflowExecutor:
         resolved = os.path.join(self.workflow_dir, config_path)
         return os.path.abspath(resolved)
 
+    def _build_run_node_kwargs(
+        self,
+        node_name: str,
+        *,
+        port: Optional[int],
+        rpc_port: Optional[int],
+        image: Optional[str],
+        data_dir: Optional[str] = None,
+        config_path: Optional[str] = None,
+        use_image_entrypoint: bool = False,
+    ) -> dict[str, Any]:
+        """Build the keyword arguments for ``manager.run_node()``.
+
+        Shared by every node-startup path (``_start_nodes`` and
+        ``_start_single_node``) so they stay in sync. ``merod_args`` /
+        ``auth_mode`` only apply in binary mode; ``use_image_entrypoint`` only
+        in Docker mode.
+        """
+        kwargs: dict[str, Any] = {
+            "node_name": node_name,
+            "port": port,
+            "rpc_port": rpc_port,
+            "data_dir": data_dir,
+            "image": image,
+            "auth_service": self.auth_service,
+            "auth_image": self.auth_image,
+            "auth_use_cached": self.auth_use_cached,
+            "webui_use_cached": self.webui_use_cached,
+            "log_level": self.log_level,
+            "rust_backtrace": self.rust_backtrace,
+            "workflow_id": self.workflow_id,
+            "e2e_mode": self.e2e_mode,
+            "config_path": config_path,
+            "bootstrap_nodes": self.bootstrap_nodes,
+        }
+        if self.is_binary_mode:
+            if self.auth_mode:
+                kwargs["auth_mode"] = self.auth_mode
+            if self.merod_args:
+                kwargs["merod_args"] = self.merod_args
+        else:
+            kwargs["use_image_entrypoint"] = use_image_entrypoint
+        return kwargs
+
     async def _start_nodes(self, restart: bool) -> bool:
         """Start the configured nodes."""
         nodes_config = self.config.get("nodes", {})
@@ -854,31 +898,13 @@ class WorkflowExecutor:
                     # Not running -> start (allow manager to allocate ports if base_* is None)
                     port = base_port + i if base_port is not None else None
                     rpc_port = base_rpc_port + i if base_rpc_port is not None else None
-                    # Build arguments for run_node
-                    run_node_kwargs = {
-                        "node_name": node_name,
-                        "port": port,
-                        "rpc_port": rpc_port,
-                        "data_dir": None,
-                        "image": image,
-                        "auth_service": self.auth_service,
-                        "auth_image": self.auth_image,
-                        "auth_use_cached": self.auth_use_cached,
-                        "webui_use_cached": self.webui_use_cached,
-                        "log_level": self.log_level,
-                        "rust_backtrace": self.rust_backtrace,
-                        "workflow_id": self.workflow_id,
-                        "e2e_mode": self.e2e_mode,
-                        "bootstrap_nodes": self.bootstrap_nodes,
-                    }
-                    if self.is_binary_mode:
-                        if self.auth_mode:
-                            run_node_kwargs["auth_mode"] = self.auth_mode
-                        if self.merod_args:
-                            run_node_kwargs["merod_args"] = self.merod_args
-                    else:
-                        run_node_kwargs["use_image_entrypoint"] = use_image_entrypoint
-
+                    run_node_kwargs = self._build_run_node_kwargs(
+                        node_name,
+                        port=port,
+                        rpc_port=rpc_port,
+                        image=image,
+                        use_image_entrypoint=use_image_entrypoint,
+                    )
                     if not self.manager.run_node(**run_node_kwargs):
                         return False
 
@@ -945,34 +971,15 @@ class WorkflowExecutor:
                         )
 
                     console.print(f"Starting node '{node_name}'...")
-                    # Build arguments for run_node
-                    run_node_kwargs = {
-                        "node_name": node_name,
-                        "port": port,
-                        "rpc_port": rpc_port,
-                        "data_dir": data_dir,
-                        "image": node_image,
-                        "auth_service": self.auth_service,
-                        "auth_image": self.auth_image,
-                        "auth_use_cached": self.auth_use_cached,
-                        "webui_use_cached": self.webui_use_cached,
-                        "log_level": self.log_level,
-                        "rust_backtrace": self.rust_backtrace,
-                        "workflow_id": self.workflow_id,
-                        "e2e_mode": self.e2e_mode,
-                        "config_path": node_config_path,
-                        "bootstrap_nodes": self.bootstrap_nodes,
-                    }
-                    if self.is_binary_mode:
-                        if self.auth_mode:
-                            run_node_kwargs["auth_mode"] = self.auth_mode
-                        if self.merod_args:
-                            run_node_kwargs["merod_args"] = self.merod_args
-                    else:
-                        run_node_kwargs["use_image_entrypoint"] = (
-                            node_use_image_entrypoint
-                        )
-
+                    run_node_kwargs = self._build_run_node_kwargs(
+                        node_name,
+                        port=port,
+                        rpc_port=rpc_port,
+                        image=node_image,
+                        data_dir=data_dir,
+                        config_path=node_config_path,
+                        use_image_entrypoint=node_use_image_entrypoint,
+                    )
                     if not self.manager.run_node(**run_node_kwargs):
                         return False
                 else:
@@ -982,32 +989,15 @@ class WorkflowExecutor:
                     continue
             else:
                 console.print(f"Starting node '{node_name}'...")
-                # Build arguments for run_node
-                run_node_kwargs = {
-                    "node_name": node_name,
-                    "port": port,
-                    "rpc_port": rpc_port,
-                    "data_dir": data_dir,
-                    "image": node_image,
-                    "auth_service": self.auth_service,
-                    "auth_image": self.auth_image,
-                    "auth_use_cached": self.auth_use_cached,
-                    "webui_use_cached": self.webui_use_cached,
-                    "log_level": self.log_level,
-                    "rust_backtrace": self.rust_backtrace,
-                    "workflow_id": self.workflow_id,
-                    "e2e_mode": self.e2e_mode,
-                    "config_path": node_config_path,
-                    "bootstrap_nodes": self.bootstrap_nodes,
-                }
-                if self.is_binary_mode:
-                    if self.auth_mode:
-                        run_node_kwargs["auth_mode"] = self.auth_mode
-                    if self.merod_args:
-                        run_node_kwargs["merod_args"] = self.merod_args
-                else:
-                    run_node_kwargs["use_image_entrypoint"] = node_use_image_entrypoint
-
+                run_node_kwargs = self._build_run_node_kwargs(
+                    node_name,
+                    port=port,
+                    rpc_port=rpc_port,
+                    image=node_image,
+                    data_dir=data_dir,
+                    config_path=node_config_path,
+                    use_image_entrypoint=node_use_image_entrypoint,
+                )
                 if not self.manager.run_node(**run_node_kwargs):
                     return False
 
@@ -1042,12 +1032,12 @@ class WorkflowExecutor:
             nodes_config = self.config.get("nodes", {})
 
         base_port = (
-            nodes_config.get("base_port", 2428)
+            nodes_config.get("base_port", DEFAULT_P2P_PORT)
             if isinstance(nodes_config, dict)
             else None
         )
         base_rpc_port = (
-            nodes_config.get("base_rpc_port", 2528)
+            nodes_config.get("base_rpc_port", DEFAULT_RPC_PORT)
             if isinstance(nodes_config, dict)
             else None
         )
@@ -1094,19 +1084,21 @@ class WorkflowExecutor:
                     "use_image_entrypoint", use_image_entrypoint
                 )
             elif isinstance(nodes_config, dict) and "count" in nodes_config:
-                # Extract index from node name (e.g., "calimero-node-1" -> 1)
+                # Count mode: derive the port offset from the node's index in
+                # its "{prefix}-{N}" name (1-based).
+                prefix = nodes_config.get("prefix", "calimero-node")
+                suffix = (
+                    node_name[len(prefix) :].lstrip("-")
+                    if node_name.startswith(prefix)
+                    else ""
+                )
                 try:
-                    prefix = nodes_config.get("prefix", "calimero-node")
-                    if node_name.startswith(prefix):
-                        index = int(node_name.split("-")[-1]) - 1
-                        port = base_port + index if base_port is not None else None
-                        rpc_port = (
-                            base_rpc_port + index if base_rpc_port is not None else None
-                        )
-                    else:
-                        port = base_port
-                        rpc_port = base_rpc_port
-                except (ValueError, IndexError):
+                    index = int(suffix) - 1
+                    port = base_port + index if base_port is not None else None
+                    rpc_port = (
+                        base_rpc_port + index if base_rpc_port is not None else None
+                    )
+                except ValueError:
                     port = base_port
                     rpc_port = base_rpc_port
                 node_image = image
@@ -1121,34 +1113,15 @@ class WorkflowExecutor:
                 node_config_path = config_path
                 node_use_image_entrypoint = use_image_entrypoint
 
-        # Build arguments for run_node — kept in sync with the per-node kwargs
-        # built in _start_nodes() (neither manager's run_node() accepts
-        # chain_id / mock_relayer / near_devnet_config).
-        run_node_kwargs = {
-            "node_name": node_name,
-            "port": port,
-            "rpc_port": rpc_port,
-            "data_dir": data_dir,
-            "image": node_image,
-            "auth_service": self.auth_service,
-            "auth_image": self.auth_image,
-            "auth_use_cached": self.auth_use_cached,
-            "webui_use_cached": self.webui_use_cached,
-            "log_level": self.log_level,
-            "rust_backtrace": self.rust_backtrace,
-            "workflow_id": self.workflow_id,
-            "e2e_mode": self.e2e_mode,
-            "config_path": node_config_path,
-            "bootstrap_nodes": self.bootstrap_nodes,
-        }
-        if self.is_binary_mode:
-            if self.auth_mode:
-                run_node_kwargs["auth_mode"] = self.auth_mode
-            if self.merod_args:
-                run_node_kwargs["merod_args"] = self.merod_args
-        else:
-            run_node_kwargs["use_image_entrypoint"] = node_use_image_entrypoint
-
+        run_node_kwargs = self._build_run_node_kwargs(
+            node_name,
+            port=port,
+            rpc_port=rpc_port,
+            image=node_image,
+            data_dir=data_dir,
+            config_path=node_config_path,
+            use_image_entrypoint=node_use_image_entrypoint,
+        )
         return self.manager.run_node(**run_node_kwargs)
 
     async def _wait_for_nodes_ready(self) -> bool:
@@ -1549,7 +1522,7 @@ class WorkflowExecutor:
             return StartNodeStep(
                 step_config,
                 workflow_config=self.config,
-                executor=self,
+                start_node_fn=self._start_single_node,
                 **common_kwargs,
             )
         elif step_type == "install_application":

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -1013,36 +1013,61 @@ class WorkflowExecutor:
         return True
 
     async def _start_single_node(
-        self, node_name: str, node_config: dict | None = None, nodes_config: dict | None = None
+        self,
+        node_name: str,
+        node_config: dict | None = None,
+        nodes_config: dict | None = None,
     ) -> bool:
         """
         Start a single node with proper configuration.
-        
+
         This is a helper method for start_node step to start individual nodes
         with all the proper configuration from the workflow.
-        
+
         Args:
             node_name: Name of the node to start
             node_config: Optional node-specific config dict
             nodes_config: Optional workflow nodes config dict
-            
+
         Returns:
             True if successful, False otherwise
         """
         if not self.manager:
             return False
-            
+
         # Get base config from workflow
         if nodes_config is None:
             nodes_config = self.config.get("nodes", {})
-            
-        base_port = nodes_config.get("base_port", 2428) if isinstance(nodes_config, dict) else None
-        base_rpc_port = nodes_config.get("base_rpc_port", 2528) if isinstance(nodes_config, dict) else None
-        chain_id = nodes_config.get("chain_id", "testnet-1") if isinstance(nodes_config, dict) else "testnet-1"
-        image = self.image if self.image is not None else (nodes_config.get("image") if isinstance(nodes_config, dict) else None)
-        config_path = self._resolve_config_path(nodes_config.get("config_path") if isinstance(nodes_config, dict) else None)
-        use_image_entrypoint = nodes_config.get("use_image_entrypoint", False) if isinstance(nodes_config, dict) else False
-        
+
+        base_port = (
+            nodes_config.get("base_port", 2428)
+            if isinstance(nodes_config, dict)
+            else None
+        )
+        base_rpc_port = (
+            nodes_config.get("base_rpc_port", 2528)
+            if isinstance(nodes_config, dict)
+            else None
+        )
+        chain_id = (
+            nodes_config.get("chain_id", "testnet-1")
+            if isinstance(nodes_config, dict)
+            else "testnet-1"
+        )
+        image = (
+            self.image
+            if self.image is not None
+            else (nodes_config.get("image") if isinstance(nodes_config, dict) else None)
+        )
+        config_path = self._resolve_config_path(
+            nodes_config.get("config_path") if isinstance(nodes_config, dict) else None
+        )
+        use_image_entrypoint = (
+            nodes_config.get("use_image_entrypoint", False)
+            if isinstance(nodes_config, dict)
+            else False
+        )
+
         # Use node-specific config if provided, otherwise derive from base config
         if node_config:
             port = node_config.get("port", base_port)
@@ -1050,8 +1075,12 @@ class WorkflowExecutor:
             node_chain_id = node_config.get("chain_id", chain_id)
             node_image = node_config.get("image", image)
             data_dir = node_config.get("data_dir")
-            node_config_path = self._resolve_config_path(node_config.get("config_path", config_path))
-            node_use_image_entrypoint = node_config.get("use_image_entrypoint", use_image_entrypoint)
+            node_config_path = self._resolve_config_path(
+                node_config.get("config_path", config_path)
+            )
+            node_use_image_entrypoint = node_config.get(
+                "use_image_entrypoint", use_image_entrypoint
+            )
         else:
             # Try to extract from nodes_config if it's a dict with node-specific entries
             if isinstance(nodes_config, dict) and node_name in nodes_config:
@@ -1059,10 +1088,16 @@ class WorkflowExecutor:
                 port = node_cfg.get("port", base_port)
                 rpc_port = node_cfg.get("rpc_port", base_rpc_port)
                 node_chain_id = node_cfg.get("chain_id", chain_id)
-                node_image = node_cfg.get("image", image) if image else node_cfg.get("image")
+                node_image = (
+                    node_cfg.get("image", image) if image else node_cfg.get("image")
+                )
                 data_dir = node_cfg.get("data_dir")
-                node_config_path = self._resolve_config_path(node_cfg.get("config_path", config_path))
-                node_use_image_entrypoint = node_cfg.get("use_image_entrypoint", use_image_entrypoint)
+                node_config_path = self._resolve_config_path(
+                    node_cfg.get("config_path", config_path)
+                )
+                node_use_image_entrypoint = node_cfg.get(
+                    "use_image_entrypoint", use_image_entrypoint
+                )
             elif isinstance(nodes_config, dict) and "count" in nodes_config:
                 # Extract index from node name (e.g., "calimero-node-1" -> 1)
                 try:
@@ -1070,7 +1105,9 @@ class WorkflowExecutor:
                     if node_name.startswith(prefix):
                         index = int(node_name.split("-")[-1]) - 1
                         port = base_port + index if base_port is not None else None
-                        rpc_port = base_rpc_port + index if base_rpc_port is not None else None
+                        rpc_port = (
+                            base_rpc_port + index if base_rpc_port is not None else None
+                        )
                     else:
                         port = base_port
                         rpc_port = base_rpc_port
@@ -1090,7 +1127,7 @@ class WorkflowExecutor:
                 data_dir = None
                 node_config_path = config_path
                 node_use_image_entrypoint = use_image_entrypoint
-        
+
         # Handle NEAR devnet config if enabled
         node_near_config = None
         if self.near_devnet:
@@ -1100,7 +1137,7 @@ class WorkflowExecutor:
                 "contract_id": self.near_config["contract_id"],
                 **creds,
             }
-        
+
         # Build arguments for run_node
         run_node_kwargs = {
             "node_name": node_name,
@@ -1129,7 +1166,7 @@ class WorkflowExecutor:
                 run_node_kwargs["merod_args"] = self.merod_args
         else:
             run_node_kwargs["use_image_entrypoint"] = node_use_image_entrypoint
-        
+
         return self.manager.run_node(**run_node_kwargs)
 
     async def _wait_for_nodes_ready(self) -> bool:

--- a/merobox/commands/bootstrap/run/run.py
+++ b/merobox/commands/bootstrap/run/run.py
@@ -84,6 +84,7 @@ async def run_workflow(
     rust_backtrace: str = "0",
     no_docker: bool = False,
     binary_path: Optional[str] = None,
+    merod_args: Optional[str] = None,
     e2e_mode: bool = False,
     cli_remote_nodes: Optional[dict[str, dict[str, Any]]] = None,
     auth_mode: Optional[str] = None,
@@ -198,6 +199,7 @@ async def run_workflow(
             auth_username=auth_username,
             auth_password=auth_password,
             dry_run=dry_run,
+            merod_args=merod_args,
         )
 
         # Execute workflow
@@ -237,6 +239,7 @@ def run_workflow_sync(
     rust_backtrace: str = "0",
     no_docker: bool = False,
     binary_path: Optional[str] = None,
+    merod_args: Optional[str] = None,
     e2e_mode: bool = False,
     cli_remote_nodes: Optional[dict[str, dict[str, Any]]] = None,
     auth_mode: Optional[str] = None,
@@ -273,6 +276,7 @@ def run_workflow_sync(
             rust_backtrace=rust_backtrace,
             no_docker=no_docker,
             binary_path=binary_path,
+            merod_args=merod_args,
             e2e_mode=e2e_mode,
             cli_remote_nodes=cli_remote_nodes,
             auth_mode=auth_mode,

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -72,6 +72,8 @@ from merobox.commands.bootstrap.steps.namespace import (
 from merobox.commands.bootstrap.steps.parallel import ParallelStep
 from merobox.commands.bootstrap.steps.repeat import RepeatStep
 from merobox.commands.bootstrap.steps.script import ScriptStep
+from merobox.commands.bootstrap.steps.start_node import StartNodeStep
+from merobox.commands.bootstrap.steps.stop_node import StopNodeStep
 from merobox.commands.bootstrap.steps.subgroup import (
     AddGroupMembersStep,
     ListSubgroupsStep,
@@ -145,4 +147,6 @@ __all__ = [
     "UpgradeGroupStep",
     "GetGroupUpgradeStatusStep",
     "RetryGroupUpgradeStep",
+    "StopNodeStep",
+    "StartNodeStep",
 ]

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -1,0 +1,211 @@
+"""
+Start node step executor - Start nodes during workflow execution.
+"""
+
+import asyncio
+import socket
+import time
+from typing import Any
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import console
+
+
+class StartNodeStep(BaseStep):
+    """Start nodes during workflow execution."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        manager: object | None = None,
+        resolver: object | None = None,
+        auth_mode: str | None = None,
+        workflow_config: dict[str, Any] | None = None,
+        executor: object | None = None,
+    ):
+        super().__init__(config, manager, resolver, auth_mode=auth_mode)
+        self.workflow_config = workflow_config or {}
+        self.executor = executor  # Reference to executor for accessing node startup logic
+
+    def _get_required_fields(self) -> list[str]:
+        """
+        Define which fields are required for this step.
+
+        Returns:
+            List of required field names
+        """
+        return ["nodes"]  # At least one node must be specified
+
+    def _validate_field_types(self) -> None:
+        """
+        Validate that fields have the correct types.
+        """
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+
+        # Validate nodes is a list or string
+        nodes = self.config.get("nodes")
+        if not isinstance(nodes, (list, str)):
+            raise ValueError(
+                f"Step '{step_name}': 'nodes' must be a list of node names or a single node name string"
+            )
+
+        # Validate wait_for_ready is a boolean if provided
+        if "wait_for_ready" in self.config and not isinstance(
+            self.config["wait_for_ready"], bool
+        ):
+            raise ValueError(
+                f"Step '{step_name}': 'wait_for_ready' must be a boolean"
+            )
+
+        # Validate wait_timeout is an integer if provided
+        if "wait_timeout" in self.config and not isinstance(
+            self.config["wait_timeout"], int
+        ):
+            raise ValueError(
+                f"Step '{step_name}': 'wait_timeout' must be an integer"
+            )
+
+        # Validate wait_timeout is positive if provided
+        if "wait_timeout" in self.config and self.config["wait_timeout"] <= 0:
+            raise ValueError(
+                f"Step '{step_name}': 'wait_timeout' must be positive"
+            )
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        """
+        Execute the start node step.
+
+        Args:
+            workflow_results: Results from previous workflow steps
+            dynamic_values: Dynamic values captured during workflow execution
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.manager:
+            console.print(
+                "[red]❌ Cannot start nodes: no manager available (remote-only mode)[/red]"
+            )
+            return False
+
+        # Get node names (can be a single string or list)
+        nodes_config = self.config.get("nodes")
+        if isinstance(nodes_config, str):
+            # Resolve dynamic values in node name
+            node_names = [
+                self._resolve_dynamic_value(nodes_config, workflow_results, dynamic_values)
+            ]
+        else:
+            # Resolve dynamic values in each node name
+            node_names = [
+                self._resolve_dynamic_value(node, workflow_results, dynamic_values)
+                for node in nodes_config
+            ]
+
+        console.print(
+            f"[yellow]🚀 Starting {len(node_names)} node(s): {', '.join(node_names)}[/yellow]"
+        )
+
+        # Get node configuration from workflow config
+        workflow_nodes_config = self.workflow_config.get("nodes", {})
+
+        started_nodes = []
+        failed_to_start = []
+
+        for node_name in node_names:
+            # Try to get node-specific config
+            node_config = None
+            if isinstance(workflow_nodes_config, dict):
+                # Check if this is a node-specific config entry
+                if node_name in workflow_nodes_config:
+                    node_config = workflow_nodes_config[node_name]
+                # Otherwise, use the base config for count-based nodes
+                elif "count" in workflow_nodes_config:
+                    # Extract index from node name (e.g., "calimero-node-1" -> 1)
+                    try:
+                        prefix = workflow_nodes_config.get("prefix", "calimero-node")
+                        if node_name.startswith(prefix):
+                            index = int(node_name.split("-")[-1]) - 1
+                            base_port = workflow_nodes_config.get("base_port", 2428)
+                            base_rpc_port = workflow_nodes_config.get("base_rpc_port", 2528)
+                            node_config = {
+                                "port": base_port + index if base_port else None,
+                                "rpc_port": base_rpc_port + index if base_rpc_port else None,
+                                "chain_id": workflow_nodes_config.get("chain_id", "testnet-1"),
+                            }
+                    except (ValueError, IndexError):
+                        pass
+
+            # Use executor's _start_single_node method if available
+            if self.executor and hasattr(self.executor, "_start_single_node"):
+                # Use executor's method which has access to all node config
+                success = await self.executor._start_single_node(
+                    node_name, node_config, workflow_nodes_config
+                )
+            else:
+                console.print(
+                    f"[red]❌ Cannot start node {node_name}: executor not available[/red]"
+                )
+                success = False
+
+            if success:
+                started_nodes.append(node_name)
+            else:
+                failed_to_start.append(node_name)
+
+        if failed_to_start:
+            console.print(
+                f"[red]❌ Failed to start nodes: {', '.join(failed_to_start)}[/red]"
+            )
+            return False
+
+        console.print(f"[green]✓ Started {len(started_nodes)} node(s)[/green]")
+
+        # Wait for nodes to be ready (optional)
+        wait_for_ready = self.config.get("wait_for_ready", True)
+        if wait_for_ready:
+            wait_timeout = self.config.get("wait_timeout", 30)
+            console.print(
+                f"[cyan]Waiting up to {wait_timeout} seconds for nodes to be ready...[/cyan]"
+            )
+
+            start_time = time.time()
+            all_ready = False
+
+            while time.time() - start_time < wait_timeout:
+                ready_count = 0
+                for node_name in started_nodes:
+                    # Try to get RPC port from manager
+                    rpc_port = None
+                    if hasattr(self.manager, "get_node_rpc_port"):
+                        rpc_port = self.manager.get_node_rpc_port(node_name)
+                    elif hasattr(self.manager, "node_rpc_ports"):
+                        rpc_port = self.manager.node_rpc_ports.get(node_name)
+
+                    if rpc_port:
+                        try:
+                            with socket.create_connection(
+                                ("127.0.0.1", rpc_port), timeout=1
+                            ):
+                                ready_count += 1
+                        except Exception:
+                            pass
+
+                if ready_count == len(started_nodes):
+                    all_ready = True
+                    break
+
+                await asyncio.sleep(1)
+
+            if all_ready:
+                console.print("[green]✓ All nodes are ready[/green]")
+            else:
+                console.print(
+                    "[yellow]⚠ Some nodes may not be ready yet, continuing...[/yellow]"
+                )
+
+        return True

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -117,28 +117,13 @@ class StartNodeStep(BaseStep):
         failed_to_start = []
 
         for node_name in node_names:
-            # Try to get node-specific config
+            # Try to get node-specific config (only for individually defined nodes)
             node_config = None
             if isinstance(workflow_nodes_config, dict):
                 # Check if this is a node-specific config entry
                 if node_name in workflow_nodes_config:
                     node_config = workflow_nodes_config[node_name]
-                # Otherwise, use the base config for count-based nodes
-                elif "count" in workflow_nodes_config:
-                    # Extract index from node name (e.g., "calimero-node-1" -> 1)
-                    try:
-                        prefix = workflow_nodes_config.get("prefix", "calimero-node")
-                        if node_name.startswith(prefix):
-                            index = int(node_name.split("-")[-1]) - 1
-                            base_port = workflow_nodes_config.get("base_port", 2428)
-                            base_rpc_port = workflow_nodes_config.get("base_rpc_port", 2528)
-                            node_config = {
-                                "port": base_port + index if base_port else None,
-                                "rpc_port": base_rpc_port + index if base_rpc_port else None,
-                                "chain_id": workflow_nodes_config.get("chain_id", "testnet-1"),
-                            }
-                    except (ValueError, IndexError):
-                        pass
+                # For count-based nodes, pass node_config=None and let _start_single_node handle it
 
             # Use executor's _start_single_node method if available
             if self.executor and hasattr(self.executor, "_start_single_node"):

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -65,11 +65,14 @@ class StartNodeStep(BaseStep):
         ):
             raise ValueError(f"Step '{step_name}': 'wait_for_ready' must be a boolean")
 
-        # Validate wait_timeout is an integer if provided
-        if "wait_timeout" in self.config and not isinstance(
-            self.config["wait_timeout"], int
-        ):
-            raise ValueError(f"Step '{step_name}': 'wait_timeout' must be an integer")
+        # Validate wait_timeout is an integer if provided (bool is an int
+        # subclass in Python, so reject it explicitly).
+        if "wait_timeout" in self.config:
+            wait_timeout = self.config["wait_timeout"]
+            if isinstance(wait_timeout, bool) or not isinstance(wait_timeout, int):
+                raise ValueError(
+                    f"Step '{step_name}': 'wait_timeout' must be an integer"
+                )
 
         # Validate wait_timeout is positive if provided
         if "wait_timeout" in self.config and self.config["wait_timeout"] <= 0:

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -25,7 +25,9 @@ class StartNodeStep(BaseStep):
     ):
         super().__init__(config, manager, resolver, auth_mode=auth_mode)
         self.workflow_config = workflow_config or {}
-        self.executor = executor  # Reference to executor for accessing node startup logic
+        self.executor = (
+            executor  # Reference to executor for accessing node startup logic
+        )
 
     def _get_required_fields(self) -> list[str]:
         """
@@ -55,23 +57,17 @@ class StartNodeStep(BaseStep):
         if "wait_for_ready" in self.config and not isinstance(
             self.config["wait_for_ready"], bool
         ):
-            raise ValueError(
-                f"Step '{step_name}': 'wait_for_ready' must be a boolean"
-            )
+            raise ValueError(f"Step '{step_name}': 'wait_for_ready' must be a boolean")
 
         # Validate wait_timeout is an integer if provided
         if "wait_timeout" in self.config and not isinstance(
             self.config["wait_timeout"], int
         ):
-            raise ValueError(
-                f"Step '{step_name}': 'wait_timeout' must be an integer"
-            )
+            raise ValueError(f"Step '{step_name}': 'wait_timeout' must be an integer")
 
         # Validate wait_timeout is positive if provided
         if "wait_timeout" in self.config and self.config["wait_timeout"] <= 0:
-            raise ValueError(
-                f"Step '{step_name}': 'wait_timeout' must be positive"
-            )
+            raise ValueError(f"Step '{step_name}': 'wait_timeout' must be positive")
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -97,7 +93,9 @@ class StartNodeStep(BaseStep):
         if isinstance(nodes_config, str):
             # Resolve dynamic values in node name
             node_names = [
-                self._resolve_dynamic_value(nodes_config, workflow_results, dynamic_values)
+                self._resolve_dynamic_value(
+                    nodes_config, workflow_results, dynamic_values
+                )
             ]
         else:
             # Resolve dynamic values in each node name

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -5,10 +5,15 @@ Start node step executor - Start nodes during workflow execution.
 import asyncio
 import socket
 import time
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, Optional
 
 from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.health import check_node_health
 from merobox.commands.utils import console
+
+# Coroutine that starts one node: (node_name, node_config, nodes_config) -> bool
+StartNodeFn = Callable[[str, Optional[dict], Optional[dict]], Awaitable[bool]]
 
 
 class StartNodeStep(BaseStep):
@@ -21,13 +26,14 @@ class StartNodeStep(BaseStep):
         resolver: object | None = None,
         auth_mode: str | None = None,
         workflow_config: dict[str, Any] | None = None,
-        executor: object | None = None,
+        start_node_fn: Optional[StartNodeFn] = None,
     ):
         super().__init__(config, manager, resolver, auth_mode=auth_mode)
         self.workflow_config = workflow_config or {}
-        self.executor = (
-            executor  # Reference to executor for accessing node startup logic
-        )
+        # Callable that actually starts a node (the executor's node-startup
+        # logic); kept as a plain callable so the step doesn't hold a back-
+        # reference to the whole executor.
+        self.start_node_fn = start_node_fn
 
     def _get_required_fields(self) -> list[str]:
         """
@@ -115,30 +121,27 @@ class StartNodeStep(BaseStep):
         failed_to_start = []
 
         for node_name in node_names:
-            # Try to get node-specific config (only for individually defined nodes)
+            # Node-specific config only exists for individually-defined nodes;
+            # for count-based nodes pass None and let the start fn resolve it.
             node_config = None
-            if isinstance(workflow_nodes_config, dict):
-                # Check if this is a node-specific config entry
-                if node_name in workflow_nodes_config:
-                    node_config = workflow_nodes_config[node_name]
-                # For count-based nodes, pass node_config=None and let _start_single_node handle it
+            if (
+                isinstance(workflow_nodes_config, dict)
+                and node_name in workflow_nodes_config
+            ):
+                node_config = workflow_nodes_config[node_name]
 
-            # Use executor's _start_single_node method if available
-            if self.executor and hasattr(self.executor, "_start_single_node"):
-                # Use executor's method which has access to all node config
-                success = await self.executor._start_single_node(
-                    node_name, node_config, workflow_nodes_config
-                )
-            else:
+            if self.start_node_fn is None:
                 console.print(
-                    f"[red]❌ Cannot start node {node_name}: executor not available[/red]"
+                    f"[red]❌ Cannot start node {node_name}: no node-start "
+                    "function available[/red]"
                 )
                 success = False
-
-            if success:
-                started_nodes.append(node_name)
             else:
-                failed_to_start.append(node_name)
+                success = await self.start_node_fn(
+                    node_name, node_config, workflow_nodes_config
+                )
+
+            (started_nodes if success else failed_to_start).append(node_name)
 
         if failed_to_start:
             console.print(
@@ -148,57 +151,72 @@ class StartNodeStep(BaseStep):
 
         console.print(f"[green]✓ Started {len(started_nodes)} node(s)[/green]")
 
-        # Wait for nodes to be ready (optional)
-        wait_for_ready = self.config.get("wait_for_ready", True)
-        if wait_for_ready:
-            wait_timeout = self.config.get("wait_timeout", 30)
-            console.print(
-                f"[cyan]Waiting up to {wait_timeout} seconds for nodes to be ready...[/cyan]"
+        # wait_for_ready defaults to True: a started node is expected to be
+        # serving requests before the workflow continues. Set it to false to
+        # return as soon as the node process/container has been launched.
+        if self.config.get("wait_for_ready", True):
+            await self._wait_for_ready(
+                started_nodes, self.config.get("wait_timeout", 30)
             )
-
-            # Resolve RPC ports up front; nodes whose port we can't determine
-            # can't be probed, so don't hold up the wait on them.
-            node_ports = {}
-            for node_name in started_nodes:
-                rpc_port = None
-                if hasattr(self.manager, "get_node_rpc_port"):
-                    rpc_port = self.manager.get_node_rpc_port(node_name)
-                elif hasattr(self.manager, "node_rpc_ports"):
-                    rpc_port = self.manager.node_rpc_ports.get(node_name)
-                if rpc_port:
-                    node_ports[node_name] = rpc_port
-
-            if not node_ports:
-                console.print(
-                    "[yellow]⚠ Could not determine RPC ports for the started "
-                    "node(s); skipping readiness check.[/yellow]"
-                )
-            else:
-                start_time = time.time()
-                all_ready = False
-
-                while time.time() - start_time < wait_timeout:
-                    ready_count = 0
-                    for rpc_port in node_ports.values():
-                        try:
-                            with socket.create_connection(
-                                ("127.0.0.1", rpc_port), timeout=1
-                            ):
-                                ready_count += 1
-                        except Exception:
-                            pass
-
-                    if ready_count == len(node_ports):
-                        all_ready = True
-                        break
-
-                    await asyncio.sleep(1)
-
-                if all_ready:
-                    console.print("[green]✓ All nodes are ready[/green]")
-                else:
-                    console.print(
-                        "[yellow]⚠ Some nodes may not be ready yet, continuing...[/yellow]"
-                    )
-
         return True
+
+    async def _wait_for_ready(self, node_names: list[str], timeout: int) -> None:
+        """Wait for each node to accept RPC connections and pass a health check.
+
+        Best-effort: nodes whose RPC port can't be resolved are skipped, and a
+        timeout logs a warning rather than failing the step (the node was
+        already launched successfully).
+        """
+        console.print(
+            f"[cyan]Waiting up to {timeout} seconds for nodes to be ready...[/cyan]"
+        )
+
+        node_ports: dict[str, int] = {}
+        for node_name in node_names:
+            rpc_port = None
+            if hasattr(self.manager, "get_node_rpc_port"):
+                rpc_port = self.manager.get_node_rpc_port(node_name)
+            elif hasattr(self.manager, "node_rpc_ports"):
+                rpc_port = self.manager.node_rpc_ports.get(node_name)
+            if rpc_port:
+                node_ports[node_name] = rpc_port
+
+        if not node_ports:
+            console.print(
+                "[yellow]⚠ Could not determine RPC ports for the started "
+                "node(s); skipping readiness check.[/yellow]"
+            )
+            return
+
+        deadline = time.monotonic() + timeout
+        pending = set(node_ports)
+        while pending and time.monotonic() < deadline:
+            for node_name in list(pending):
+                if await self._node_ready(node_name, node_ports[node_name]):
+                    pending.discard(node_name)
+                    console.print(f"[green]✓ Node {node_name} is ready[/green]")
+            if pending:
+                await asyncio.sleep(1)
+
+        if pending:
+            console.print(
+                "[yellow]⚠ Node(s) not confirmed ready: "
+                f"{', '.join(sorted(pending))}; continuing...[/yellow]"
+            )
+        else:
+            console.print("[green]✓ All nodes are ready[/green]")
+
+    async def _node_ready(self, node_name: str, rpc_port: int) -> bool:
+        """A node is ready once its RPC port accepts a connection *and* the
+        admin health endpoint responds (a bound port alone doesn't mean the
+        node is serving requests)."""
+        try:
+            with socket.create_connection(("127.0.0.1", rpc_port), timeout=1):
+                pass
+        except OSError:
+            return False
+        try:
+            result = await check_node_health(f"http://localhost:{rpc_port}")
+            return bool(result.get("success"))
+        except Exception:
+            return False

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -3,7 +3,7 @@ Start node step executor - Start nodes during workflow execution.
 """
 
 import asyncio
-import socket
+import contextlib
 import time
 from collections.abc import Awaitable, Callable
 from typing import Any, Optional
@@ -117,6 +117,14 @@ class StartNodeStep(BaseStep):
             f"[yellow]🚀 Starting {len(node_names)} node(s): {', '.join(node_names)}[/yellow]"
         )
 
+        # No node-start function -> nothing we can do; fail fast (it would be
+        # None for every node anyway).
+        if self.start_node_fn is None:
+            console.print(
+                "[red]❌ Cannot start nodes: no node-start function available[/red]"
+            )
+            return False
+
         # Get node configuration from workflow config
         workflow_nodes_config = self.workflow_config.get("nodes", {})
 
@@ -126,24 +134,14 @@ class StartNodeStep(BaseStep):
         for node_name in node_names:
             # Node-specific config only exists for individually-defined nodes;
             # for count-based nodes pass None and let the start fn resolve it.
-            node_config = None
-            if (
-                isinstance(workflow_nodes_config, dict)
-                and node_name in workflow_nodes_config
-            ):
-                node_config = workflow_nodes_config[node_name]
-
-            if self.start_node_fn is None:
-                console.print(
-                    f"[red]❌ Cannot start node {node_name}: no node-start "
-                    "function available[/red]"
-                )
-                success = False
-            else:
-                success = await self.start_node_fn(
-                    node_name, node_config, workflow_nodes_config
-                )
-
+            node_config = (
+                workflow_nodes_config.get(node_name)
+                if isinstance(workflow_nodes_config, dict)
+                else None
+            )
+            success = await self.start_node_fn(
+                node_name, node_config, workflow_nodes_config
+            )
             (started_nodes if success else failed_to_start).append(node_name)
 
         if failed_to_start:
@@ -154,21 +152,22 @@ class StartNodeStep(BaseStep):
 
         console.print(f"[green]✓ Started {len(started_nodes)} node(s)[/green]")
 
-        # wait_for_ready defaults to True: a started node is expected to be
-        # serving requests before the workflow continues. Set it to false to
-        # return as soon as the node process/container has been launched.
+        # wait_for_ready defaults to True: callers expect a started node to be
+        # serving requests before the workflow continues, so a readiness
+        # timeout fails the step. Set it to false to return as soon as the
+        # node process/container has been launched.
         if self.config.get("wait_for_ready", True):
-            await self._wait_for_ready(
+            return await self._wait_for_ready(
                 started_nodes, self.config.get("wait_timeout", 30)
             )
         return True
 
-    async def _wait_for_ready(self, node_names: list[str], timeout: int) -> None:
+    async def _wait_for_ready(self, node_names: list[str], timeout: int) -> bool:
         """Wait for each node to accept RPC connections and pass a health check.
 
-        Best-effort: nodes whose RPC port can't be resolved are skipped, and a
-        timeout logs a warning rather than failing the step (the node was
-        already launched successfully).
+        Returns True if every node became ready (or if no RPC port could be
+        resolved for any node, in which case the check is skipped). Returns
+        False if the deadline passed with nodes still not responding.
         """
         console.print(
             f"[cyan]Waiting up to {timeout} seconds for nodes to be ready...[/cyan]"
@@ -189,13 +188,13 @@ class StartNodeStep(BaseStep):
                 "[yellow]⚠ Could not determine RPC ports for the started "
                 "node(s); skipping readiness check.[/yellow]"
             )
-            return
+            return True
 
         deadline = time.monotonic() + timeout
         pending = set(node_ports)
         while pending and time.monotonic() < deadline:
             for node_name in list(pending):
-                if await self._node_ready(node_name, node_ports[node_name]):
+                if await self._node_ready(node_ports[node_name]):
                     pending.discard(node_name)
                     console.print(f"[green]✓ Node {node_name} is ready[/green]")
             if pending:
@@ -203,20 +202,25 @@ class StartNodeStep(BaseStep):
 
         if pending:
             console.print(
-                "[yellow]⚠ Node(s) not confirmed ready: "
-                f"{', '.join(sorted(pending))}; continuing...[/yellow]"
+                f"[red]❌ Node(s) not ready within {timeout}s: "
+                f"{', '.join(sorted(pending))}[/red]"
             )
-        else:
-            console.print("[green]✓ All nodes are ready[/green]")
+            return False
+        console.print("[green]✓ All nodes are ready[/green]")
+        return True
 
-    async def _node_ready(self, node_name: str, rpc_port: int) -> bool:
+    async def _node_ready(self, rpc_port: int) -> bool:
         """A node is ready once its RPC port accepts a connection *and* the
         admin health endpoint responds (a bound port alone doesn't mean the
         node is serving requests)."""
         try:
-            with socket.create_connection(("127.0.0.1", rpc_port), timeout=1):
-                pass
-        except OSError:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection("127.0.0.1", rpc_port), timeout=1
+            )
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+        except (OSError, asyncio.TimeoutError):
             return False
         try:
             result = await check_node_health(f"http://localhost:{rpc_port}")

--- a/merobox/commands/bootstrap/steps/start_node.py
+++ b/merobox/commands/bootstrap/steps/start_node.py
@@ -156,20 +156,30 @@ class StartNodeStep(BaseStep):
                 f"[cyan]Waiting up to {wait_timeout} seconds for nodes to be ready...[/cyan]"
             )
 
-            start_time = time.time()
-            all_ready = False
+            # Resolve RPC ports up front; nodes whose port we can't determine
+            # can't be probed, so don't hold up the wait on them.
+            node_ports = {}
+            for node_name in started_nodes:
+                rpc_port = None
+                if hasattr(self.manager, "get_node_rpc_port"):
+                    rpc_port = self.manager.get_node_rpc_port(node_name)
+                elif hasattr(self.manager, "node_rpc_ports"):
+                    rpc_port = self.manager.node_rpc_ports.get(node_name)
+                if rpc_port:
+                    node_ports[node_name] = rpc_port
 
-            while time.time() - start_time < wait_timeout:
-                ready_count = 0
-                for node_name in started_nodes:
-                    # Try to get RPC port from manager
-                    rpc_port = None
-                    if hasattr(self.manager, "get_node_rpc_port"):
-                        rpc_port = self.manager.get_node_rpc_port(node_name)
-                    elif hasattr(self.manager, "node_rpc_ports"):
-                        rpc_port = self.manager.node_rpc_ports.get(node_name)
+            if not node_ports:
+                console.print(
+                    "[yellow]⚠ Could not determine RPC ports for the started "
+                    "node(s); skipping readiness check.[/yellow]"
+                )
+            else:
+                start_time = time.time()
+                all_ready = False
 
-                    if rpc_port:
+                while time.time() - start_time < wait_timeout:
+                    ready_count = 0
+                    for rpc_port in node_ports.values():
                         try:
                             with socket.create_connection(
                                 ("127.0.0.1", rpc_port), timeout=1
@@ -178,17 +188,17 @@ class StartNodeStep(BaseStep):
                         except Exception:
                             pass
 
-                if ready_count == len(started_nodes):
-                    all_ready = True
-                    break
+                    if ready_count == len(node_ports):
+                        all_ready = True
+                        break
 
-                await asyncio.sleep(1)
+                    await asyncio.sleep(1)
 
-            if all_ready:
-                console.print("[green]✓ All nodes are ready[/green]")
-            else:
-                console.print(
-                    "[yellow]⚠ Some nodes may not be ready yet, continuing...[/yellow]"
-                )
+                if all_ready:
+                    console.print("[green]✓ All nodes are ready[/green]")
+                else:
+                    console.print(
+                        "[yellow]⚠ Some nodes may not be ready yet, continuing...[/yellow]"
+                    )
 
         return True

--- a/merobox/commands/bootstrap/steps/stop_node.py
+++ b/merobox/commands/bootstrap/steps/stop_node.py
@@ -1,0 +1,97 @@
+"""
+Stop node step executor - Stop nodes during workflow execution.
+"""
+
+from typing import Any
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import console
+
+
+class StopNodeStep(BaseStep):
+    """Stop nodes during workflow execution."""
+
+    def _get_required_fields(self) -> list[str]:
+        """
+        Define which fields are required for this step.
+
+        Returns:
+            List of required field names
+        """
+        return ["nodes"]  # At least one node must be specified
+
+    def _validate_field_types(self) -> None:
+        """
+        Validate that fields have the correct types.
+        """
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+
+        # Validate nodes is a list or string
+        nodes = self.config.get("nodes")
+        if not isinstance(nodes, (list, str)):
+            raise ValueError(
+                f"Step '{step_name}': 'nodes' must be a list of node names or a single node name string"
+            )
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        """
+        Execute the stop node step.
+
+        Args:
+            workflow_results: Results from previous workflow steps
+            dynamic_values: Dynamic values captured during workflow execution
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.manager:
+            console.print(
+                "[red]❌ Cannot stop nodes: no manager available (remote-only mode)[/red]"
+            )
+            return False
+
+        # Get node names (can be a single string or list)
+        nodes_config = self.config.get("nodes")
+        if isinstance(nodes_config, str):
+            # Resolve dynamic values in node name
+            node_names = [
+                self._resolve_dynamic_value(nodes_config, workflow_results, dynamic_values)
+            ]
+        else:
+            # Resolve dynamic values in each node name
+            node_names = [
+                self._resolve_dynamic_value(node, workflow_results, dynamic_values)
+                for node in nodes_config
+            ]
+
+        console.print(
+            f"[yellow]🛑 Stopping {len(node_names)} node(s): {', '.join(node_names)}[/yellow]"
+        )
+
+        stopped_nodes = []
+        failed_to_stop = []
+
+        for node_name in node_names:
+            if hasattr(self.manager, "stop_node"):
+                if self.manager.stop_node(node_name):
+                    stopped_nodes.append(node_name)
+                else:
+                    failed_to_stop.append(node_name)
+            else:
+                console.print(
+                    f"[yellow]⚠ Manager does not support stop_node for {node_name}[/yellow]"
+                )
+                failed_to_stop.append(node_name)
+
+        if failed_to_stop:
+            console.print(
+                f"[red]❌ Failed to stop nodes: {', '.join(failed_to_stop)}[/red]"
+            )
+            return False
+
+        console.print(f"[green]✓ Stopped {len(stopped_nodes)} node(s)[/green]")
+        return True

--- a/merobox/commands/bootstrap/steps/stop_node.py
+++ b/merobox/commands/bootstrap/steps/stop_node.py
@@ -4,8 +4,6 @@ Stop node step executor - Stop nodes during workflow execution.
 
 from typing import Any, Optional
 
-import docker
-
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.utils import console
 
@@ -24,23 +22,19 @@ class StopNodeStep(BaseStep):
         if not self.manager:
             return False
 
-        if hasattr(self.manager, "is_node_running"):
-            try:
-                return self.manager.is_node_running(node_name)
-            except docker.errors.APIError as e:
-                explanation = getattr(e, "explanation", str(e))
-                console.print(
-                    f"[red]❌ Failed to check node status for {node_name}: {explanation}[/red]"
-                )
-                return None
-            except docker.errors.DockerException as e:
-                explanation = getattr(e, "explanation", str(e))
-                console.print(
-                    f"[red]❌ Docker error while checking node status for {node_name}: {explanation}[/red]"
-                )
-                return None
+        if not hasattr(self.manager, "is_node_running"):
+            return None
 
-        return None
+        try:
+            return self.manager.is_node_running(node_name)
+        except Exception as e:
+            # Backend-specific failure (e.g. Docker API error) — treat the
+            # status as unknown rather than letting it abort the workflow.
+            explanation = getattr(e, "explanation", str(e))
+            console.print(
+                f"[red]❌ Failed to check node status for {node_name}: {explanation}[/red]"
+            )
+            return None
 
     def _get_required_fields(self) -> list[str]:
         """

--- a/merobox/commands/bootstrap/steps/stop_node.py
+++ b/merobox/commands/bootstrap/steps/stop_node.py
@@ -90,7 +90,9 @@ class StopNodeStep(BaseStep):
         if isinstance(nodes_config, str):
             # Resolve dynamic values in node name
             node_names = [
-                self._resolve_dynamic_value(nodes_config, workflow_results, dynamic_values)
+                self._resolve_dynamic_value(
+                    nodes_config, workflow_results, dynamic_values
+                )
             ]
         else:
             # Resolve dynamic values in each node name

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -283,15 +283,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
 
         # Create a temporary step instance to trigger validation
         # This will catch any validation errors without executing
-        # Note: start_node requires executor/workflow_config, so we skip validation for it
-        # It will be validated at runtime
         try:
-            if step_type == "start_node":
-                # start_node requires executor and workflow_config, skip validation here
-                # It will be validated at runtime when executor creates it
-                pass
-            else:
-                step_class(step)
+            step_class(step)
         except Exception as e:
             errors.append(f"Step '{step_name}' validation failed: {str(e)}")
 

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -66,6 +66,8 @@ from merobox.commands.bootstrap.steps.proposals import (
 )
 from merobox.commands.bootstrap.steps.repeat import RepeatStep
 from merobox.commands.bootstrap.steps.script import ScriptStep
+from merobox.commands.bootstrap.steps.start_node import StartNodeStep
+from merobox.commands.bootstrap.steps.stop_node import StopNodeStep
 from merobox.commands.bootstrap.steps.subgroup import (
     AddGroupMembersStep,
     ListSubgroupsStep,
@@ -271,14 +273,25 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = GetGroupUpgradeStatusStep
         elif step_type == "retry_group_upgrade":
             step_class = RetryGroupUpgradeStep
+        elif step_type == "stop_node":
+            step_class = StopNodeStep
+        elif step_type == "start_node":
+            step_class = StartNodeStep
         else:
             errors.append(f"Step '{step_name}' has unknown type: {step_type}")
             return errors
 
         # Create a temporary step instance to trigger validation
         # This will catch any validation errors without executing
+        # Note: start_node requires executor/workflow_config, so we skip validation for it
+        # It will be validated at runtime
         try:
-            step_class(step)
+            if step_type == "start_node":
+                # start_node requires executor and workflow_config, skip validation here
+                # It will be validated at runtime when executor creates it
+                pass
+            else:
+                step_class(step)
         except Exception as e:
             errors.append(f"Step '{step_name}' validation failed: {str(e)}")
 

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -1800,6 +1800,16 @@ class DockerManager(CleanupMixin):
             console.print(f"[red]✗ Failed to stop node {node_name}: {str(e)}[/red]")
             return False
 
+    def is_node_running(self, node_name: str) -> bool:
+        """Check if a node container exists and is running."""
+        try:
+            container = self.client.containers.get(node_name)
+            return container.status == "running"
+        except docker.errors.NotFound:
+            return False
+        except docker.errors.APIError:
+            raise
+
     def stop_all_nodes(
         self,
         drain_timeout: int = 5,

--- a/merobox/tests/unit/test_docker_manager.py
+++ b/merobox/tests/unit/test_docker_manager.py
@@ -1121,3 +1121,46 @@ def test_run_multiple_nodes_single_node_unchanged(mock_docker):
     manager._ensure_cluster_network.assert_not_called()
     manager._wire_cluster_bootstrap_peers.assert_not_called()
     manager.wait_for_cluster_peers.assert_not_called()
+
+
+# ============================================================================
+# is_node_running (PR #143 — stop_node/start_node steps)
+# ============================================================================
+
+
+@patch("docker.from_env")
+def test_is_node_running_returns_true_for_running_container(mock_docker):
+    client = MagicMock()
+    running_container = MagicMock()
+    running_container.status = "running"
+    client.containers.get.return_value = running_container
+    mock_docker.return_value = client
+
+    manager = DockerManager()
+
+    assert manager.is_node_running("node1") is True
+    client.containers.get.assert_called_once_with("node1")
+
+
+@patch("docker.from_env")
+def test_is_node_running_returns_false_when_container_missing(mock_docker):
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    mock_docker.return_value = client
+
+    manager = DockerManager()
+
+    assert manager.is_node_running("node1") is False
+    client.containers.get.assert_called_once_with("node1")
+
+
+@patch("docker.from_env")
+def test_is_node_running_raises_api_error(mock_docker):
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.APIError("denied")
+    mock_docker.return_value = client
+
+    manager = DockerManager()
+
+    with pytest.raises(docker.errors.APIError):
+        manager.is_node_running("node1")

--- a/merobox/tests/unit/test_start_node_step.py
+++ b/merobox/tests/unit/test_start_node_step.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 from merobox.commands.bootstrap.steps.start_node import StartNodeStep
 
 
-def _make_step(config_extra=None, *, manager=None, executor=None, workflow_config=None):
+def _make_step(
+    config_extra=None, *, manager=None, start_node_fn=None, workflow_config=None
+):
     config = {"type": "start_node", "nodes": ["node-1"], "wait_for_ready": False}
     if config_extra:
         config.update(config_extra)
@@ -12,42 +14,39 @@ def _make_step(config_extra=None, *, manager=None, executor=None, workflow_confi
         config,
         manager=manager if manager is not None else MagicMock(),
         workflow_config=workflow_config or {"nodes": {"count": 1}},
-        executor=executor,
+        start_node_fn=start_node_fn,
     )
 
 
-def test_start_node_step_starts_nodes_via_executor():
-    executor = MagicMock()
-    executor._start_single_node = AsyncMock(return_value=True)
-    step = _make_step({"nodes": ["node-1", "node-2"]}, executor=executor)
+def test_start_node_step_starts_nodes_via_callable():
+    start_fn = AsyncMock(return_value=True)
+    step = _make_step({"nodes": ["node-1", "node-2"]}, start_node_fn=start_fn)
 
     assert asyncio.run(step.execute({}, {})) is True
-    assert executor._start_single_node.await_count == 2
+    assert start_fn.await_count == 2
 
 
-def test_start_node_step_fails_without_executor():
-    step = _make_step(executor=None)
+def test_start_node_step_fails_without_start_fn():
+    step = _make_step(start_node_fn=None)
 
     assert asyncio.run(step.execute({}, {})) is False
 
 
 def test_start_node_step_fails_when_a_node_does_not_start():
-    executor = MagicMock()
-    executor._start_single_node = AsyncMock(side_effect=[True, False])
-    step = _make_step({"nodes": ["node-1", "node-2"]}, executor=executor)
+    start_fn = AsyncMock(side_effect=[True, False])
+    step = _make_step({"nodes": ["node-1", "node-2"]}, start_node_fn=start_fn)
 
     assert asyncio.run(step.execute({}, {})) is False
 
 
 def test_start_node_step_skips_readiness_check_when_ports_unknown():
-    executor = MagicMock()
-    executor._start_single_node = AsyncMock(return_value=True)
+    start_fn = AsyncMock(return_value=True)
     # Manager exposes neither get_node_rpc_port nor node_rpc_ports.
     manager = MagicMock(spec=[])
     step = _make_step(
         {"wait_for_ready": True, "wait_timeout": 1},
         manager=manager,
-        executor=executor,
+        start_node_fn=start_fn,
     )
 
     assert asyncio.run(step.execute({}, {})) is True

--- a/merobox/tests/unit/test_start_node_step.py
+++ b/merobox/tests/unit/test_start_node_step.py
@@ -1,0 +1,53 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from merobox.commands.bootstrap.steps.start_node import StartNodeStep
+
+
+def _make_step(config_extra=None, *, manager=None, executor=None, workflow_config=None):
+    config = {"type": "start_node", "nodes": ["node-1"], "wait_for_ready": False}
+    if config_extra:
+        config.update(config_extra)
+    return StartNodeStep(
+        config,
+        manager=manager if manager is not None else MagicMock(),
+        workflow_config=workflow_config or {"nodes": {"count": 1}},
+        executor=executor,
+    )
+
+
+def test_start_node_step_starts_nodes_via_executor():
+    executor = MagicMock()
+    executor._start_single_node = AsyncMock(return_value=True)
+    step = _make_step({"nodes": ["node-1", "node-2"]}, executor=executor)
+
+    assert asyncio.run(step.execute({}, {})) is True
+    assert executor._start_single_node.await_count == 2
+
+
+def test_start_node_step_fails_without_executor():
+    step = _make_step(executor=None)
+
+    assert asyncio.run(step.execute({}, {})) is False
+
+
+def test_start_node_step_fails_when_a_node_does_not_start():
+    executor = MagicMock()
+    executor._start_single_node = AsyncMock(side_effect=[True, False])
+    step = _make_step({"nodes": ["node-1", "node-2"]}, executor=executor)
+
+    assert asyncio.run(step.execute({}, {})) is False
+
+
+def test_start_node_step_skips_readiness_check_when_ports_unknown():
+    executor = MagicMock()
+    executor._start_single_node = AsyncMock(return_value=True)
+    # Manager exposes neither get_node_rpc_port nor node_rpc_ports.
+    manager = MagicMock(spec=[])
+    step = _make_step(
+        {"wait_for_ready": True, "wait_timeout": 1},
+        manager=manager,
+        executor=executor,
+    )
+
+    assert asyncio.run(step.execute({}, {})) is True

--- a/merobox/tests/unit/test_stop_node_step.py
+++ b/merobox/tests/unit/test_stop_node_step.py
@@ -1,0 +1,44 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import docker
+
+from merobox.commands.bootstrap.steps.stop_node import StopNodeStep
+
+
+def test_stop_node_step_treats_confirmed_stopped_node_as_success():
+    manager = MagicMock()
+    manager.stop_node.return_value = False
+    manager.is_node_running.return_value = False
+
+    step = StopNodeStep({"type": "stop_node", "nodes": ["node-1"]}, manager=manager)
+    result = asyncio.run(step.execute({}, {}))
+
+    assert result is True
+    manager.stop_node.assert_called_once_with("node-1")
+    manager.is_node_running.assert_called_once_with("node-1")
+
+
+def test_stop_node_step_fails_when_status_check_is_unknown():
+    manager = MagicMock()
+    manager.stop_node.return_value = False
+    manager.is_node_running.side_effect = docker.errors.APIError("permission denied")
+
+    step = StopNodeStep({"type": "stop_node", "nodes": ["node-1"]}, manager=manager)
+    result = asyncio.run(step.execute({}, {}))
+
+    assert result is False
+    manager.stop_node.assert_called_once_with("node-1")
+    manager.is_node_running.assert_called_once_with("node-1")
+
+
+def test_stop_node_step_does_not_check_status_after_successful_stop():
+    manager = MagicMock()
+    manager.stop_node.return_value = True
+
+    step = StopNodeStep({"type": "stop_node", "nodes": ["node-1"]}, manager=manager)
+    result = asyncio.run(step.execute({}, {}))
+
+    assert result is True
+    manager.stop_node.assert_called_once_with("node-1")
+    manager.is_node_running.assert_not_called()

--- a/workflow-examples/workflow-stop-start-nodes.yml
+++ b/workflow-examples/workflow-stop-start-nodes.yml
@@ -1,0 +1,50 @@
+description: Test stop_node and start_node steps
+name: Test Stop/Start Nodes
+
+nodes:
+  count: 2
+  prefix: test-node
+  chain_id: testnet-1
+  image: ghcr.io/calimero-network/merod:edge
+
+steps:
+  - name: Install Application
+    type: install_application
+    node: test-node-1
+    path: workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Context
+    type: create_context
+    node: test-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      context_id: contextId
+
+  - name: Stop Node 1
+    type: stop_node
+    nodes: test-node-1
+
+  - name: Wait After Stop
+    type: wait
+    seconds: 3
+
+  - name: Start Node 1 Again
+    type: start_node
+    nodes: test-node-1
+    wait_for_ready: true
+    wait_timeout: 30
+
+  - name: Verify Node 1 is Running
+    type: call
+    node: test-node-1
+    context_id: "{{context_id}}"
+    executor_public_key: "test"
+    method: get
+    args:
+      key: test
+
+stop_all_nodes: true
+restart: false

--- a/workflow-examples/workflow-stop-start-nodes.yml
+++ b/workflow-examples/workflow-stop-start-nodes.yml
@@ -16,12 +16,21 @@ steps:
     outputs:
       app_id: applicationId
 
+  - name: Create Namespace
+    type: create_namespace
+    node: test-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      namespace_id: namespaceId
+
   - name: Create Context
     type: create_context
     node: test-node-1
     application_id: "{{app_id}}"
+    group_id: "{{namespace_id}}"
     outputs:
       context_id: contextId
+      member_public_key: memberPublicKey
 
   - name: Stop Node 1
     type: stop_node
@@ -41,7 +50,7 @@ steps:
     type: call
     node: test-node-1
     context_id: "{{context_id}}"
-    executor_public_key: "test"
+    executor_public_key: "{{member_public_key}}"
     method: get
     args:
       key: test


### PR DESCRIPTION
## Feature Request: Add --merod-args flag and stop_node/start_node steps

### Goal
1. Add a `--merod-args` CLI flag to merobox bootstrap run that passes arbitrary arguments to merod run when using `--no-docker` mode.
2. Add `stop_node` and `start_node` workflow steps for full control over node lifecycle during workflow execution.

### Changes

#### 1. --merod-args CLI Flag
- ✅ Added `--merod-args` CLI option to `bootstrap run` command
- ✅ Only applies in `--no-docker` mode (binary execution)
- ✅ Warns and ignores if used without `--no-docker`
- ✅ Uses `shlex.split()` for safe argument parsing
- ✅ Passes args after existing merod run command arguments

#### 2. stop_node and start_node Steps
- ✅ Added `stop_node` step to stop nodes during workflow execution
- ✅ Added `start_node` step to start nodes during workflow execution
- ✅ Both steps support single node or multiple nodes
- ✅ `start_node` includes optional readiness check with configurable timeout
- ✅ Steps use full node configuration from workflow (ports, chain_id, etc.)
- ✅ Added helper method `_start_single_node` in executor for node startup
- ✅ Updated validator to recognize new step types
- ✅ Added comprehensive documentation in README.md
- ✅ Added example workflow demonstrating stop/start functionality

### Usage Examples

#### --merod-args Flag
```bash
merobox bootstrap run --no-docker --binary-path ./merod \
  --merod-args="--sync-strategy delta --state-sync-strategy hash" \
  workflow.yml
```

#### stop_node Step
```yaml
- name: "Stop Node for Benchmark"
  type: "stop_node"
  nodes: calimero-node-1
```

#### start_node Step
```yaml
- name: "Start Node After Benchmark"
  type: "start_node"
  nodes: calimero-node-1
  wait_for_ready: true
  wait_timeout: 30
```

### Implementation Details

#### --merod-args
- CLI definition: `merobox/commands/bootstrap/bootstrap.py`
- Parameter propagation: `merobox/commands/bootstrap/run/run.py`
- WorkflowExecutor: `merobox/commands/bootstrap/run/executor.py`
- BinaryManager: `merobox/commands/binary_manager.py`

#### stop_node/start_node Steps
- Step implementations: `merobox/commands/bootstrap/steps/stop_node.py`, `start_node.py`
- Executor integration: `merobox/commands/bootstrap/run/executor.py`
- Validator: `merobox/commands/bootstrap/validate/validator.py`
- Example workflow: `workflow-examples/workflow-stop-start-nodes.yml`

### Use Cases

#### --merod-args
- Configure sync strategies
- Set state sync options
- Pass multiple merod configuration options

#### stop_node/start_node
- **Benchmarking**: Stop nodes to measure performance without them
- **Recovery Testing**: Test how workflows handle node failures
- **Resource Management**: Temporarily free up resources during long workflows
- **Dynamic Node Management**: Control node lifecycle mid-workflow

### Edge Cases Handled

#### --merod-args
- `--merod-args` without `--no-docker` → Log warning, ignore
- Empty string `--merod-args=""` → No-op
- Invalid args → Let merod fail with its own error message

#### stop_node/start_node
- Remote nodes → Steps only work with local nodes (Docker or binary mode)
- Node not running → `stop_node` handles gracefully
- Node already running → `start_node` handles gracefully
- Configuration → Nodes started with full workflow configuration

### Testing

#### --merod-args
```bash
# Test 1: Single arg
merobox bootstrap run --no-docker --binary-path ./merod \
  --merod-args="--sync-strategy delta" workflow.yml

# Test 2: Multiple args
merobox bootstrap run --no-docker --binary-path ./merod \
  --merod-args="--sync-strategy snapshot --state-sync-strategy hash" workflow.yml

# Test 3: Ignored in docker mode (should warn)
merobox bootstrap run --merod-args="--sync-strategy delta" workflow.yml
```

#### stop_node/start_node
```bash
# Validate workflow
merobox bootstrap validate workflow-examples/workflow-stop-start-nodes.yml

# Run test workflow
merobox bootstrap run workflow-examples/workflow-stop-start-nodes.yml
```

### Documentation
- ✅ Updated README.md with comprehensive documentation
- ✅ Added step type documentation with examples
- ✅ Added CLI flag documentation
- ✅ Added example workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new workflow step types that can stop/start local nodes and changes node startup argument plumbing, which could affect workflow execution and node lifecycle behavior. Risk is mitigated by being mostly additive with unit tests, but touches core executor/manager paths.
> 
> **Overview**
> Adds a new `--merod-args` option to `merobox bootstrap run` that (in `--no-docker` mode) forwards arbitrary extra CLI flags to `merod run` via `BinaryManager` using `shlex.split`, and warns/ignores the flag in Docker mode.
> 
> Extends the workflow engine with `stop_node` and `start_node` step types, including executor support for starting a single node idempotently and an optional readiness wait (port connect + health check). Updates validation/config to recognize the new steps, adds DockerManager `is_node_running` to support idempotent stop behavior, and includes unit tests plus an example workflow demonstrating stop/start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04569b02f74c3719008648c0d2b9d328be631a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->