### PR TITLE
fix: use automatic upgrade policy in group upgrade workflow

### DIFF
--- a/workflow-examples/workflow-group-upgrade-example.yml
+++ b/workflow-examples/workflow-group-upgrade-example.yml
@@ -76,12 +76,12 @@ steps:
     type: wait
     seconds: 5
 
-  # Phase 3: Set upgrade policy to coordinated (synchronous upgrade)
-  - name: Set Upgrade Policy to Coordinated
+  # Phase 3: Set upgrade policy to automatic
+  - name: Set Upgrade Policy to Automatic
     type: update_group_settings
     node: calimero-node-1
     group_id: '{{group_id}}'
-    upgrade_policy: coordinated
+    upgrade_policy: automatic
 
   # Phase 4: Initiate upgrade v1 -> v2
   - name: Upgrade Subgroup Application to v2


### PR DESCRIPTION
## Summary
- Changes `upgrade_policy` from `coordinated` to `automatic` in `workflow-group-upgrade-example.yml`
- `coordinated` was causing errors; `automatic` lets the node handle upgrades without requiring explicit synchronous coordination

## Test plan
- [ ] `group-upgrade` CI job passes in both binary and Docker mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/example workflow change that only alters the upgrade policy used during a sample upgrade flow; primary impact is on CI/examples rather than runtime code paths.
> 
> **Overview**
> Updates the `workflow-group-upgrade-example.yml` to set the group `upgrade_policy` to **`automatic`** instead of `coordinated`, and renames the step/comment accordingly.
> 
> This changes the example upgrade flow to rely on node-managed upgrades rather than explicit coordinated/synchronous upgrade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e575e18ecfe26009c5b6dbaa37e936363b42ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->