### PR TITLE
chore: release 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-04-13
+
+### Added
+- New `add_group_members` workflow step for adding members to a subgroup.
+- `create_group_in_namespace` step now exports its `group_id` for downstream steps.
+- `workflow-subgroups-example.yml` demonstrating the full subgroup flow
+  (create namespace → create subgroup → add members → create context in subgroup).
+
+### Changed
+- Docker CI now runs the groups and subgroups example workflows
+  (previously skipped because the edge image lagged behind core master;
+  fixes from core PR #2127 are now in edge).
+
+### Fixed
+- `add_group_members` step is now wired into the main executor dispatch.
+- Pin `rich<14.3.4` to avoid lazy-import breakage on Linux.
+- Install `merobox` in dev mode for the `test-unit` CI job.
+
 ### Breaking
 - **NEAR blockchain removed**: All NEAR Sandbox, relayer, and blockchain functionality has been removed. Context management is now fully local (P2P gossip).
 - **`--enable-relayer` / `--no-enable-relayer` CLI flags**: Removed.

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
## Summary

Bumps merobox to **0.4.4**.

The release pipeline auto-tags from `merobox/__init__.py` on merge to master.

## Changes since 0.4.3

### Added
- `add_group_members` workflow step for adding members to a subgroup.
- `create_group_in_namespace` step now exports its `group_id` for downstream steps.
- `workflow-subgroups-example.yml` demonstrating the full subgroup flow.

### Changed
- Docker CI now runs the groups and subgroups example workflows (re-enabled now that core PR #2127 is in the edge image).

### Fixed
- `add_group_members` wired into the main executor dispatch.
- Pin `rich<14.3.4` to avoid lazy-import breakage on Linux.
- Install merobox in dev mode for the `test-unit` CI job.

## Test plan
- [ ] CI passes (format, unit, binary workflows, Docker workflows including groups + subgroups)
- [ ] On merge, release pipeline auto-creates `v0.4.4` tag and publishes to PyPI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only change that updates metadata and documentation; no functional code paths are modified in this PR.
> 
> **Overview**
> Bumps `merobox` version from `0.4.3` to `0.4.4` and adds a `0.4.4` entry to `CHANGELOG.md` documenting new subgroup workflow steps/examples, CI workflow re-enablement, and a few dependency/CI fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287ffcb740305d58aeb4e89e27bac113f8681ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->