### PR TITLE
fix: replace git URL dependency with PyPI version for calimero-client-py

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "docker>=6.0.0",
     "rich>=13.0.0",
     "PyYAML>=6.0.0",
-    "calimero-client-py @ git+https://github.com/calimero-network/calimero-client-py.git@master",
+    "calimero-client-py>=0.4.0",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",


### PR DESCRIPTION
## Summary

- Replaced `calimero-client-py @ git+https://...@master` with `calimero-client-py>=0.4.0` (already published on PyPI)
- Bumped `merobox` version from `0.4.0` → `0.4.1` to allow re-upload (PyPI rejects re-uploads of the same version)

## Root Cause

PyPI's upload API rejects packages that declare direct URL dependencies (PEP 508 `@` git URLs). All dependencies must be resolvable via PyPI alone.

## Test plan

- [ ] Run `python -m build` locally and verify the wheel builds cleanly
- [ ] Run `twine check dist/*` to validate metadata before uploading
- [ ] Upload to TestPyPI first: `twine upload --repository testpypi dist/merobox-0.4.1-*`
- [ ] Publish to PyPI: `twine upload dist/merobox-0.4.1-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging-only change: swaps a git URL dependency for a pinned PyPI release and bumps the package version; no runtime logic changes beyond the resolved dependency version.
> 
> **Overview**
> Updates packaging metadata to replace the direct git dependency `calimero-client-py @ git+...@master` with the PyPI requirement `calimero-client-py>=0.4.0`.
> 
> Bumps `merobox` version from `0.4.0` to `0.4.1` to publish the updated dependency metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f5af09203e9f22cad43f6118fffb243438ed37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->