### PR TITLE
fix: revert parallel container shutdown to sequential

### DIFF
--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -1278,14 +1278,17 @@ class DockerManager(CleanupMixin):
             )
             time.sleep(drain_timeout)
 
-        # Phase 3: Capture logs, then stop and remove all containers in parallel
-        from concurrent.futures import ThreadPoolExecutor, as_completed
+        # Phase 3: Capture logs, then stop and remove containers.
+        # Sequential here is fine — containers already received SIGTERM in
+        # Phase 1 and had drain_timeout to stop, so container.stop() returns
+        # almost immediately for already-stopped containers.
+        success_count = 0
+        failed_names = []
 
         log_dir = os.path.join("data", "container-logs")
         os.makedirs(log_dir, exist_ok=True)
 
-        def stop_one(container_name, container):
-            # Capture logs before stopping
+        for container_name, container in containers:
             try:
                 log_content = container.logs(timestamps=True).decode(
                     "utf-8", errors="replace"
@@ -1302,22 +1305,10 @@ class DockerManager(CleanupMixin):
                 console.print(
                     f"[green]✓ Gracefully stopped and removed {container_name}[/green]"
                 )
-                return container_name, True
+                success_count += 1
             except Exception as e:
                 console.print(f"[red]✗ Failed to stop {container_name}: {str(e)}[/red]")
-                return container_name, False
-
-        success_count = 0
-        failed_names = []
-
-        with ThreadPoolExecutor(max_workers=len(containers)) as pool:
-            futures = [pool.submit(stop_one, name, ctr) for name, ctr in containers]
-            for future in as_completed(futures):
-                name, ok = future.result()
-                if ok:
-                    success_count += 1
-                else:
-                    failed_names.append(name)
+                failed_names.append(container_name)
 
         return success_count, failed_names
 


### PR DESCRIPTION
The ThreadPoolExecutor in the shutdown path crashes with `RuntimeError: cannot schedule new futures after interpreter shutdown` when called during cleanup. This breaks ALL e2e tests in calimero-network/core#2162.

Reverted Phase 3 (stop+remove) to sequential. Not actually slow — Phase 1 already sent SIGTERM to all containers and Phase 2 waited for drain, so by Phase 3 most are already stopped and `container.stop()` returns immediately.

Parallel startup (Phase 1 of run_multiple_nodes) is unaffected — that runs during normal execution, not shutdown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the shutdown/cleanup path; it removes parallelism to avoid `ThreadPoolExecutor` failures during interpreter teardown, with minimal behavioral impact beyond potentially slower stops.
> 
> **Overview**
> Reverts Phase 3 of `DockerManager._graceful_stop_containers_batch` from parallel stop/remove to a **sequential** loop, removing the `ThreadPoolExecutor` used during cleanup.
> 
> Containers still receive SIGTERM and a shared drain wait first, but log capture + `container.stop()`/`container.remove()` now run one-by-one while tracking `success_count` and `failed_names`, avoiding shutdown-time executor scheduling errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e833101d8cf1d3b49dfaa0d99399b925947c2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->