### PR TITLE
fix(workflow): grant CAN_MANAGE_METADATA at the subgroup it targets

### DIFF
--- a/workflow-examples/workflow-group-metadata-example.yml
+++ b/workflow-examples/workflow-group-metadata-example.yml
@@ -207,11 +207,15 @@ steps:
       attempted: 'true'
     expected_failure: true
 
-  # Grant CAN_MANAGE_METADATA to node 2 in the namespace.
+  # Grant CAN_MANAGE_METADATA to node 2 on the subgroup it will modify.
+  # Core does not propagate non-admin governance capabilities across the
+  # namespace→subgroup boundary (see
+  # crates/context/src/group_store/permission_checker.rs::is_authorized_with_capability),
+  # so the bit must be granted directly on {{sub}}, not on the parent {{ns}}.
   - name: Grant Node 2 CAN_MANAGE_METADATA
     type: set_member_capabilities
     node: calimero-node-1
-    group_id: '{{ns}}'
+    group_id: '{{sub}}'
     member_id: '{{node2_id}}'
     # CAN_MANAGE_METADATA = 1 << 8 = 256
     # (calimero-network/core: crates/context/config/src/lib.rs,
@@ -220,7 +224,7 @@ steps:
 
   - name: Wait for Capability Sync
     type: wait_for_sync
-    group_id: '{{ns}}'
+    group_id: '{{sub}}'
     nodes:
       - calimero-node-1
       - calimero-node-2


### PR DESCRIPTION
## Summary
- Fixes the long-standing `Docker (group-metadata-example)` and `Binary (group-metadata-example)` failures on master (red since #235 landed).
- The workflow granted `CAN_MANAGE_METADATA` on the parent namespace `{{ns}}` and then tried to exercise the cap on the subgroup `{{sub}}`. core does **not** cascade non-admin governance capabilities across the namespace→subgroup boundary — only admin status crosses parents — so node-2 got the bit on the namespace but was still denied on the subgroup. Surface error: `set_group_metadata failed on calimero-node-2`.
- One-file YAML change: move the grant (and the subsequent `wait_for_sync`) to `{{sub}}`, which matches core's contract in `crates/context/src/group_store/permission_checker.rs::is_authorized_with_capability` and the unit-test pattern in `group_store/tests.rs::permission_checker_can_manage_metadata` (cap and target are always the same `gid`).

## Why not fix core instead
Considered, but the inheritance model is intentional: admin status cascades, governance capability bits don't. The relevant comment in `permission_checker.rs` is explicit:

> Non-admin inherited members do **not** inherit governance capabilities … Subgroup admins must grant governance capabilities explicitly at the subgroup level for non-admin parent members.

If we wanted namespace-level scoping for `CAN_MANAGE_METADATA` specifically, that's a core-side design discussion, not a workflow fix.

## Test plan
- [ ] CI: `Binary (group-metadata-example)` and `Docker (group-metadata-example)` go green
- [ ] No regressions on the other workflow examples
- [x] Diff is two `group_id` value swaps + a clarifying comment block — no schema/step changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small YAML workflow adjustment and clarifying comment; no production code changes, just test/example behavior.
> 
> **Overview**
> Updates `workflow-group-metadata-example.yml` so the `CAN_MANAGE_METADATA` capability grant (and subsequent `wait_for_sync`) targets the subgroup `{{sub}}` instead of the parent namespace `{{ns}}`, ensuring node 2 can successfully set subgroup metadata after the grant.
> 
> Adds a short comment explaining the namespace→subgroup capability non-propagation assumption and why the grant must be scoped to the subgroup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc1990f25ed5b754f59880d2de7baf6ebfeebd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->