### PR TITLE
chore(release): bump 0.6.9 → 0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.10] - 2026-05-12
+
+### Added
+
+- `--merod-args` flag for `merobox bootstrap run` (binary / `--no-docker` mode
+  only): forwards arbitrary arguments to each `merod run` invocation, e.g.
+  `--merod-args="--sync-strategy delta --state-sync-strategy hash"`. Parsed with
+  `shlex.split()`, ignored (with a warning) outside `--no-docker` mode, and
+  threaded through both individual and count-based / `restart: true` node
+  starts.
+- `stop_node` and `start_node` workflow steps for mid-workflow node lifecycle
+  control (benchmarking, failure/recovery testing, freeing resources). Each
+  accepts a single node name or a list. `stop_node` is idempotent for
+  already-stopped nodes; `start_node` reuses the workflow's `nodes:` config, is
+  idempotent for already-running nodes, and supports an optional readiness wait
+  (`wait_for_ready`, default `true` — a timeout fails the step — and
+  `wait_timeout`, default 30s) that connects to the RPC port and probes the
+  admin health endpoint. Resolves
+  [#143](https://github.com/calimero-network/merobox/pull/143).
+
 ### Fixed
 
 - `stop_all_nodes: false` (also the default) now actually leaves nodes running

--- a/LLM.md
+++ b/LLM.md
@@ -171,6 +171,10 @@ merobox bootstrap validate workflow.yml
 
 # Create a sample workflow
 merobox bootstrap create-sample
+
+# Pass extra arguments straight to `merod run` (binary mode only)
+merobox bootstrap run workflow.yml --no-docker --binary-path ./merod \
+  --merod-args="--sync-strategy delta --state-sync-strategy hash"
 ```
 
 ## Workflow YAML Structure
@@ -576,6 +580,33 @@ Join a context using an open invitation.
   outputs:
     joined_context_id: "contextId"
     member_public_key: "memberPublicKey"
+```
+
+#### Stop Node Step
+
+Stop one or more running nodes mid-workflow (useful for benchmarking, failure
+testing, or freeing resources). Local nodes only; remote nodes can't be stopped.
+Already-stopped nodes are handled gracefully.
+
+```yaml
+- type: stop_node
+  nodes: calimero-node-1        # single node, or a list:
+  # nodes:
+  #   - calimero-node-1
+  #   - calimero-node-2
+```
+
+#### Start Node Step
+
+(Re)start one or more nodes mid-workflow, using their configuration from the
+workflow's `nodes:` section. Idempotent — a node that's already running is left
+alone.
+
+```yaml
+- type: start_node
+  nodes: calimero-node-1        # single node, or a list
+  wait_for_ready: true          # default true; fails the step on timeout
+  wait_timeout: 30              # seconds, default 30
 ```
 
 ## Variable Substitution
@@ -1180,7 +1211,8 @@ merobox blob delete --node <node> --blob-id <id>   # Delete blob
 
 # Workflow step types
 install_application, create_context, create_identity, join_context, call, wait,
-repeat, script, assert, json_assert, upload_blob, invite_open, join_open, fuzzy_test
+repeat, script, assert, json_assert, upload_blob, invite_open, join_open, fuzzy_test,
+stop_node, start_node
 
 # Workflow configuration options
 auth_service, config_path, nuke_on_start, nuke_on_end, force_pull_image,

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.9"
+__version__ = "0.6.10"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Cuts the **0.6.10** release.

## What's in 0.6.10

**Added** (#143)
- `--merod-args` flag for `merobox bootstrap run` (binary / `--no-docker` mode only) — forwards arbitrary args to each `merod run`, e.g. `--merod-args="--sync-strategy delta --state-sync-strategy hash"`. Threaded through both individual and count-based / `restart: true` starts.
- `stop_node` / `start_node` workflow steps for mid-workflow node lifecycle control. Single node or list; `stop_node` idempotent for already-stopped nodes; `start_node` reuses the workflow `nodes:` config, idempotent for already-running nodes, optional readiness wait (`wait_for_ready` default `true` — timeout fails the step — and `wait_timeout` default 30s) that probes the admin health endpoint.

**Fixed** (already merged, was sitting in `[Unreleased]`)
- `stop_all_nodes: false` now actually leaves nodes running past process exit — #227
- Deterministic static-bootstrap-peer wiring for multi-node clusters (no more mDNS-only-over-default-bridge) — #231
- `merobox health` peer-count parsing

**CI** — node-container log capture artifacts on the Docker/integration jobs.

## Changes in this PR
- `merobox/__init__.py`: `0.6.9` → `0.6.10` (the single version source; `pyproject.toml` reads it dynamically).
- `CHANGELOG.md`: moved the `[Unreleased]` entries under `## [0.6.10] - 2026-05-12`, added the #143 features under `### Added`, fresh empty `[Unreleased]` on top.
- `LLM.md`: documented the `stop_node` / `start_node` steps and the `--merod-args` flag.

The `architecture/*.html` reference docs aren't touched here — the `update-docs` automation regenerates those on merge (per the doc-review bot note on #143).

Merging this to `master` triggers `release.yml` → tags `v0.6.10`, builds the binaries/`.deb`, publishes to PyPI and the APT repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the version constant and documentation/changelog; no runtime logic changes are included in the diff.
> 
> **Overview**
> Bumps Merobox’s version to `0.6.10` and rolls release notes into `CHANGELOG.md` under a new `0.6.10` section.
> 
> Updates `LLM.md` to document the new `--merod-args` option for binary-mode workflow runs and the `stop_node`/`start_node` workflow step types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786993c69f66039ccd2374126f6e072920f6c715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->