### PR TITLE
fix(manager): add CAP_PERFMON so  works inside containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-04-23
+
+### Fixed
+
+- Add `CAP_PERFMON` to the container capability list so `perf record`
+  works inside Docker containers running the profiling image. Without
+  it, `sys_perf_event_open()` fails with `EPERM` even when `linux-tools`
+  is correctly installed, which blocks CPU-profile collection in
+  calimero-network/core's fuzzy-load-test. `CAP_PERFMON` is the narrow
+  Linux 5.8+ capability specifically for `perf_events` — preferred over
+  `CAP_SYS_ADMIN`. File-permission caps are unchanged.
+
 ## [0.5.0] - 2026-04-22
 
 ### Breaking changes

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -459,9 +459,22 @@ class DockerManager(CleanupMixin):
                 "image": image_to_use,
                 "detach": True,
                 "user": "root",  # Override the default user in the image
-                # Use specific capabilities instead of privileged mode for security
-                # These capabilities are needed for file permission handling with volumes
-                "cap_add": ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"],
+                # Use specific capabilities instead of privileged mode for security.
+                # CHOWN/DAC_OVERRIDE/FOWNER/SETGID/SETUID handle file permissions
+                # across bind-mounted volumes. PERFMON is required for `perf
+                # record` (sys_perf_event_open) inside the container; without it
+                # the profiling image's entrypoint fails with EPERM even when
+                # linux-tools is correctly installed. CAP_PERFMON is the narrow
+                # capability added in kernel 5.8 specifically for perf_events —
+                # preferred over CAP_SYS_ADMIN.
+                "cap_add": [
+                    "CHOWN",
+                    "DAC_OVERRIDE",
+                    "FOWNER",
+                    "SETGID",
+                    "SETUID",
+                    "PERFMON",
+                ],
                 "environment": node_env,
                 "ports": {
                     # Map external P2P port to internal P2P port

--- a/merobox/tests/unit/test_docker_manager.py
+++ b/merobox/tests/unit/test_docker_manager.py
@@ -63,7 +63,16 @@ def test_docker_container_uses_cap_add_not_privileged(mock_docker):
         "cap_add" in main_config
     ), "Container should use cap_add for specific capabilities"
 
-    expected_caps = ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"]
+    # File-permission caps (bind mount handling) + PERFMON (required for
+    # `perf record` / sys_perf_event_open inside the profiling image).
+    expected_caps = [
+        "CHOWN",
+        "DAC_OVERRIDE",
+        "FOWNER",
+        "SETGID",
+        "SETUID",
+        "PERFMON",
+    ]
     for cap in expected_caps:
         assert (
             cap in main_config["cap_add"]


### PR DESCRIPTION
## Problem

The `ghcr.io/calimero-network/merod:edge-profiling` image used by calimero-network/core's fuzzy-load-test needs `perf record` to produce CPU flamegraphs for the ongoing merge-apply performance investigation (#2199 / #2215 in core).

With the current `cap_add` list, the entrypoint's `perf record -o /dev/null -- true` sanity check fails even after `linux-tools-6.17.0-1010-azure` is correctly installed. Captured stderr from a live run:

```
perf_event_open(..., PERF_FLAG_FD_CLOEXEC) failed with unexpected error 1 (Operation not permitted)
perf_event_open(..., 0) failed unexpectedly with error 1 (Operation not permitted)
Error:
No permission to enable cycles:Pu event.
```

`EPERM` on `sys_perf_event_open()` means the kernel refused the syscall because the calling process doesn't hold `CAP_PERFMON` (Linux 5.8+) or `CAP_SYS_ADMIN`.

## Fix

Add `PERFMON` to the `cap_add` list. This is the narrow capability Linux 5.8+ added specifically for `perf_events` — preferred over `CAP_SYS_ADMIN`, which grants much broader privileges. Docker and containerd have both supported it since 19.03 / 1.4.

No other changes — existing file-permission caps (`CHOWN`/`DAC_OVERRIDE`/`FOWNER`/`SETGID`/`SETUID`) are unchanged.

## Impact on non-profiling containers

Containers running the non-profiling image get the extra cap too but don't exercise it (nothing in that image calls `perf_event_open`). Effectively a no-op for the default workflow.

## Test plan

- [x] `pytest merobox/tests/unit/test_docker_manager.py::test_docker_container_uses_cap_add_not_privileged` — PASSED (extended to assert PERFMON is in the list)
- [ ] Cut a merobox release, calimero-network/core picks it up via apt
- [ ] Fuzzy-load-test run in core: verify `fuzzy-kv-node-N/perf-fuzzy-kv-node-N.data` is present in the profiling-data artifact

## Related

- calimero-network/core#2217 — host-mount harvest (merged, artifacts now include runtime container data)
- calimero-network/core#2223 — `linux-tools-generic` fallback (merged)
- calimero-network/core#2224 — surfaces the real perf stderr (merged; that's how we diagnosed this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, additive Docker runtime capability change plus corresponding version/changelog/test updates. Main risk is slightly expanded container privileges, but it uses the narrow `PERFMON` capability rather than `SYS_ADMIN`.
> 
> **Overview**
> Enables `perf record` inside Merobox-managed containers by adding `PERFMON` to the Docker `cap_add` list (avoiding privileged mode and avoiding `CAP_SYS_ADMIN`).
> 
> Bumps the package to `0.5.2`, documents the fix in `CHANGELOG.md`, and updates the Docker manager unit test to assert `PERFMON` is included in the expected capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4700b1b81229e9943db404b30724e135b598948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->