### PR TITLE
perf: parallel node startup/shutdown, reduce startup delay

### DIFF
--- a/merobox/commands/binary_manager.py
+++ b/merobox/commands/binary_manager.py
@@ -524,14 +524,28 @@ class BinaryManager(CleanupMixin):
 
         console.print(f"[bold]Stopping {len(running_nodes)} Calimero nodes...[/bold]")
 
-        # Stop each running node
+        # Phase 1: Send SIGTERM to all nodes first (fast, non-blocking)
         for node_name in running_nodes:
             try:
-                # Try tracked process first
+                if node_name in self.processes:
+                    self.processes[node_name].terminate()
+                else:
+                    pid = self._load_pid(node_name)
+                    if pid and self._is_process_running(pid):
+                        os.kill(pid, signal.SIGTERM)
+            except Exception:
+                pass
+
+        # Phase 2: Wait once for all to drain (instead of per-node sleep)
+        time.sleep(2)
+
+        # Phase 3: Collect results and clean up (SIGTERM already sent)
+        for node_name in running_nodes:
+            try:
                 if node_name in self.processes:
                     process = self.processes[node_name]
                     try:
-                        process.terminate()
+                        # SIGTERM already sent in Phase 1, just wait
                         process.wait(timeout=PROCESS_WAIT_TIMEOUT)
                         console.print(f"[green]✓ Stopped node {node_name}[/green]")
                     except subprocess.TimeoutExpired:
@@ -546,18 +560,13 @@ class BinaryManager(CleanupMixin):
                     self.node_rpc_ports.pop(node_name, None)
                     stopped += 1
                 else:
-                    # Stop by PID file
                     pid = self._load_pid(node_name)
                     if pid and self._is_process_running(pid):
-                        os.kill(pid, signal.SIGTERM)
-                        time.sleep(2)
-
-                        # Check if still running
-                        if self._is_process_running(pid):
-                            console.print(
-                                f"[yellow]Force killing node {node_name}...[/yellow]"
-                            )
-                            os.kill(pid, signal.SIGKILL)
+                        # SIGTERM already sent in Phase 1, force-kill if needed
+                        console.print(
+                            f"[yellow]Force killing node {node_name}...[/yellow]"
+                        )
+                        os.kill(pid, signal.SIGKILL)
 
                         console.print(f"[green]✓ Stopped node {node_name}[/green]")
                     else:
@@ -809,19 +818,24 @@ class BinaryManager(CleanupMixin):
                 base_rpc_port = DEFAULT_RPC_PORT
             allocated_ports = []
 
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        # Pre-compute ports for all nodes before starting threads
+        node_configs = []
         for i in range(count):
             node_name = f"{prefix}-{i+1}"
             if e2e_mode:
-                # Use dynamically allocated ports
-                port = allocated_ports[i * 2]  # P2P port
-                rpc_port = allocated_ports[i * 2 + 1]  # RPC port
+                port = allocated_ports[i * 2]
+                rpc_port = allocated_ports[i * 2 + 1]
             else:
-                # Use fixed port ranges (legacy behavior)
                 port = base_port + i
                 rpc_port = base_rpc_port + i
+            node_configs.append((node_name, port, rpc_port))
 
-            if self.run_node(
-                node_name=node_name,
+        def start_one(cfg):
+            name, port, rpc_port = cfg
+            return name, self.run_node(
+                node_name=name,
                 port=port,
                 rpc_port=rpc_port,
                 log_level=log_level,
@@ -830,11 +844,19 @@ class BinaryManager(CleanupMixin):
                 e2e_mode=e2e_mode,
                 bootstrap_nodes=bootstrap_nodes,
                 auth_mode=auth_mode,
-            ):
-                success_count += 1
-            else:
-                console.print(f"[red]✗ Failed to start node {node_name}[/red]")
-                return False
+            )
+
+        with ThreadPoolExecutor(max_workers=count) as pool:
+            futures = [pool.submit(start_one, cfg) for cfg in node_configs]
+            for future in as_completed(futures):
+                name, ok = future.result()
+                if ok:
+                    success_count += 1
+                else:
+                    console.print(f"[red]✗ Failed to start node {name}[/red]")
+
+        if success_count < count:
+            return False
 
         console.print(
             f"\n[bold green]✓ Successfully started all {success_count} node(s)[/bold green]"

--- a/merobox/commands/constants.py
+++ b/merobox/commands/constants.py
@@ -72,7 +72,7 @@ PERSISTENT_READ_TIMEOUT = 60.0  # seconds
 CONTAINER_STOP_TIMEOUT = 10  # seconds
 SCRIPT_CONTAINER_STOP_TIMEOUT = 5  # seconds
 PROCESS_WAIT_TIMEOUT = 5  # seconds
-NODE_STARTUP_DELAY = 3  # seconds
+NODE_STARTUP_DELAY = 1  # seconds (health check handles actual readiness)
 SOCKET_CONNECTION_TIMEOUT = 1.5  # seconds
 NUKE_STOP_TIMEOUT = 30  # seconds
 

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -1157,16 +1157,14 @@ class DockerManager(CleanupMixin):
         else:
             rpc_ports = [base_rpc_port + i for i in range(count)]
 
-        success_count = 0
-        for i in range(count):
-            node_name = f"{prefix}-{i + 1}"
-            port = p2p_ports[i]
-            rpc_port = rpc_ports[i]
+        from concurrent.futures import ThreadPoolExecutor, as_completed
 
-            if self.run_node(
+        def start_one(i):
+            node_name = f"{prefix}-{i + 1}"
+            return node_name, self.run_node(
                 node_name,
-                port,
-                rpc_port,
+                p2p_ports[i],
+                rpc_ports[i],
                 image=image,
                 auth_service=auth_service,
                 auth_image=auth_image,
@@ -1179,13 +1177,17 @@ class DockerManager(CleanupMixin):
                 bootstrap_nodes=bootstrap_nodes,
                 use_image_entrypoint=use_image_entrypoint,
                 cors_allowed_origins=cors_allowed_origins,
-            ):
-                success_count += 1
-            else:
-                console.print(
-                    f"[red]Failed to start node {node_name}, stopping deployment[/red]"
-                )
-                break
+            )
+
+        success_count = 0
+        with ThreadPoolExecutor(max_workers=count) as pool:
+            futures = [pool.submit(start_one, i) for i in range(count)]
+            for future in as_completed(futures):
+                node_name, ok = future.result()
+                if ok:
+                    success_count += 1
+                else:
+                    console.print(f"[red]Failed to start node {node_name}[/red]")
 
         console.print(
             f"\n[bold]Deployment Summary: {success_count}/{count} nodes started successfully[/bold]"
@@ -1263,16 +1265,15 @@ class DockerManager(CleanupMixin):
             )
             time.sleep(drain_timeout)
 
-        # Phase 3: Capture logs, then stop and remove all containers
-        success_count = 0
-        failed_names = []
+        # Phase 3: Capture logs, then stop and remove all containers in parallel
+        from concurrent.futures import ThreadPoolExecutor, as_completed
 
-        for container_name, container in containers:
-            # Capture container logs before stopping so they survive removal.
-            # Written to ./data/container-logs/ which is included in CI artifacts.
+        log_dir = os.path.join("data", "container-logs")
+        os.makedirs(log_dir, exist_ok=True)
+
+        def stop_one(container_name, container):
+            # Capture logs before stopping
             try:
-                log_dir = os.path.join("data", "container-logs")
-                os.makedirs(log_dir, exist_ok=True)
                 log_content = container.logs(timestamps=True).decode(
                     "utf-8", errors="replace"
                 )
@@ -1288,10 +1289,22 @@ class DockerManager(CleanupMixin):
                 console.print(
                     f"[green]✓ Gracefully stopped and removed {container_name}[/green]"
                 )
-                success_count += 1
+                return container_name, True
             except Exception as e:
                 console.print(f"[red]✗ Failed to stop {container_name}: {str(e)}[/red]")
-                failed_names.append(container_name)
+                return container_name, False
+
+        success_count = 0
+        failed_names = []
+
+        with ThreadPoolExecutor(max_workers=len(containers)) as pool:
+            futures = [pool.submit(stop_one, name, ctr) for name, ctr in containers]
+            for future in as_completed(futures):
+                name, ok = future.result()
+                if ok:
+                    success_count += 1
+                else:
+                    failed_names.append(name)
 
         return success_count, failed_names
 

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -1157,8 +1157,6 @@ class DockerManager(CleanupMixin):
         else:
             rpc_ports = [base_rpc_port + i for i in range(count)]
 
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-
         def start_one(i):
             node_name = f"{prefix}-{i + 1}"
             return node_name, self.run_node(
@@ -1180,14 +1178,29 @@ class DockerManager(CleanupMixin):
             )
 
         success_count = 0
-        with ThreadPoolExecutor(max_workers=count) as pool:
-            futures = [pool.submit(start_one, i) for i in range(count)]
-            for future in as_completed(futures):
-                node_name, ok = future.result()
+
+        if auth_service:
+            # Sequential startup when auth service is enabled to avoid
+            # races on shared Traefik/auth containers.
+            for i in range(count):
+                node_name, ok = start_one(i)
                 if ok:
                     success_count += 1
                 else:
                     console.print(f"[red]Failed to start node {node_name}[/red]")
+                    break
+        else:
+            # Parallel startup for the common non-auth case.
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+
+            with ThreadPoolExecutor(max_workers=count) as pool:
+                futures = [pool.submit(start_one, i) for i in range(count)]
+                for future in as_completed(futures):
+                    node_name, ok = future.result()
+                    if ok:
+                        success_count += 1
+                    else:
+                        console.print(f"[red]Failed to start node {node_name}[/red]")
 
         console.print(
             f"\n[bold]Deployment Summary: {success_count}/{count} nodes started successfully[/bold]"


### PR DESCRIPTION
## Summary

Three changes to reduce merobox workflow execution time:

### 1. Parallel node startup
`run_multiple_nodes` now uses `ThreadPoolExecutor` to start all nodes concurrently instead of sequentially.

**Before:** 3 nodes × (start + 3s delay) = ~9s serial
**After:** all 3 start concurrently + 1s delay = ~1s

### 2. Reduce `NODE_STARTUP_DELAY` (3s → 1s)
The health check (`_wait_for_nodes_ready`) already polls until nodes are actually responding. The post-start sleep was just a conservative buffer.

### 3. Parallel shutdown
- **Docker:** `_graceful_stop_containers_batch` Phase 3 (stop + remove) now runs in parallel via ThreadPoolExecutor instead of sequential per-container
- **Binary:** Send SIGTERM to all nodes first, single shared 2s drain period, then collect results (was: per-node SIGTERM + 2s sleep)

### Expected savings
~10-15s per workflow with 3 nodes. Bigger savings for workflows with more nodes (propagation-monitoring has 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces concurrency in node startup and container stop/remove paths, which can surface race conditions or resource contention (ports, shared Docker/auth infrastructure) and change shutdown semantics for PID-tracked processes.
> 
> **Overview**
> **Improves workflow execution time** by starting multiple nodes concurrently: `DockerManager.run_multiple_nodes` now uses a thread pool for the non-auth case (keeps *sequential* startup when `auth_service` is enabled), and `BinaryManager.run_multiple_nodes` starts nodes in parallel after precomputing per-node port assignments.
> 
> **Reduces fixed startup waiting** by lowering `NODE_STARTUP_DELAY` from 3s to 1s, relying on existing health checks for readiness.
> 
> **Accelerates shutdown** by parallelizing Docker batch shutdown Phase 3 (log capture + `stop`/`remove`) and by changing binary `stop_all_nodes` to send SIGTERM to all nodes first, wait once, then finalize cleanup/force-kill as needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2539b45b64b697192480219b10330c95aab82163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->