### PR TITLE
feat: expose leave-context / leave / leave (namespace) commands

### DIFF
--- a/merobox/commands/group.py
+++ b/merobox/commands/group.py
@@ -314,9 +314,7 @@ def leave_context(context_id, node, verbose):
     """
     manager = DockerManager()
     rpc_url = get_node_rpc_url(node, manager)
-    console.print(
-        f"[blue]Leaving context {context_id} locally on node {node}[/blue]"
-    )
+    console.print(f"[blue]Leaving context {context_id} locally on node {node}[/blue]")
 
     result = run_async_function(call_admin_api, rpc_url, "leave_context", context_id)
 
@@ -335,9 +333,7 @@ def leave_context(context_id, node, verbose):
         if verbose:
             console.print(json_lib.dumps(result, indent=2))
     else:
-        console.print(
-            f"[red]✗ Failed to leave context: {result.get('error')}[/red]"
-        )
+        console.print(f"[red]✗ Failed to leave context: {result.get('error')}[/red]")
         sys.exit(1)
 
 

--- a/merobox/commands/group.py
+++ b/merobox/commands/group.py
@@ -302,6 +302,79 @@ def join_context(group_id, node, context_id, verbose):
         sys.exit(1)
 
 
+@group.command(name="leave-context")
+@click.argument("context_id")
+@click.option("--node", "-n", required=True, help="Node name")
+@click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
+def leave_context(context_id, node, verbose):
+    """Locally opt out of a context (no DAG op, no broadcast).
+
+    Stops sync and disarms auto-follow on this node only — peers do
+    not observe the leave. Reverse with `group join-context`.
+    """
+    manager = DockerManager()
+    rpc_url = get_node_rpc_url(node, manager)
+    console.print(
+        f"[blue]Leaving context {context_id} locally on node {node}[/blue]"
+    )
+
+    result = run_async_function(call_admin_api, rpc_url, "leave_context", context_id)
+
+    if result["success"]:
+        data = unwrap_api_response(result)
+        console.print(
+            "[green]✓ Left context locally (sync stopped, auto-follow disarmed)![/green]"
+        )
+        if isinstance(data, dict):
+            if "contextId" in data:
+                console.print(f"[cyan]Context ID: {data['contextId']}[/cyan]")
+            if "memberPublicKey" in data:
+                console.print(
+                    f"[cyan]Member Public Key: {data['memberPublicKey']}[/cyan]"
+                )
+        if verbose:
+            console.print(json_lib.dumps(result, indent=2))
+    else:
+        console.print(
+            f"[red]✗ Failed to leave context: {result.get('error')}[/red]"
+        )
+        sys.exit(1)
+
+
+@group.command(name="leave")
+@click.argument("group_id")
+@click.option("--node", "-n", required=True, help="Node name")
+@click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
+def leave(group_id, node, verbose):
+    """Voluntarily leave a group (publishes MemberLeft).
+
+    Rejected if you are the Owner (transfer ownership first), the only
+    admin (last-admin protection), or only an inherited member of an
+    Open subgroup (leave the parent that anchors your membership).
+    """
+    manager = DockerManager()
+    rpc_url = get_node_rpc_url(node, manager)
+    console.print(f"[blue]Leaving group {group_id} on node {node}[/blue]")
+
+    result = run_async_function(call_admin_api, rpc_url, "leave_group", group_id)
+
+    if result["success"]:
+        data = unwrap_api_response(result)
+        console.print("[green]✓ Left group (MemberLeft published)![/green]")
+        if isinstance(data, dict):
+            if "groupId" in data:
+                console.print(f"[cyan]Group ID: {data['groupId']}[/cyan]")
+            if "memberPublicKey" in data:
+                console.print(
+                    f"[cyan]Member Public Key: {data['memberPublicKey']}[/cyan]"
+                )
+        if verbose:
+            console.print(json_lib.dumps(result, indent=2))
+    else:
+        console.print(f"[red]✗ Failed to leave group: {result.get('error')}[/red]")
+        sys.exit(1)
+
+
 @group.command(name="subgroups")
 @click.argument("group_id")
 @click.option("--node", "-n", required=True, help="Node name")

--- a/merobox/commands/namespace.py
+++ b/merobox/commands/namespace.py
@@ -238,6 +238,48 @@ def join_namespace(namespace_id, invitation_json, node, verbose):
         console.print(json_lib.dumps(result, indent=2))
 
 
+@namespace.command(name="leave")
+@click.argument("namespace_id")
+@click.option("--node", "-n", required=True, help="Node name")
+@click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
+def leave_namespace(namespace_id, node, verbose):
+    """Voluntarily leave a namespace (cascades through descendant groups).
+
+    Publishes MemberLeft at the namespace root; the apply path cascades
+    through every descendant group where this node has a direct row.
+    Multi-scope owner + last-admin checks run upfront — rejected with
+    `MustTransferOwnership` if the leaver owns any group in the subtree.
+    """
+    manager = DockerManager()
+    rpc_url = get_node_rpc_url(node, manager)
+    console.print(f"[blue]Leaving namespace {namespace_id} on node {node}[/blue]")
+
+    result = run_async_function(
+        call_namespace_api,
+        rpc_url,
+        "leave_namespace",
+        namespace_id,
+        node_name=node,
+    )
+    if not result["success"]:
+        console.print(f"[red]✗ Failed to leave namespace: {result.get('error')}[/red]")
+        sys.exit(1)
+
+    console.print(
+        "[green]✓ Left namespace (cascade through descendants complete)![/green]"
+    )
+    data = unwrap_api_response(result)
+    if isinstance(data, dict):
+        if "namespaceId" in data:
+            console.print(f"[cyan]Namespace ID: {data['namespaceId']}[/cyan]")
+        if "memberPublicKey" in data:
+            console.print(
+                f"[cyan]Member Public Key: {data['memberPublicKey']}[/cyan]"
+            )
+    if verbose:
+        console.print(json_lib.dumps(result, indent=2))
+
+
 @namespace.command(name="groups")
 @click.argument("namespace_id")
 @click.option("--node", "-n", required=True, help="Node name")

--- a/merobox/commands/namespace.py
+++ b/merobox/commands/namespace.py
@@ -273,9 +273,7 @@ def leave_namespace(namespace_id, node, verbose):
         if "namespaceId" in data:
             console.print(f"[cyan]Namespace ID: {data['namespaceId']}[/cyan]")
         if "memberPublicKey" in data:
-            console.print(
-                f"[cyan]Member Public Key: {data['memberPublicKey']}[/cyan]"
-            )
+            console.print(f"[cyan]Member Public Key: {data['memberPublicKey']}[/cyan]")
     if verbose:
         console.print(json_lib.dumps(result, indent=2))
 


### PR DESCRIPTION
## Summary

Three new CLI commands wrapping the admin-API leave endpoints from [calimero-network/core#2280](https://github.com/calimero-network/core/pull/2280):

| Command | Behavior |
|---|---|
| \`merobox group leave-context <CONTEXT_ID> --node <node>\` | Local-only opt-out from a context (no DAG op). Stops sync + disarms auto-follow. |
| \`merobox group leave <GROUP_ID> --node <node>\` | Voluntary self-leave from a group. Publishes \`MemberLeft\`. Rejected if Owner / only-admin / inherited-only. |
| \`merobox namespace leave <NAMESPACE_ID> --node <node>\` | Voluntary self-leave from a namespace. Cascades through descendants. Rejected with \`MustTransferOwnership\` if leaver owns any subgroup. |

Each dispatches via the existing \`call_admin_api\` / \`call_namespace_api\` retry wrappers, which forward to the calimero-client-py methods. Output mirrors the join-context patterns: success message with key fields, JSON dump on \`--verbose\`.

## Blocked on

1. **[calimero-network/core#2280](https://github.com/calimero-network/core/pull/2280)** — adds the admin API endpoints + Rust client methods.
2. **[calimero-network/calimero-client-py#41](https://github.com/calimero-network/calimero-client-py/pull/41)** — exposes the methods to Python (depends on #1).

Once both merge and a new \`calimero-client-py\` is released, merobox picks up the methods automatically via its pinned dependency. Marked as draft until then.

## Test plan

- [ ] After core#2280 + calimero-client-py#41 merge and a new calimero-client-py is published, the three commands work against a running node.
- [ ] \`merobox group leave-context <ctx> --node <n>\` reports success with marker written + identity row deleted.
- [ ] \`merobox group leave <gid> --node <n>\` rejects when run as Owner with a clear error message.
- [ ] \`merobox namespace leave <nsid> --node <n>\` cascades through subgroups; rejects with \`MustTransferOwnership\` when leaver owns subgroups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new CLI wrappers around existing client API methods with standard error handling and output, without changing core logic or data processing in merobox.
> 
> **Overview**
> Adds three new CLI commands: `group leave-context` (local-only context opt-out), `group leave` (publishes `MemberLeft` to leave a group), and `namespace leave` (leaves a namespace and cascades through descendant groups).
> 
> Each command calls the corresponding admin/namespace API method via the existing async/retry wrappers and prints key IDs plus optional full JSON output via `--verbose`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3350d2999e06c96a1f254dc942aa3dbf0af759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->