### PR TITLE
fix: honor `stop_all_nodes: false` past process exit (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `stop_all_nodes: false` (also the default) now actually leaves nodes running
+  after `merobox bootstrap run` exits. Previously the manager's `atexit` handler
+  unconditionally tore down every container it had started, so the "Step 5:
+  Leaving nodes running" path was immediately undone on process exit — the only
+  workaround was to background the run and `kill -9` it before `atexit` could
+  fire. The bootstrap executor now calls `manager.keep_resources_on_exit()` when
+  `stop_all_nodes` is falsy, suppressing the `atexit` teardown (SIGINT/SIGTERM
+  cleanup is unchanged — interrupting a run still stops the nodes). Resolves
+  [#227](https://github.com/calimero-network/merobox/issues/227).
 - Multi-node clusters now wire up static bootstrap peers instead of depending on
   mDNS-only discovery over Docker's default bridge. When 2+ nodes are started
   (and `MEROBOX_LEGACY_CLUSTER_NETWORKING` is not set), merobox now: (1) attaches

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -252,6 +252,13 @@ class WorkflowExecutor:
             stop_all_nodes = self.config.get("stop_all_nodes", False)
             nuke_on_end = self.config.get("nuke_on_end", False)
 
+            # A workflow that leaves nodes running (stop_all_nodes: false, which
+            # is also the default) must actually do so: the manager's atexit
+            # handler would otherwise tear every container/process down the
+            # moment `merobox bootstrap run` exits. See merobox#227.
+            if self.manager is not None and not stop_all_nodes:
+                self.manager.keep_resources_on_exit()
+
             # Steps 1-3: Local node management (skip if remote-only mode)
             if has_local_nodes:
                 # Step 1: Restart nodes if requested (at beginning)

--- a/merobox/commands/cleanup_mixin.py
+++ b/merobox/commands/cleanup_mixin.py
@@ -55,6 +55,11 @@ class CleanupMixin(ABC):
         self._cleanup_done = False
         self._original_sigint_handler = None
         self._original_sigterm_handler = None
+        # When True, the atexit handler skips resource teardown so managed
+        # containers/processes outlive the merobox process. Set via
+        # keep_resources_on_exit() — used for `stop_all_nodes: false` workflows.
+        # Signal-triggered cleanup (SIGINT/SIGTERM) is unaffected.
+        self._keep_resources_on_exit = False
 
     def _setup_signal_handlers(self):
         """Register signal handlers for graceful shutdown."""
@@ -93,10 +98,33 @@ class CleanupMixin(ABC):
     def _cleanup_on_exit(self):
         """Cleanup handler for atexit.
 
-        Calls _cleanup_resources unconditionally since it's idempotent and
-        will return immediately if cleanup was already done or is in progress.
+        Skips teardown entirely when keep_resources_on_exit() was requested
+        (e.g. a ``stop_all_nodes: false`` workflow wants the nodes to outlive
+        the run). Otherwise calls _cleanup_resources, which is idempotent and
+        returns immediately if cleanup was already done or is in progress.
         """
+        if self._keep_resources_on_exit:
+            return
         self._cleanup_resources()
+
+    def keep_resources_on_exit(self, keep: bool = True) -> None:
+        """Control whether the atexit handler tears down managed resources.
+
+        ``merobox bootstrap run`` exits as soon as the workflow finishes, which
+        fires the registered ``atexit`` handler and stops every container/process
+        this manager started. Workflows that set ``stop_all_nodes: false`` (the
+        default) want the nodes to keep running afterwards — e.g. to hand off to
+        a separate test runner — so the bootstrap executor calls this to
+        suppress the atexit teardown.
+
+        This does not affect the SIGINT/SIGTERM handlers: interrupting a run
+        still stops the managed resources.
+
+        Args:
+            keep: If True, the atexit handler becomes a no-op. If False,
+                restores the default teardown-on-exit behaviour.
+        """
+        self._keep_resources_on_exit = keep
 
     def _cleanup_resources_guarded(self, cleanup_fn, *args, **kwargs) -> CleanupResult:
         """Execute cleanup function with thread-safe guards.

--- a/merobox/tests/unit/test_docker_manager.py
+++ b/merobox/tests/unit/test_docker_manager.py
@@ -310,6 +310,72 @@ def test_docker_manager_cleanup_returns_in_progress_when_flag_set(mock_docker):
 
 
 # ============================================================================
+# keep_resources_on_exit (merobox#227)
+# ============================================================================
+
+
+@patch("docker.from_env")
+def test_cleanup_on_exit_tears_down_by_default(mock_docker):
+    """By default the atexit handler stops every managed container."""
+    client = MagicMock()
+    mock_docker.return_value = client
+
+    manager = DockerManager(enable_signal_handlers=False)
+    mock_container = MagicMock()
+    manager.nodes = {"node1": mock_container}
+
+    manager._cleanup_on_exit()
+
+    assert mock_container.stop.call_count == 1
+    assert manager.nodes == {}
+
+
+@patch("docker.from_env")
+def test_keep_resources_on_exit_skips_atexit_teardown(mock_docker):
+    """keep_resources_on_exit() makes the atexit handler a no-op.
+
+    Regression test for merobox#227: `stop_all_nodes: false` must actually
+    leave the nodes running once `merobox bootstrap run` exits.
+    """
+    client = MagicMock()
+    mock_docker.return_value = client
+
+    manager = DockerManager(enable_signal_handlers=False)
+    mock_container = MagicMock()
+    manager.nodes = {"node1": mock_container}
+
+    manager.keep_resources_on_exit()
+    manager._cleanup_on_exit()
+
+    assert mock_container.stop.call_count == 0
+    assert manager.nodes == {"node1": mock_container}
+
+    # ...and flipping it back restores the default teardown.
+    manager.keep_resources_on_exit(False)
+    manager._cleanup_on_exit()
+    assert mock_container.stop.call_count == 1
+    assert manager.nodes == {}
+
+
+@patch("docker.from_env")
+def test_keep_resources_on_exit_does_not_block_signal_cleanup(mock_docker):
+    """keep_resources_on_exit() only suppresses atexit, not SIGINT/SIGTERM."""
+    client = MagicMock()
+    mock_docker.return_value = client
+
+    manager = DockerManager(enable_signal_handlers=False)
+    mock_container = MagicMock()
+    manager.nodes = {"node1": mock_container}
+
+    manager.keep_resources_on_exit()
+    # An explicit cleanup (what the signal handler invokes) still runs.
+    result = manager._cleanup_resources()
+
+    assert result == CleanupResult.PERFORMED
+    assert mock_container.stop.call_count == 1
+
+
+# ============================================================================
 # Graceful shutdown tests
 # ============================================================================
 

--- a/merobox/tests/unit/test_executor_lifecycle.py
+++ b/merobox/tests/unit/test_executor_lifecycle.py
@@ -5,71 +5,113 @@ false``, also the default) must suppress the manager's atexit teardown so the
 nodes survive ``merobox bootstrap run`` exiting.
 """
 
-import asyncio
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from merobox.commands.bootstrap.run.executor import WorkflowExecutor
 
+# Sentinel: "build a default MagicMock manager" — distinct from manager=None,
+# which is a meaningful value (remote-only runs have no manager).
+_AUTO = object()
 
-def _make_executor(config, manager=...):
-    if manager is ...:
+
+def _make_executor(config, manager=_AUTO):
+    if manager is _AUTO:
         manager = MagicMock()
         manager.binary_path = None  # exercise the Docker-mode path
     return WorkflowExecutor(config, manager), manager
 
 
-def _run_with_stubs(executor):
-    """Run execute_workflow() with all node-management I/O stubbed out."""
-    with (
-        patch.object(executor, "_setup_resolver"),
-        patch.object(executor, "_has_local_nodes", return_value=True),
-        patch.object(executor, "_has_remote_nodes", return_value=False),
-        patch.object(executor, "_start_nodes", new=AsyncMock(return_value=True)),
+def _stub_node_io(executor, *, has_local_nodes=True, steps_ok=True):
+    """Stub out all node-management I/O so execute_workflow() runs offline."""
+    stack = ExitStack()
+    stack.enter_context(patch.object(executor, "_setup_resolver"))
+    stack.enter_context(
+        patch.object(executor, "_has_local_nodes", return_value=has_local_nodes)
+    )
+    stack.enter_context(
+        patch.object(executor, "_has_remote_nodes", return_value=not has_local_nodes)
+    )
+    stack.enter_context(
         patch.object(
-            executor, "_wait_for_nodes_ready", new=AsyncMock(return_value=True)
-        ),
-        patch.object(
-            executor, "_execute_workflow_steps", new=AsyncMock(return_value=True)
-        ),
-    ):
-        return asyncio.run(executor.execute_workflow())
+            executor, "_execute_workflow_steps", new=AsyncMock(return_value=steps_ok)
+        )
+    )
+    if has_local_nodes:
+        stack.enter_context(
+            patch.object(executor, "_start_nodes", new=AsyncMock(return_value=True))
+        )
+        stack.enter_context(
+            patch.object(
+                executor, "_wait_for_nodes_ready", new=AsyncMock(return_value=True)
+            )
+        )
+    return stack
 
 
-def test_keep_resources_on_exit_called_when_nodes_left_running():
+@pytest.mark.asyncio
+async def test_keep_resources_on_exit_called_when_nodes_left_running():
     executor, manager = _make_executor(
         {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": False}
     )
 
-    assert _run_with_stubs(executor) is True
+    with _stub_node_io(executor):
+        assert await executor.execute_workflow() is True
+
     manager.keep_resources_on_exit.assert_called_once()
+    manager.stop_all_nodes.assert_not_called()
 
 
-def test_keep_resources_on_exit_called_by_default():
+@pytest.mark.asyncio
+async def test_keep_resources_on_exit_called_by_default():
     # `stop_all_nodes` omitted -> defaults to leaving nodes running.
     executor, manager = _make_executor({"name": "wf", "nodes": {"count": 1}})
 
-    assert _run_with_stubs(executor) is True
+    with _stub_node_io(executor):
+        assert await executor.execute_workflow() is True
+
     manager.keep_resources_on_exit.assert_called_once()
 
 
-def test_keep_resources_on_exit_not_called_when_stopping_nodes():
+@pytest.mark.asyncio
+async def test_stop_all_nodes_true_keeps_atexit_and_stops_nodes_at_step5():
     executor, manager = _make_executor(
         {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": True}
     )
 
-    assert _run_with_stubs(executor) is True
+    with _stub_node_io(executor):
+        assert await executor.execute_workflow() is True
+
     manager.keep_resources_on_exit.assert_not_called()
+    # Step 5 explicitly tears the nodes down when stop_all_nodes is true.
+    manager.stop_all_nodes.assert_called_once()
 
 
-def test_remote_only_workflow_has_no_manager_to_keep():
+@pytest.mark.asyncio
+async def test_keep_resources_on_exit_persists_when_workflow_fails():
+    # A failed workflow with `stop_all_nodes: false` still leaves the nodes
+    # running (useful for inspecting what went wrong) — consistent with
+    # _stop_nodes_on_failure() already being gated on `stop_all_nodes`. The
+    # atexit suppression is intentionally *not* reverted on failure.
+    executor, manager = _make_executor(
+        {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": False}
+    )
+
+    with _stub_node_io(executor, steps_ok=False):
+        with patch.object(executor, "_stop_nodes_on_failure") as stop_on_failure:
+            assert await executor.execute_workflow() is False
+
+    manager.keep_resources_on_exit.assert_called_once()
+    stop_on_failure.assert_not_called()
+    manager.stop_all_nodes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remote_only_workflow_has_no_manager_to_keep():
     # manager is None for remote-only runs; execute_workflow must not blow up.
     executor, _ = _make_executor({"name": "wf", "remote_nodes": {}}, manager=None)
-    with (
-        patch.object(executor, "_setup_resolver"),
-        patch.object(executor, "_has_local_nodes", return_value=False),
-        patch.object(executor, "_has_remote_nodes", return_value=True),
-        patch.object(
-            executor, "_execute_workflow_steps", new=AsyncMock(return_value=True)
-        ),
-    ):
-        assert asyncio.run(executor.execute_workflow()) is True
+
+    with _stub_node_io(executor, has_local_nodes=False):
+        assert await executor.execute_workflow() is True

--- a/merobox/tests/unit/test_executor_lifecycle.py
+++ b/merobox/tests/unit/test_executor_lifecycle.py
@@ -1,0 +1,75 @@
+"""Lifecycle behaviour of WorkflowExecutor.execute_workflow().
+
+Focused on merobox#227: a workflow that leaves nodes running (``stop_all_nodes:
+false``, also the default) must suppress the manager's atexit teardown so the
+nodes survive ``merobox bootstrap run`` exiting.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from merobox.commands.bootstrap.run.executor import WorkflowExecutor
+
+
+def _make_executor(config, manager=...):
+    if manager is ...:
+        manager = MagicMock()
+        manager.binary_path = None  # exercise the Docker-mode path
+    return WorkflowExecutor(config, manager), manager
+
+
+def _run_with_stubs(executor):
+    """Run execute_workflow() with all node-management I/O stubbed out."""
+    with (
+        patch.object(executor, "_setup_resolver"),
+        patch.object(executor, "_has_local_nodes", return_value=True),
+        patch.object(executor, "_has_remote_nodes", return_value=False),
+        patch.object(executor, "_start_nodes", new=AsyncMock(return_value=True)),
+        patch.object(
+            executor, "_wait_for_nodes_ready", new=AsyncMock(return_value=True)
+        ),
+        patch.object(
+            executor, "_execute_workflow_steps", new=AsyncMock(return_value=True)
+        ),
+    ):
+        return asyncio.run(executor.execute_workflow())
+
+
+def test_keep_resources_on_exit_called_when_nodes_left_running():
+    executor, manager = _make_executor(
+        {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": False}
+    )
+
+    assert _run_with_stubs(executor) is True
+    manager.keep_resources_on_exit.assert_called_once()
+
+
+def test_keep_resources_on_exit_called_by_default():
+    # `stop_all_nodes` omitted -> defaults to leaving nodes running.
+    executor, manager = _make_executor({"name": "wf", "nodes": {"count": 1}})
+
+    assert _run_with_stubs(executor) is True
+    manager.keep_resources_on_exit.assert_called_once()
+
+
+def test_keep_resources_on_exit_not_called_when_stopping_nodes():
+    executor, manager = _make_executor(
+        {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": True}
+    )
+
+    assert _run_with_stubs(executor) is True
+    manager.keep_resources_on_exit.assert_not_called()
+
+
+def test_remote_only_workflow_has_no_manager_to_keep():
+    # manager is None for remote-only runs; execute_workflow must not blow up.
+    executor, _ = _make_executor({"name": "wf", "remote_nodes": {}}, manager=None)
+    with (
+        patch.object(executor, "_setup_resolver"),
+        patch.object(executor, "_has_local_nodes", return_value=False),
+        patch.object(executor, "_has_remote_nodes", return_value=True),
+        patch.object(
+            executor, "_execute_workflow_steps", new=AsyncMock(return_value=True)
+        ),
+    ):
+        assert asyncio.run(executor.execute_workflow()) is True


### PR DESCRIPTION
## Summary

Fixes #227. `merobox bootstrap run` exits as soon as the workflow finishes, which fires the manager's `atexit` handler and stops **every** container/process it started — unconditionally. So `stop_all_nodes: false` (also the default) printed `Step 5: Leaving nodes running` and then the containers got torn down anyway on process exit. The only workaround was to background the run and `kill -9` it before `atexit` could fire (see calimero-network/battleships#39).

## Change

- **`CleanupMixin.keep_resources_on_exit(keep=True)`** — sets a flag that makes `_cleanup_on_exit()` (the `atexit` handler) a no-op. SIGINT/SIGTERM cleanup is **unaffected** — an interrupted run still stops the nodes; only normal-exit teardown is suppressed.
- **`WorkflowExecutor.execute_workflow()`** — calls `manager.keep_resources_on_exit()` whenever `stop_all_nodes` is falsy and a local manager exists, so a workflow that asks to leave nodes running actually does (e.g. to hand off to Playwright / another test runner). Applies to both Docker and binary mode (shared `CleanupMixin`).

This matches the issue's suggested option 2. I chose to suppress the teardown whenever `stop_all_nodes` is falsy (not just on success) — it's consistent with the existing `_stop_nodes_on_failure` gating, and for a testing tool, leaving nodes up after a *failed* setup workflow is useful for inspection.

## Tests

- `test_docker_manager.py`: atexit tears down by default; `keep_resources_on_exit()` makes the atexit handler a no-op (and flipping it back restores teardown); it does not block explicit/signal-driven cleanup.
- `test_executor_lifecycle.py` (new): `keep_resources_on_exit` is called when `stop_all_nodes: false`, called by default, **not** called when `stop_all_nodes: true`, and remote-only (`manager=None`) doesn't error.

## Blast radius

CI's `run_with_retry.sh` and the `test-merobox-integration` job both run `merobox stop --all` + `merobox nuke -f` afterward, and the `merobox.testing` fixtures have their own teardown — so leaving nodes running until process exit doesn't leak containers in CI. No version bump (sits in `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-exit cleanup behavior for managed containers/processes, which could cause unexpected resource retention if misused, but is gated behind `stop_all_nodes` and keeps SIGINT/SIGTERM cleanup intact.
> 
> **Overview**
> Fixes `merobox bootstrap run` so workflows that set **`stop_all_nodes: false` (default)** actually leave nodes running after the command exits by suppressing the manager’s `atexit` teardown via a new `CleanupMixin.keep_resources_on_exit()` flag.
> 
> Adds unit coverage for the new atexit-suppression behavior in `DockerManager` and a new lifecycle-focused `WorkflowExecutor` test suite to ensure the flag is applied by default/when `stop_all_nodes` is falsy, not applied when `stop_all_nodes: true`, and safe for remote-only runs (`manager=None`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803e33e6b86a77e5cd13ae10c859dd490459a562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->