### PR TITLE
fix: pass unwrapped SignedGroupOpenInvitation to join_namespace

### DIFF
--- a/merobox/commands/bootstrap/steps/group_join.py
+++ b/merobox/commands/bootstrap/steps/group_join.py
@@ -111,24 +111,34 @@ class JoinNamespaceStep(BaseStep):
             self.config["invitation"], workflow_results, dynamic_values
         )
 
-        # invitation is a SignedGroupOpenInvitation dict or JSON string from
-        # create_group_invitation. The Rust client parses invitation_json as
-        # JoinGroupApiRequest { invitation: SignedGroupOpenInvitation }, so we
-        # must wrap the invitation in {"invitation": ...}.
+        # The calimero-client-py join_namespace() expects invitation_json to be
+        # a SignedGroupOpenInvitation (the inner invitation object). The client
+        # wraps it in JoinGroupApiRequest { invitation, group_alias } internally.
+        #
+        # The invitation may be nested multiple levels deep:
+        # {"invitation": {"invitation": {<SignedGroupOpenInvitation>}}}
+        # Keep unwrapping until we reach the actual invitation (has inviter_signature).
         if isinstance(invitation, dict):
-            if "inviter_signature" in invitation:
-                invitation_json = json_lib.dumps({"invitation": invitation})
-            elif "invitation" in invitation and isinstance(
-                invitation.get("invitation"), dict
+            while (
+                "invitation" in invitation
+                and isinstance(invitation["invitation"], dict)
+                and "inviter_signature" not in invitation
             ):
-                invitation_json = json_lib.dumps(invitation)
-            else:
-                invitation_json = json_lib.dumps({"invitation": invitation})
+                invitation = invitation["invitation"]
+            invitation_json = json_lib.dumps(invitation)
         elif isinstance(invitation, str):
-            # Validate it's parseable JSON
             try:
-                json_lib.loads(invitation)
-                invitation_json = invitation
+                parsed = json_lib.loads(invitation)
+                if isinstance(parsed, dict):
+                    while (
+                        "invitation" in parsed
+                        and isinstance(parsed["invitation"], dict)
+                        and "inviter_signature" not in parsed
+                    ):
+                        parsed = parsed["invitation"]
+                    invitation_json = json_lib.dumps(parsed)
+                else:
+                    invitation_json = invitation
             except json_lib.JSONDecodeError as e:
                 console.print(
                     f"[red]Step 'join_namespace' on {node_name}: "

--- a/merobox/commands/join.py
+++ b/merobox/commands/join.py
@@ -39,16 +39,32 @@ async def join_namespace_via_admin_api(
 
         client = get_client_for_rpc_url(rpc_url, node_name=node_name)
 
+        # The calimero-client-py join_namespace() expects the raw
+        # SignedGroupOpenInvitation JSON. Unwrap nested {"invitation": ...}
+        # layers until we reach the actual invitation (has inviter_signature).
         if isinstance(invitation_data, dict):
-            if "inviter_signature" in invitation_data:
-                invitation_json = json_lib.dumps({"invitation": invitation_data})
-            elif "invitation" in invitation_data and isinstance(
-                invitation_data.get("invitation"), dict
+            while (
+                "invitation" in invitation_data
+                and isinstance(invitation_data["invitation"], dict)
+                and "inviter_signature" not in invitation_data
             ):
-                invitation_json = json_lib.dumps(invitation_data)
-            else:
-                invitation_json = json_lib.dumps({"invitation": invitation_data})
-
+                invitation_data = invitation_data["invitation"]
+            invitation_json = json_lib.dumps(invitation_data)
+        elif isinstance(invitation_data, str):
+            try:
+                parsed = json_lib.loads(invitation_data)
+                if isinstance(parsed, dict):
+                    while (
+                        "invitation" in parsed
+                        and isinstance(parsed["invitation"], dict)
+                        and "inviter_signature" not in parsed
+                    ):
+                        parsed = parsed["invitation"]
+                    invitation_json = json_lib.dumps(parsed)
+                else:
+                    invitation_json = invitation_data
+            except (json_lib.JSONDecodeError, ValueError):
+                invitation_json = invitation_data
         else:
             invitation_json = str(invitation_data)
 


### PR DESCRIPTION
calimero-client-py#32 changed join_namespace to use the Rust client bindings, which expects the raw SignedGroupOpenInvitation JSON. Merobox was passing the full API response wrapper (`{"invitation": {...}}`), causing `missing field inviter_identity` deserialization error.

Fix: unwrap the invitation dict before passing to the client. This is blocking all e2e tests in calimero-network/core#2162.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change to JSON shaping for join flows; main risk is breaking compatibility with unexpected invitation formats if the unwrapping heuristic mis-detects the payload shape.
> 
> **Overview**
> Fixes `join_namespace` calls to pass the **raw `SignedGroupOpenInvitation` JSON** instead of the API response wrapper.
> 
> Both the bootstrap `JoinNamespaceStep` and the `join namespace` command now *repeatedly unwrap* nested `{"invitation": ...}` layers (for dict or JSON-string inputs) until the inner object is reached, preventing deserialization errors in newer `calimero-client-py` bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7908ea1811b755af7799baa7777aa3cb7d03a2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->