### PR TITLE
perf(ci): remove format gate — run all jobs in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
 
   test-unit:
     runs-on: ubuntu-latest
-    needs: format
     steps:
       - uses: actions/checkout@v4
 
@@ -95,7 +94,6 @@ jobs:
   build-binary:
     name: Build (binary mode)
     runs-on: ubuntu-latest
-    needs: format
     steps:
       - uses: actions/checkout@v4
 
@@ -193,7 +191,7 @@ jobs:
   test-merobox-docker:
     name: Docker (${{ matrix.name }})
     runs-on: ubuntu-latest
-    needs: [format, list-workflows]
+    needs: [list-workflows]
     strategy:
       fail-fast: false
       matrix:
@@ -237,7 +235,6 @@ jobs:
 
   test-merobox-integration:
     runs-on: ubuntu-latest
-    needs: format
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
All jobs (test-unit, build-binary, Docker tests, integration tests) now start immediately instead of waiting ~2.5 min for the format check. If format fails, the PR still fails — but all results are visible immediately.

Saves ~2.5 min from the critical path on every CI run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions job dependencies so test/build jobs no longer wait on `format`; the main impact is CI execution order/visibility, not production code.
> 
> **Overview**
> **CI pipeline now runs in parallel instead of being gated by formatting.** The `format` job remains, but `test-unit`, `build-binary`, `test-merobox-docker`, and `test-merobox-integration` no longer declare `needs: format`, so they start immediately.
> 
> `test-merobox-docker` is now only dependent on `list-workflows`, reducing critical-path time while still failing the workflow if formatting fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8a1bc9d0e28f357fc6c0bc6535f20cee2b2146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->