### PR TITLE
chore(release): bump 0.6.0 -> 0.6.1

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
## Summary

Patch bump to publish the additive `set_subgroup_visibility` step type added in #218 (mirroring [core#2256](https://github.com/calimero-network/core/issues/2256) / [core#2261](https://github.com/calimero-network/core/pull/2261) / [py-client#40](https://github.com/calimero-network/calimero-client-py/pull/40)).

Backward compat is preserved — the legacy `set_default_visibility` step type still dispatches to the same executor class — so this is a patch bump, not minor.

## Why publish now

Releasing this version unblocks core#2261's CI. Two matrix entries currently fail because the apt-installed merobox (`0.6.0-1`) doesn't know the new surface:

- `Test (group-capabilities)` — workflow uses `type: set_default_visibility`; published merobox calls the old route, but core#2261 removed it.
- `Test (group-subgroup-visibility-inheritance)` — new workflow added in core#2261 uses `type: set_subgroup_visibility`; published merobox doesn't know it.

This release picks up the renamed dispatcher and step class added in #218.

## What gets bundled

The PyInstaller binary built by the release pipeline pulls py-client from the git ref in `requirements.txt` (currently `@master`). py-client master exposes `client.set_subgroup_visibility(...)` calling the new core route `/admin-api/groups/{id}/settings/subgroup-visibility`.

No PyPI release of py-client is required — PyInstaller bakes the git-ref version into the merobox binary.

## Test plan

- [ ] `check-version` step detects the bump → triggers tag + apt publish + PyPI publish
- [ ] After apt repo updates, re-run core#2261's CI:
  - `Test (group-capabilities)` ✅
  - `Test (group-subgroup-visibility-inheritance)` ✅
- [ ] Follow-up cleanup (separate PRs) once core#2261 merges:
  - py-client: flip `Cargo.toml` from `branch = "impl/2256-subgroup-visibility"` back to `branch = "master"`.
  - merobox: flip `requirements.txt` from `@master` back to a PyPI version pin (whatever py-client publishes), bump `pyproject.toml` / `setup.py` floor to that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only changes the exported `__version__` string and does not modify runtime logic.
> 
> **Overview**
> Updates `merobox.__version__` from `0.6.0` to `0.6.1` to publish a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30a62b8524a0a1c4cc8e6ef64ed4fb5716e1b0cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->