### PR TITLE
fix(ci): re-enable subgroups-example workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,16 +72,12 @@ jobs:
       - uses: actions/checkout@v4
       - id: set
         run: |
-          # Binary mode: all workflows except fuzzy, auth-related, and subgroups
-          # Note: subgroups-example requires the signing key hierarchy fix
-          # (calimero-network/core#2148) in the merod binary. Re-enable once
-          # the edge image / cached binary includes that fix.
+          # Binary mode: all workflows except fuzzy and auth-related
           BINARY=$(ls workflow-examples/*.yml | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
             grep -v auth-image | \
             grep -v cached-frontends | \
-            grep -v subgroups-example | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
@@ -92,7 +88,6 @@ jobs:
             grep -v auth-image | \
             grep -v cached-frontends | \
             grep -v example-binary | \
-            grep -v subgroups-example | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "docker=$DOCKER" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

Re-enables `workflow-subgroups-example.yml` in CI. It was excluded because it required the signing key hierarchy fix (calimero-network/core#2148), which has now landed on core master.

The binary build fetches core master via `git pull`, so the fix is picked up. The cargo cache key also changed with the CI rewrite (#195), so stale binaries won't be served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI matrix selection logic and comments, with no production/runtime code impact; main risk is increased CI time or a newly-failing workflow.
> 
> **Overview**
> Re-enables the `subgroups-example` workflow in CI by removing it from the exclusion list when building the binary and Docker workflow matrices in `.github/workflows/ci.yml`.
> 
> Also trims outdated comments that referenced a previously-missing signing key hierarchy fix, so the matrix now includes `workflow-subgroups-example.yml` in standard CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e7b81c7235b2174b916b0a21de9136c514607a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->