### PR TITLE
perf: reduce polling intervals for faster sync detection

### DIFF
--- a/merobox/commands/bootstrap/steps/wait_for_sync.py
+++ b/merobox/commands/bootstrap/steps/wait_for_sync.py
@@ -356,7 +356,7 @@ class WaitForSyncStep(BaseStep):
         )
         nodes = self.config["nodes"]
         timeout = self.config.get("timeout", 30)
-        check_interval = self.config.get("check_interval", 1.0)
+        check_interval = self.config.get("check_interval", 0.5)
         retry_attempts = self.config.get("retry_attempts")
         # Default: enabled - uses sync_context(context_id) for targeted sync
         trigger_sync = self.config.get("trigger_sync", True)

--- a/merobox/commands/constants.py
+++ b/merobox/commands/constants.py
@@ -82,7 +82,7 @@ RPC_WAIT_TIMEOUT = 10  # seconds to wait for RPC to be ready
 RPC_POLL_INTERVAL = 0.1  # seconds between RPC readiness checks
 RPC_INITIAL_DELAY = 1.0  # seconds initial delay before polling
 CLEANUP_DELAY = 0.5  # seconds after process cleanup
-ASYNC_POLL_INTERVAL = 2  # seconds between async checks
+ASYNC_POLL_INTERVAL = 0.5  # seconds between async checks (node readiness, etc.)
 
 # State sync retry configuration
 STATE_RETRY_ATTEMPTS = 5


### PR DESCRIPTION
- `ASYNC_POLL_INTERVAL`: 2s → 0.5s (node readiness checks)
- `wait_for_sync` default `check_interval`: 1.0s → 0.5s

Faster detection of node readiness and CRDT convergence. Saves ~1-2s per sync step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral change that only increases polling frequency; main downside is slightly higher RPC/CPU load and potential for noisier logs during waits.
> 
> **Overview**
> Speeds up bootstrap sync/readiness detection by reducing default polling intervals.
> 
> `WaitForSyncStep` now defaults `check_interval` to `0.5s` (from `1.0s`), and the shared `ASYNC_POLL_INTERVAL` constant is reduced to `0.5s` (from `2s`) for faster async status checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd524f73754ef1e70417bc2b7471929e5a8a1cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->