### PR TITLE
feat: add group management workflow step types

### DIFF
--- a/architecture/workflow-yaml.html
+++ b/architecture/workflow-yaml.html
@@ -24,7 +24,7 @@
 <div class="g4" style="margin-bottom:36px;">
   <div class="stat"><div class="v">YAML</div><div class="l">format</div></div>
   <div class="stat"><div class="v">{{}}</div><div class="l">dynamic vars</div></div>
-  <div class="stat"><div class="v">16</div><div class="l">step types</div></div>
+  <div class="stat"><div class="v">36</div><div class="l">step types</div></div>
   <div class="stat"><div class="v">2</div><div class="l">node modes</div></div>
 </div>
 
@@ -757,6 +757,398 @@
     </div>
   </div>
 </details>
+
+<!-- ── Namespace & Group Steps ── -->
+<h3 style="margin-top:32px;margin-bottom:12px;color:var(--accent);">Namespace &amp; Group Steps</h3>
+
+<!-- ── create_namespace ── -->
+<details>
+  <summary>create_namespace</summary>
+  <div class="detail-body">
+    <p>Creates a new namespace (root group) with an application binding. A namespace is the top-level governance unit that contains groups, contexts, and members.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">create_namespace</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">application_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">namespaceId</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Created namespace (root group) ID</span>
+    </div>
+    <h4>Example</h4>
+    <div class="typedef">
+- <span class="field">name</span>: <span class="ty">Create namespace</span><br>
+&nbsp;&nbsp;<span class="field">type</span>: <span class="ty">create_namespace</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">e2e-node-1</span><br>
+&nbsp;&nbsp;<span class="field">application_id</span>: <span class="ty">'{{app_id}}'</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">namespaceId</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── create_namespace_invitation ── -->
+<details>
+  <summary>create_namespace_invitation</summary>
+  <div class="detail-body">
+    <p>Creates an invitation for another node to join a namespace. The invitation payload is used in a subsequent <span class="code">join_namespace</span> step.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">create_namespace_invitation</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">invitation</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Invitation payload (JSON)</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── join_namespace ── -->
+<details>
+  <summary>join_namespace</summary>
+  <div class="detail-body">
+    <p>Joins a namespace using an invitation from <span class="code">create_namespace_invitation</span>.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">join_namespace</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">invitation</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">memberIdentity</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;<span class="comment"># Joined member's public key</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── join_context ── -->
+<details>
+  <summary>join_context</summary>
+  <div class="detail-body">
+    <p>Joins an existing context. The node must already be a member of the namespace/group that owns the context.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">join_context</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">context_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">memberPublicKey</span>: <span class="ty">string</span>&nbsp;&nbsp;<span class="comment"># Member's context public key</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── list_namespaces ── -->
+<details>
+  <summary>list_namespaces</summary>
+  <div class="detail-body">
+    <p>Lists all namespaces known to a node.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">list_namespaces</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">namespaces</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># List of namespace objects</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── get_namespace_identity ── -->
+<details>
+  <summary>get_namespace_identity</summary>
+  <div class="detail-body">
+    <p>Gets the node's signing identity for a namespace.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">get_namespace_identity</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">publicKey</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Namespace signing public key</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── create_group_in_namespace ── -->
+<details>
+  <summary>create_group_in_namespace</summary>
+  <div class="detail-body">
+    <p>Creates a subgroup inside a namespace. The subgroup inherits the namespace's application binding.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">create_group_in_namespace</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_alias</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Optional display name</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">groupId</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Created subgroup ID</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── list_subgroups ── -->
+<details>
+  <summary>list_subgroups</summary>
+  <div class="detail-body">
+    <p>Lists child groups (subgroups) of a parent group.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">list_subgroups</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">subgroups</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Array of {groupId, alias} objects</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── list_namespace_groups ── -->
+<details>
+  <summary>list_namespace_groups</summary>
+  <div class="detail-body">
+    <p>Lists all groups in a namespace (root + subgroups).</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">list_namespace_groups</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">groups</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Array of group objects</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── nest_group / unnest_group ── -->
+<details>
+  <summary>nest_group / unnest_group</summary>
+  <div class="detail-body">
+    <p>Manually nest or unnest a group under a parent. Typically <span class="code">create_group_in_namespace</span> handles nesting automatically.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">nest_group</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># or unnest_group</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">parent_group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">child_group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<h3 style="margin-top:32px;margin-bottom:12px;color:var(--accent);">Group Membership Steps</h3>
+
+<!-- ── add_group_members ── -->
+<details>
+  <summary>add_group_members</summary>
+  <div class="detail-body">
+    <p>Adds members to a group. Each member entry is an object with an <span class="code">identity</span> field (public key) and an optional <span class="code">role</span>.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">add_group_members</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">members</span>: <span class="ty">list[object]</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># [{identity, role?}, ...]</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+    <h4>Example</h4>
+    <div class="typedef">
+- <span class="field">name</span>: <span class="ty">Add node-2 to group</span><br>
+&nbsp;&nbsp;<span class="field">type</span>: <span class="ty">add_group_members</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">e2e-node-1</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">'{{namespace_id}}'</span><br>
+&nbsp;&nbsp;<span class="field">members</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- <span class="field">identity</span>: <span class="ty">'{{member_identity_node2}}'</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">role</span>: <span class="ty">Member</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── remove_group_members ── -->
+<details>
+  <summary>remove_group_members</summary>
+  <div class="detail-body">
+    <p>Removes members from a group by their public key identities.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">remove_group_members</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">members</span>: <span class="ty">list[string]</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Public key identities to remove</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+    <h4>Example</h4>
+    <div class="typedef">
+- <span class="field">name</span>: <span class="ty">Remove node-2 from group</span><br>
+&nbsp;&nbsp;<span class="field">type</span>: <span class="ty">remove_group_members</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">e2e-node-1</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">'{{namespace_id}}'</span><br>
+&nbsp;&nbsp;<span class="field">members</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- <span class="ty">'{{member_identity_node2}}'</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── list_group_members ── -->
+<details>
+  <summary>list_group_members</summary>
+  <div class="detail-body">
+    <p>Lists all members of a group with their roles.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">list_group_members</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">members</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Array of {identity, role} objects</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── update_member_role ── -->
+<details>
+  <summary>update_member_role</summary>
+  <div class="detail-body">
+    <p>Changes a member's role in a group. Valid roles: <span class="code">Admin</span>, <span class="code">Member</span>.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">update_member_role</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">member_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Member's public key</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">role</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Admin | Member</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<h3 style="margin-top:32px;margin-bottom:12px;color:var(--accent);">Capabilities &amp; Permissions Steps</h3>
+
+<!-- ── set_member_capabilities ── -->
+<details>
+  <summary>set_member_capabilities</summary>
+  <div class="detail-body">
+    <p>Sets capability flags for a specific member. Capabilities are a bitmask: bit 0 = CAN_CREATE_CONTEXT, bit 1 = CAN_INVITE_MEMBERS, bit 2 = CAN_JOIN_OPEN_CONTEXTS.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">set_member_capabilities</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">member_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">capabilities</span>: <span class="ty">integer</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Bitmask (e.g. 7 = all capabilities)</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── get_member_capabilities ── -->
+<details>
+  <summary>get_member_capabilities</summary>
+  <div class="detail-body">
+    <p>Queries a member's current capability flags.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">get_member_capabilities</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">member_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">capabilities</span>: <span class="ty">integer</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Current capability bitmask</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── set_default_capabilities ── -->
+<details>
+  <summary>set_default_capabilities</summary>
+  <div class="detail-body">
+    <p>Sets the default capability flags assigned to new members when they join the group.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">set_default_capabilities</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">capabilities</span>: <span class="ty">integer</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Default bitmask for new members</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── set_default_visibility ── -->
+<details>
+  <summary>set_default_visibility</summary>
+  <div class="detail-body">
+    <p>Sets the default context visibility mode for a group.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">set_default_visibility</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">visibility</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Visibility mode</span>&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<h3 style="margin-top:32px;margin-bottom:12px;color:var(--accent);">Group Info &amp; Query Steps</h3>
+
+<!-- ── get_group_info ── -->
+<details>
+  <summary>get_group_info</summary>
+  <div class="detail-body">
+    <p>Gets detailed information about a group including member count, context count, application ID, and upgrade status.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">get_group_info</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">data.groupId</span>: <span class="ty">string</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">data.memberCount</span>: <span class="ty">integer</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">data.contextCount</span>: <span class="ty">integer</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">data.targetApplicationId</span>: <span class="ty">string</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── list_group_contexts ── -->
+<details>
+  <summary>list_group_contexts</summary>
+  <div class="detail-body">
+    <p>Lists all contexts that belong to a group.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">list_group_contexts</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">outputs</span>:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">contexts</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Array of {contextId, alias} objects</span>
+    </div>
+  </div>
+</details>
+
+<h3 style="margin-top:32px;margin-bottom:12px;color:var(--accent);">Lifecycle &amp; Cleanup Steps</h3>
+
+<!-- ── delete_group ── -->
+<details>
+  <summary>delete_group</summary>
+  <div class="detail-body">
+    <p>Deletes a group and all its associated data.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">delete_group</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">group_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── delete_namespace ── -->
+<details>
+  <summary>delete_namespace</summary>
+  <div class="detail-body">
+    <p>Deletes a namespace and all its groups.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">delete_namespace</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">namespace_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── delete_context ── -->
+<details>
+  <summary>delete_context</summary>
+  <div class="detail-body">
+    <p>Deletes a context.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">delete_context</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">context_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
+<!-- ── uninstall_application ── -->
+<details>
+  <summary>uninstall_application</summary>
+  <div class="detail-body">
+    <p>Uninstalls an application from a node.</p>
+    <div class="typedef">
+- <span class="field">type</span>: <span class="ty">uninstall_application</span><br>
+&nbsp;&nbsp;<span class="field">node</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span><br>
+&nbsp;&nbsp;<span class="field">application_id</span>: <span class="ty">string</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="tag tag-gap">required</span>
+    </div>
+  </div>
+</details>
+
 </div>
 
 <!-- ─────────────────────────────────────────────── -->

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -26,21 +26,34 @@ from merobox.commands.bootstrap.steps import (
     CreateIdentityStep,
     CreateNamespaceInvitationStep,
     CreateNamespaceStep,
+    DeleteContextStep,
+    DeleteGroupStep,
+    DeleteNamespaceStep,
     ExecuteStep,
+    GetGroupInfoStep,
+    GetMemberCapabilitiesStep,
     GetNamespaceIdentityStep,
     InstallApplicationStep,
     InviteOpenStep,
     JoinContextStep,
     JoinNamespaceStep,
     JoinOpenStep,
+    ListGroupContextsStep,
+    ListGroupMembersStep,
     ListNamespaceGroupsStep,
     ListNamespacesStep,
     ListSubgroupsStep,
     NestGroupStep,
     ParallelStep,
+    RemoveGroupMembersStep,
     RepeatStep,
     ScriptStep,
+    SetDefaultCapabilitiesStep,
+    SetDefaultVisibilityStep,
+    SetMemberCapabilitiesStep,
+    UninstallApplicationStep,
     UnnestGroupStep,
+    UpdateMemberRoleStep,
     UploadBlobStep,
     WaitForSyncStep,
     WaitStep,
@@ -1422,6 +1435,32 @@ class WorkflowExecutor:
             return ListSubgroupsStep(step_config, **common_kwargs)
         elif step_type == "add_group_members":
             return AddGroupMembersStep(step_config, **common_kwargs)
+        elif step_type == "remove_group_members":
+            return RemoveGroupMembersStep(step_config, **common_kwargs)
+        elif step_type == "list_group_members":
+            return ListGroupMembersStep(step_config, **common_kwargs)
+        elif step_type == "update_member_role":
+            return UpdateMemberRoleStep(step_config, **common_kwargs)
+        elif step_type == "set_member_capabilities":
+            return SetMemberCapabilitiesStep(step_config, **common_kwargs)
+        elif step_type == "get_member_capabilities":
+            return GetMemberCapabilitiesStep(step_config, **common_kwargs)
+        elif step_type == "set_default_capabilities":
+            return SetDefaultCapabilitiesStep(step_config, **common_kwargs)
+        elif step_type == "set_default_visibility":
+            return SetDefaultVisibilityStep(step_config, **common_kwargs)
+        elif step_type == "get_group_info":
+            return GetGroupInfoStep(step_config, **common_kwargs)
+        elif step_type == "list_group_contexts":
+            return ListGroupContextsStep(step_config, **common_kwargs)
+        elif step_type == "delete_group":
+            return DeleteGroupStep(step_config, **common_kwargs)
+        elif step_type == "delete_namespace":
+            return DeleteNamespaceStep(step_config, **common_kwargs)
+        elif step_type == "delete_context":
+            return DeleteContextStep(step_config, **common_kwargs)
+        elif step_type == "uninstall_application":
+            return UninstallApplicationStep(step_config, **common_kwargs)
         elif step_type == "join_context":
             return JoinContextStep(step_config, **common_kwargs)
         else:

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -8,6 +8,21 @@ from merobox.commands.bootstrap.steps.blob import UploadBlobStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
+from merobox.commands.bootstrap.steps.group_management import (
+    DeleteContextStep,
+    DeleteGroupStep,
+    DeleteNamespaceStep,
+    GetGroupInfoStep,
+    GetMemberCapabilitiesStep,
+    ListGroupContextsStep,
+    ListGroupMembersStep,
+    RemoveGroupMembersStep,
+    SetDefaultCapabilitiesStep,
+    SetDefaultVisibilityStep,
+    SetMemberCapabilitiesStep,
+    UninstallApplicationStep,
+    UpdateMemberRoleStep,
+)
 from merobox.commands.bootstrap.steps.group_create import (
     CreateGroupStep,
     CreateNamespaceStep,
@@ -87,4 +102,17 @@ __all__ = [
     "UploadBlobStep",
     "CreateMeshStep",
     "FuzzyTestStep",
+    "RemoveGroupMembersStep",
+    "ListGroupMembersStep",
+    "UpdateMemberRoleStep",
+    "SetMemberCapabilitiesStep",
+    "GetMemberCapabilitiesStep",
+    "SetDefaultCapabilitiesStep",
+    "SetDefaultVisibilityStep",
+    "GetGroupInfoStep",
+    "ListGroupContextsStep",
+    "DeleteGroupStep",
+    "DeleteNamespaceStep",
+    "DeleteContextStep",
+    "UninstallApplicationStep",
 ]

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -8,6 +8,15 @@ from merobox.commands.bootstrap.steps.blob import UploadBlobStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
+from merobox.commands.bootstrap.steps.group_create import (
+    CreateGroupStep,
+    CreateNamespaceStep,
+)
+from merobox.commands.bootstrap.steps.group_invite import (
+    CreateGroupInvitationStep,
+    CreateNamespaceInvitationStep,
+)
+from merobox.commands.bootstrap.steps.group_join import JoinGroupStep, JoinNamespaceStep
 from merobox.commands.bootstrap.steps.group_management import (
     DeleteContextStep,
     DeleteGroupStep,
@@ -23,15 +32,6 @@ from merobox.commands.bootstrap.steps.group_management import (
     UninstallApplicationStep,
     UpdateMemberRoleStep,
 )
-from merobox.commands.bootstrap.steps.group_create import (
-    CreateGroupStep,
-    CreateNamespaceStep,
-)
-from merobox.commands.bootstrap.steps.group_invite import (
-    CreateGroupInvitationStep,
-    CreateNamespaceInvitationStep,
-)
-from merobox.commands.bootstrap.steps.group_join import JoinGroupStep, JoinNamespaceStep
 from merobox.commands.bootstrap.steps.identity import CreateIdentityStep
 from merobox.commands.bootstrap.steps.install import InstallApplicationStep
 from merobox.commands.bootstrap.steps.invite_open import InviteOpenStep

--- a/merobox/commands/bootstrap/steps/group_management.py
+++ b/merobox/commands/bootstrap/steps/group_management.py
@@ -38,9 +38,11 @@ class RemoveGroupMembersStep(BaseStep):
             self.config["group_id"], workflow_results, dynamic_values
         )
         members = [
-            self._resolve_dynamic_value(m, workflow_results, dynamic_values)
-            if isinstance(m, str)
-            else m
+            (
+                self._resolve_dynamic_value(m, workflow_results, dynamic_values)
+                if isinstance(m, str)
+                else m
+            )
             for m in self.config["members"]
         ]
         members_json = json.dumps(members)
@@ -410,9 +412,7 @@ class GetGroupInfoStep(BaseStep):
             return False
         workflow_results[f"group_info_{node_name}"] = result["data"]
         self._export_variables(result["data"], node_name, dynamic_values)
-        console.print(
-            f"[green]✓ Got info for group {group_id} on {node_name}[/green]"
-        )
+        console.print(f"[green]✓ Got info for group {group_id} on {node_name}[/green]")
         return True
 
 
@@ -500,9 +500,7 @@ class DeleteGroupStep(BaseStep):
         if self._check_jsonrpc_error(result["data"]):
             return False
         workflow_results[f"delete_group_{node_name}"] = result["data"]
-        console.print(
-            f"[green]✓ Deleted group {group_id} on {node_name}[/green]"
-        )
+        console.print(f"[green]✓ Deleted group {group_id} on {node_name}[/green]")
         return True
 
 
@@ -586,9 +584,7 @@ class DeleteContextStep(BaseStep):
         if self._check_jsonrpc_error(result["data"]):
             return False
         workflow_results[f"delete_context_{node_name}"] = result["data"]
-        console.print(
-            f"[green]✓ Deleted context {context_id} on {node_name}[/green]"
-        )
+        console.print(f"[green]✓ Deleted context {context_id} on {node_name}[/green]")
         return True
 
 

--- a/merobox/commands/bootstrap/steps/group_management.py
+++ b/merobox/commands/bootstrap/steps/group_management.py
@@ -1,0 +1,635 @@
+"""
+Group management workflow step executors.
+
+Steps for managing group membership, roles, capabilities, and lifecycle.
+"""
+
+import json
+from typing import Any
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.client import get_client_for_rpc_url
+from merobox.commands.result import fail, ok
+from merobox.commands.utils import console
+
+
+class RemoveGroupMembersStep(BaseStep):
+    """Remove members from a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "members"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        if not isinstance(self.config.get("node"), str):
+            raise ValueError(f"Step '{step_name}': 'node' must be a string")
+        if not isinstance(self.config.get("group_id"), str):
+            raise ValueError(f"Step '{step_name}': 'group_id' must be a string")
+        if not isinstance(self.config.get("members"), list):
+            raise ValueError(f"Step '{step_name}': 'members' must be a list")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        members = [
+            self._resolve_dynamic_value(m, workflow_results, dynamic_values)
+            if isinstance(m, str)
+            else m
+            for m in self.config["members"]
+        ]
+        members_json = json.dumps(members)
+
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.remove_group_members(
+                group_id=group_id, members_json=members_json
+            )
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("remove_group_members failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]Failed to remove group members on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"remove_group_members_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Removed {len(members)} member(s) from group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class ListGroupMembersStep(BaseStep):
+    """List members of a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    def _get_exportable_variables(self):
+        return [("members", "members_{node_name}", "List of group members")]
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.list_group_members(group_id=group_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("list_group_members failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]list_group_members failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"members_{node_name}"] = result["data"]
+        self._export_variables(result["data"], node_name, dynamic_values)
+        console.print(
+            f"[green]✓ Listed members for group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class UpdateMemberRoleStep(BaseStep):
+    """Update a member's role in a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "member_id", "role"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id", "member_id", "role"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        member_id = self._resolve_dynamic_value(
+            self.config["member_id"], workflow_results, dynamic_values
+        )
+        role = self._resolve_dynamic_value(
+            self.config["role"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.update_member_role(
+                group_id=group_id, member_id=member_id, role=role
+            )
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("update_member_role failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]update_member_role failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"update_member_role_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Updated role to '{role}' for {member_id} in group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class SetMemberCapabilitiesStep(BaseStep):
+    """Set capabilities for a specific member in a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "member_id", "capabilities"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id", "member_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+        if not isinstance(self.config.get("capabilities"), int):
+            raise ValueError(f"Step '{step_name}': 'capabilities' must be an integer")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        member_id = self._resolve_dynamic_value(
+            self.config["member_id"], workflow_results, dynamic_values
+        )
+        capabilities = self.config["capabilities"]
+
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.set_member_capabilities(
+                group_id=group_id, member_id=member_id, capabilities=capabilities
+            )
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("set_member_capabilities failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]set_member_capabilities failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"set_member_capabilities_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Set capabilities for {member_id} in group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class GetMemberCapabilitiesStep(BaseStep):
+    """Get capabilities for a specific member in a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "member_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id", "member_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    def _get_exportable_variables(self):
+        return [("capabilities", "capabilities_{node_name}", "Member capabilities")]
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        member_id = self._resolve_dynamic_value(
+            self.config["member_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.get_member_capabilities(
+                group_id=group_id, member_id=member_id
+            )
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("get_member_capabilities failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]get_member_capabilities failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"capabilities_{node_name}"] = result["data"]
+        self._export_variables(result["data"], node_name, dynamic_values)
+        console.print(
+            f"[green]✓ Got capabilities for {member_id} in group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class SetDefaultCapabilitiesStep(BaseStep):
+    """Set default capabilities for new members in a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "capabilities"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        if not isinstance(self.config.get("node"), str):
+            raise ValueError(f"Step '{step_name}': 'node' must be a string")
+        if not isinstance(self.config.get("group_id"), str):
+            raise ValueError(f"Step '{step_name}': 'group_id' must be a string")
+        if not isinstance(self.config.get("capabilities"), int):
+            raise ValueError(f"Step '{step_name}': 'capabilities' must be an integer")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        capabilities = self.config["capabilities"]
+
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.set_default_capabilities(
+                group_id=group_id, capabilities=capabilities
+            )
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("set_default_capabilities failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]set_default_capabilities failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"set_default_capabilities_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Set default capabilities for group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class SetDefaultVisibilityStep(BaseStep):
+    """Set default context visibility for a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "visibility"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id", "visibility"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        visibility = self._resolve_dynamic_value(
+            self.config["visibility"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.set_default_visibility(
+                group_id=group_id, visibility=visibility
+            )
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("set_default_visibility failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]set_default_visibility failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"set_default_visibility_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Set default visibility to '{visibility}' for group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class GetGroupInfoStep(BaseStep):
+    """Get detailed info about a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    def _get_exportable_variables(self):
+        return [("group_info", "group_info_{node_name}", "Group info")]
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.get_group_info(group_id=group_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("get_group_info failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]get_group_info failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"group_info_{node_name}"] = result["data"]
+        self._export_variables(result["data"], node_name, dynamic_values)
+        console.print(
+            f"[green]✓ Got info for group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class ListGroupContextsStep(BaseStep):
+    """List contexts in a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    def _get_exportable_variables(self):
+        return [("contexts", "contexts_{node_name}", "List of group contexts")]
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.list_group_contexts(group_id=group_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("list_group_contexts failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]list_group_contexts failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"contexts_{node_name}"] = result["data"]
+        self._export_variables(result["data"], node_name, dynamic_values)
+        console.print(
+            f"[green]✓ Listed contexts for group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class DeleteGroupStep(BaseStep):
+    """Delete a group."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "group_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.delete_group(group_id=group_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("delete_group failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]delete_group failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"delete_group_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Deleted group {group_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class DeleteNamespaceStep(BaseStep):
+    """Delete a namespace."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "namespace_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "namespace_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        namespace_id = self._resolve_dynamic_value(
+            self.config["namespace_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.delete_namespace(namespace_id=namespace_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("delete_namespace failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]delete_namespace failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"delete_namespace_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Deleted namespace {namespace_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class DeleteContextStep(BaseStep):
+    """Delete a context."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "context_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "context_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        context_id = self._resolve_dynamic_value(
+            self.config["context_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.delete_context(context_id=context_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("delete_context failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]delete_context failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"delete_context_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Deleted context {context_id} on {node_name}[/green]"
+        )
+        return True
+
+
+class UninstallApplicationStep(BaseStep):
+    """Uninstall an application."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "application_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "application_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        application_id = self._resolve_dynamic_value(
+            self.config["application_id"], workflow_results, dynamic_values
+        )
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.uninstall_application(app_id=application_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("uninstall_application failed", error=e)
+
+        if not result["success"]:
+            console.print(
+                f"[red]uninstall_application failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+        if self._check_jsonrpc_error(result["data"]):
+            return False
+        workflow_results[f"uninstall_application_{node_name}"] = result["data"]
+        console.print(
+            f"[green]✓ Uninstalled application {application_id} on {node_name}[/green]"
+        )
+        return True


### PR DESCRIPTION
## Summary

- Adds 14 new merobox workflow step types for group management, membership, capabilities, and lifecycle operations
- All steps use the existing `calimero_client_py` methods — no client changes needed
- Follows the established step pattern (dynamic value resolution, error handling, result export)

## New step types

**Membership:**
- `remove_group_members` — remove members from a group
- `list_group_members` — list members (with output export)
- `update_member_role` — change a member's role (admin/member)

**Capabilities:**
- `set_member_capabilities` / `get_member_capabilities` — per-member capability flags
- `set_default_capabilities` — default capabilities for new members
- `set_default_visibility` — default context visibility mode

**Group info/queries:**
- `get_group_info` — group details (with output export)
- `list_group_contexts` — contexts in a group (with output export)

**Lifecycle/cleanup:**
- `delete_group` / `delete_namespace` / `delete_context`
- `uninstall_application`

## Example usage

```yaml
- name: Remove member from group
  type: remove_group_members
  node: e2e-node-1
  group_id: '{{namespace_id}}'
  members:
    - '{{member_identity}}'

- name: List group members
  type: list_group_members
  node: e2e-node-1
  group_id: '{{namespace_id}}'
  outputs:
    member_list: members
```

## Test plan

- [x] All Python imports verified (`python3 -c "from merobox.commands.bootstrap.run.executor import WorkflowExecutor"`)
- [ ] E2E validation via new workflows in calimero-network/core (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new workflow actions that can mutate or delete group/context data; risk is mainly incorrect wiring/parameter validation or unexpected destructive use rather than changes to core execution flow.
> 
> **Overview**
> Extends the workflow engine with **new group/namespace management step types** covering membership changes, role updates, capability/visibility configuration, group info queries, and lifecycle cleanup (delete group/namespace/context, uninstall app).
> 
> Implements these steps in a new `group_management.py` module and wires them into the executor’s step factory and step exports, while updating the Workflow YAML reference docs (including the step type count and schemas/examples for the added steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77d436cba2e1ad01fcc65f0c65b28f694a49de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->