### PR TITLE
chore(release): bump 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-23
+
 ### Added
 
 - 9 new workflow step types wrapping admin-API methods that

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
## Summary

Release bump for the work merged in [#209](https://github.com/calimero-network/merobox/pull/209) (close issue #205 — missing group admin-API step types).

- `merobox/__init__.py`: `0.5.2` → `0.6.0`.
- `CHANGELOG.md`: `[Unreleased]` → `[0.6.0] - 2026-04-23`.

## Why now

#209 landed 22 new step types + 2 example workflows + a new dependency floor on `calimero-client-py >= 0.6.3` (which itself requires `core 0.10.1-rc.31+`). That's substantive additive feature surface — minor bump fits under the SemVer-in-0.x convention this project uses.

## Why a follow-up PR instead of part of #209

The bump commit was prepared after #209 was already merged. Cleaner to cut it here than force-push over a merged PR.

## Version rationale

- `0.5.0`: breaking change (reparent_group replacing nest_group/unnest_group)
- `0.5.1`: tiny dep pin revert
- `0.5.2`: tiny CAP_PERFMON fix
- **`0.6.0`: 22 new step types, 2 new example workflows, new dependency floor** — additive feature surface expansion

## Test Plan

- [x] `merobox/__init__.py` diff is exactly the version-string change.
- [x] `CHANGELOG.md` entries preserved; only moved from `[Unreleased]` to `[0.6.0] - 2026-04-23`.
- [ ] Release Pipeline cuts `v0.6.0`, tags, and publishes to PyPI on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)