### PR TITLE
fix: graceful shutdown crashes in atexit path with ThreadPoolExecutor race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-04-20
+
+### Fixed
+- Graceful shutdown no longer crashes with `RuntimeError: cannot schedule new
+  futures after interpreter shutdown` when cleanup runs from the `atexit`
+  path. `_graceful_stop_containers_batch` now catches the error raised by
+  `ThreadPoolExecutor.submit()` during interpreter finalization and falls
+  back to a sequential stop, so containers are properly torn down instead of
+  being left running between workflow runs (regression from #198).
+
 ## [0.4.4] - 2026-04-13
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -164,9 +164,7 @@ class DockerManager(CleanupMixin):
             console.print(
                 "[cyan]Stopping managed containers with graceful shutdown...[/cyan]"
             )
-            containers_to_stop = [
-                (name, container) for name, container in self.nodes.items()
-            ]
+            containers_to_stop = list(self.nodes.items())
             self._graceful_stop_containers_batch(
                 containers_to_stop, drain_timeout, stop_timeout
             )
@@ -1307,19 +1305,36 @@ class DockerManager(CleanupMixin):
                 console.print(f"[red]✗ Failed to stop {container_name}: {str(e)}[/red]")
                 return container_name, False
 
-        success_count = 0
-        failed_names = []
-
-        with ThreadPoolExecutor(max_workers=len(containers)) as pool:
-            futures = [pool.submit(stop_one, name, ctr) for name, ctr in containers]
-            for future in as_completed(futures):
-                name, ok = future.result()
+        def run_sequential():
+            success = 0
+            failed = []
+            for name, ctr in containers:
+                name_out, ok = stop_one(name, ctr)
                 if ok:
-                    success_count += 1
+                    success += 1
                 else:
-                    failed_names.append(name)
+                    failed.append(name_out)
+            return success, failed
 
-        return success_count, failed_names
+        # When cleanup runs from the atexit path, concurrent.futures.thread's
+        # own shutdown handler has already flipped its internal _shutdown flag,
+        # so ThreadPoolExecutor.submit() raises "cannot schedule new futures
+        # after interpreter shutdown". Fall back to sequential stop in that
+        # case so cleanup still completes instead of leaving containers behind.
+        try:
+            success_count = 0
+            failed_names = []
+            with ThreadPoolExecutor(max_workers=len(containers)) as pool:
+                futures = [pool.submit(stop_one, name, ctr) for name, ctr in containers]
+                for future in as_completed(futures):
+                    name, ok = future.result()
+                    if ok:
+                        success_count += 1
+                    else:
+                        failed_names.append(name)
+            return success_count, failed_names
+        except RuntimeError:
+            return run_sequential()
 
     def stop_node(
         self,


### PR DESCRIPTION
## Summary

- Catches `RuntimeError: cannot schedule new futures after interpreter shutdown` in `_graceful_stop_containers_batch` and falls back to sequential stop when cleanup runs from the `atexit` path (regression from #198).
- Bumps version to 0.4.5 and adds a CHANGELOG entry.

## Context

After #198 parallelised the stop+remove phase inside `_graceful_stop_containers_batch` using `ThreadPoolExecutor`, any cleanup reached via `atexit` (normal or failed workflow completion — not SIGTERM) started crashing:

```
Exception ignored in atexit callback: <bound method CleanupMixin._cleanup_on_exit ...>
Traceback (most recent call last):
  ...
  File ".../merobox/commands/manager.py", line 1314, in _graceful_stop_containers_batch
    futures = [pool.submit(stop_one, name, ctr) for name, ctr in containers]
  File ".../concurrent/futures/thread.py", line 169, in submit
    raise RuntimeError('cannot schedule new futures after '
RuntimeError: cannot schedule new futures after interpreter shutdown
```

`concurrent.futures.thread._python_exit` is registered via `threading._register_atexit`, which runs *before* user-level `atexit.register` handlers. By the time `CleanupMixin._cleanup_on_exit` fires, `_python_exit` has already set the module's `_shutdown` flag, so `pool.submit()` refuses new tasks.

The crash left containers and node data dirs stranded after failed runs, which then poisoned the next workflow's "reuse running nodes" startup path with stale gossipsub subscriptions — masking the root cause as a node-readiness timeout.

## Fix

Wrap the parallel block in `try / except RuntimeError` and fall back to a plain sequential `run_sequential()` helper on exception. The SIGTERM path (interpreter still alive) keeps the parallel speedup from #198 unchanged.

`sys.is_finalizing()` was considered first but is the wrong signal — it only flips *after* all atexit handlers have run, whereas `concurrent.futures`' own `_shutdown` flag flips *before*. Verified with a standalone reproducer.

Also takes a drive-by ruff C416 fix on an unrelated list comprehension in the same function body so pre-commit passes.

## Test plan

- [x] 292 existing unit tests pass (`pytest`)
- [x] Standalone atexit reproducer confirms the fallback triggers and all stops complete
- [x] Black + ruff pre-commit hooks pass
- [ ] Re-run a multi-node workflow and confirm containers are cleanly stopped when the workflow exits normally and when it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches container teardown during interpreter finalization; while the fallback is narrow, cleanup paths are timing-sensitive and could still leave resources running if mishandled.
> 
> **Overview**
> Fixes a regression where graceful shutdown could crash during `atexit` cleanup with `RuntimeError: cannot schedule new futures after interpreter shutdown`.
> 
> `_graceful_stop_containers_batch` now wraps the `ThreadPoolExecutor` stop/remove phase in `try/except RuntimeError` and falls back to a sequential stop so containers still get removed even when the interpreter is finalizing. Also bumps the package version to `0.4.5` and adds a `CHANGELOG` entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa7cb64a00532682710427a59a9c715f5cfb2f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->