### PR TITLE
fix: resolve dynamic placeholders in create_context params

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/context.py
+++ b/merobox/commands/bootstrap/steps/context.py
@@ -105,7 +105,11 @@ class CreateContextStep(BaseStep):
             try:
                 import json
 
-                params_json = self.config["params"]
+                raw_params = self.config["params"]
+                # Resolve dynamic placeholders in params before JSON validation
+                params_json = self._resolve_dynamic_value(
+                    raw_params, workflow_results, dynamic_values
+                )
                 # Validate JSON
                 json.loads(params_json)
                 console.print("[blue]Using initialization params JSON[/blue]")


### PR DESCRIPTION
## Summary
- Fix `create_context` step to resolve `{{placeholder}}` variables in the `params` field before passing to the WASM init
- Previously, raw placeholder strings like `{{p1_key}}` were sent as literal values to the contract init, causing silent failures when init params referenced dynamic variables
- Bump version to 0.4.2

## Root Cause
`CreateContextStep.execute()` in `context.py` read `self.config["params"]` directly without calling `_resolve_dynamic_value()`, unlike `group_id`, `application_id`, and `service_name` which were properly resolved.

## Test plan
- [x] Verified with battleships e2e workflow that passes init params with `{{p1_key}}`, `{{p2_key}}`, `{{lobby_ctx_id}}` placeholders
- [x] Full workflow passes: namespace creation → lobby → match with init params → ship placement → shooting → verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to resolve placeholders in `params` before JSON parsing plus a version bump; main risk is behavior change for workflows that relied on literal `{{...}}` strings in init params.
> 
> **Overview**
> Fixes the `create_context` bootstrap step to resolve dynamic `{{placeholder}}` values inside the `params` JSON string before validating/parsing and sending it to the client, preventing unresolved placeholders from being passed through.
> 
> Bumps the package version from `0.4.1` to `0.4.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3ccb5288ff8dfd7caa7d28c114a37d82e519a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->