### PR TITLE
fix(auth): bypass forward-auth for CORS preflight (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.9] - 2026-05-09
+
+### Fixed
+
+- `auth_service: true` no longer breaks CORS preflight on `/admin-api`,
+  `/jsonrpc`, `/ws`, and `/sse`. The Traefik forward-auth middleware was
+  rejecting `OPTIONS` preflights (browsers don't send `Authorization`
+  on preflights) and the resulting auth-service response lacked
+  `Access-Control-Allow-*` headers, so cross-origin browser clients
+  could not reach a node fronted by the auth proxy. Per-node
+  `*-preflight` routers now match `Method(`OPTIONS`)` at priority 300
+  and apply only the CORS headers middleware, skipping forward-auth.
+  Resolves [#228](https://github.com/calimero-network/merobox/issues/228).
+
 ## [0.6.8] - 2026-05-07
 
 ### Changed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -543,6 +543,25 @@ class DockerManager(CleanupMixin):
                     f"traefik.http.routers.{node_name}-sse.entrypoints": "web",
                     f"traefik.http.routers.{node_name}-sse.service": f"{node_name}-core",
                     f"traefik.http.routers.{node_name}-sse.middlewares": f"cors-sse-{node_name},auth-{node_name}",
+                    # CORS preflight bypass: browsers don't send Authorization on
+                    # OPTIONS, so forward-auth would 401 the preflight and the
+                    # response would lack Access-Control-Allow-* headers. Route
+                    # OPTIONS through CORS-only middleware at higher priority.
+                    f"traefik.http.routers.{node_name}-api-preflight.rule": f"Host(`{hostname}.127.0.0.1.nip.io`) && Method(`OPTIONS`) && (PathPrefix(`/jsonrpc`) || PathPrefix(`/admin-api/`))",
+                    f"traefik.http.routers.{node_name}-api-preflight.entrypoints": "web",
+                    f"traefik.http.routers.{node_name}-api-preflight.service": f"{node_name}-core",
+                    f"traefik.http.routers.{node_name}-api-preflight.middlewares": cors_middleware_name,
+                    f"traefik.http.routers.{node_name}-api-preflight.priority": "300",
+                    f"traefik.http.routers.{node_name}-ws-preflight.rule": f"Host(`{hostname}.127.0.0.1.nip.io`) && Method(`OPTIONS`) && PathPrefix(`/ws`)",
+                    f"traefik.http.routers.{node_name}-ws-preflight.entrypoints": "web",
+                    f"traefik.http.routers.{node_name}-ws-preflight.service": f"{node_name}-core",
+                    f"traefik.http.routers.{node_name}-ws-preflight.middlewares": cors_middleware_name,
+                    f"traefik.http.routers.{node_name}-ws-preflight.priority": "300",
+                    f"traefik.http.routers.{node_name}-sse-preflight.rule": f"Host(`{hostname}.127.0.0.1.nip.io`) && Method(`OPTIONS`) && PathPrefix(`/sse`)",
+                    f"traefik.http.routers.{node_name}-sse-preflight.entrypoints": "web",
+                    f"traefik.http.routers.{node_name}-sse-preflight.service": f"{node_name}-core",
+                    f"traefik.http.routers.{node_name}-sse-preflight.middlewares": f"cors-sse-{node_name}",
+                    f"traefik.http.routers.{node_name}-sse-preflight.priority": "300",
                     # Admin dashboard (publicly accessible)
                     f"traefik.http.routers.{node_name}-dashboard.rule": f"Host(`{hostname}.127.0.0.1.nip.io`) && PathPrefix(`/admin-dashboard`)",
                     f"traefik.http.routers.{node_name}-dashboard.entrypoints": "web",


### PR DESCRIPTION
## Summary

- Adds per-node `*-preflight` Traefik routers that match `Method(\`OPTIONS\`)` at priority 300 with only the CORS headers middleware (no forward-auth) — so browser preflights succeed when `auth_service: true`
- Bumps `0.6.8 → 0.6.9` and adds a CHANGELOG entry

Resolves #228.

## Why

The Traefik label chain `cors-{node},auth-{node}` looks correct on paper, but the CORS middleware is just a `headers` middleware (`accesscontrolalloworiginlist` etc.) — it only mutates response headers and does **not** short-circuit `OPTIONS`. Forward-auth then runs against the preflight, sees no `Authorization` (browsers don't send one on OPTIONS), forwards to `/auth/validate`, and returns the auth-service's 401/403 — which has no `Access-Control-Allow-*` headers. The browser blocks the actual request.

Hit while wiring up Playwright integration tests for the battleships app ([calimero-network/battleships#39](https://github.com/calimero-network/battleships/pull/39)). The same wall affects any production deployment fronting a merod node with the auth proxy and serving the UI from a different origin (`https://app.example.com` → `https://node.example.com`).

## Approach

Per-node OPTIONS-only routers are added next to the existing protected routers:

```python
f"traefik.http.routers.{node_name}-api-preflight.rule":
    f"Host(`{hostname}.127.0.0.1.nip.io`) && Method(`OPTIONS`) && (PathPrefix(`/jsonrpc`) || PathPrefix(`/admin-api/`))",
f"traefik.http.routers.{node_name}-api-preflight.middlewares": cors_middleware_name,
f"traefik.http.routers.{node_name}-api-preflight.priority": "300",
# …same shape for -ws-preflight and -sse-preflight
```

The OPTIONS request reaches merod, which responds 204 with permissive CORS (`CorsLayer::new().allow_origin(Any)` in `core/crates/server/src/lib.rs`); the Traefik headers middleware then overrides `Access-Control-Allow-Origin` with the configured allowlist. Existing non-OPTIONS routers are unchanged.

## Test plan

- [x] Python syntax check (`ast.parse`)
- [x] `ruff check merobox/commands/manager.py` — All checks passed
- [x] Visual confirmation that all 3 preflight routers (`-api`, `-ws`, `-sse`) carry: rule, entrypoints, service, middlewares, priority — no other label modified
- [ ] End-to-end: pull this branch, run a 2-node workflow with `auth_service: true`, mint a JWT via `/auth/token`, then `fetch('http://node1.127.0.0.1.nip.io/admin-api/contexts', { headers: { Authorization: 'Bearer …' } })` from `http://localhost:5173` — should return 200 (was CORS-blocked on master)

## Notes

- The fix is additive — three new routers per node. Doesn't touch `-api`, `-ws`, `-sse`, `-dashboard`, or `-auth` routers, the forward-auth middleware definition, or the CORS headers middleware definitions.
- The `-dashboard` and `-auth` routers don't use forward-auth, so they don't need preflight bypass.
- Pairs naturally with the existing battleships PR #39 — once a 0.6.9 release is cut, the workflow there can re-enable `auth_service: true` and drop its localhost-port workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Traefik routing around authenticated endpoints by bypassing `forwardAuth` for `OPTIONS` requests; misconfiguration could unintentionally change request handling for preflight or routing priority.
> 
> **Overview**
> Fixes cross-origin browser access when `auth_service: true` by adding per-node Traefik `*-preflight` routers that match `Method(`OPTIONS`)` for `/admin-api`, `/jsonrpc`, `/ws`, and `/sse` and apply only the CORS headers middleware (skipping `forwardAuth`) at higher priority.
> 
> Bumps the package version to `0.6.9` and documents the fix in `CHANGELOG.md` (resolves `#228`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b6d8cad4d0c5ae710989a65a102f77b0172882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->