### PR TITLE
feat(steps): add assert_log_absent / assert_log_present step types

### DIFF
--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -80,6 +80,8 @@ VALID_STEP_TYPES = frozenset(
         "script",
         "assert",
         "json_assert",
+        "assert_log_absent",
+        "assert_log_present",
         "get_proposal",
         "list_proposals",
         "get_proposal_approvers",
@@ -382,6 +384,51 @@ class JsonAssertStep(BaseStepConfig):
     type: Literal["json_assert"] = "json_assert"
     statements: list[Union[str, dict[str, Any]]] = Field(
         ..., description="List of JSON assertion statements"
+    )
+
+
+class AssertLogAbsentStepConfig(BaseStepConfig):
+    """Configuration for assert_log_absent step."""
+
+    type: Literal["assert_log_absent"] = "assert_log_absent"
+    nodes: list[str] = Field(
+        ..., description="Node names to scan. Empty list = all running nodes."
+    )
+    patterns: list[str] = Field(
+        ..., description="Patterns whose presence in any node's logs fails the step"
+    )
+    regex: Optional[bool] = Field(
+        False, description="If true, treat patterns as Python regex"
+    )
+    tail_lines: Optional[int] = Field(
+        None, description="Only scan the last N lines per node"
+    )
+    case_sensitive: Optional[bool] = Field(
+        True, description="If false, matching is case-insensitive"
+    )
+
+
+class AssertLogPresentStepConfig(BaseStepConfig):
+    """Configuration for assert_log_present step."""
+
+    type: Literal["assert_log_present"] = "assert_log_present"
+    nodes: list[str] = Field(
+        ..., description="Node names to scan. Empty list = all running nodes."
+    )
+    patterns: list[str] = Field(
+        ..., description="Patterns each requiring at least min_matches hits"
+    )
+    regex: Optional[bool] = Field(
+        False, description="If true, treat patterns as Python regex"
+    )
+    tail_lines: Optional[int] = Field(
+        None, description="Only scan the last N lines per node"
+    )
+    case_sensitive: Optional[bool] = Field(
+        True, description="If false, matching is case-insensitive"
+    )
+    min_matches: Optional[int] = Field(
+        1, description="Required hits per pattern, aggregated across nodes"
     )
 
 
@@ -1015,6 +1062,8 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "script": ScriptStep,
     "assert": AssertStep,
     "json_assert": JsonAssertStep,
+    "assert_log_absent": AssertLogAbsentStepConfig,
+    "assert_log_present": AssertLogPresentStepConfig,
     "get_proposal": GetProposalStep,
     "list_proposals": ListProposalsStep,
     "get_proposal_approvers": GetProposalApproversStep,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -75,6 +75,10 @@ from merobox.commands.bootstrap.steps import (
     WaitForSyncStep,
     WaitStep,
 )
+from merobox.commands.bootstrap.steps.assert_log import (
+    AssertLogAbsentStep,
+    AssertLogPresentStep,
+)
 from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
 from merobox.commands.bootstrap.steps.json_assertion import JsonAssertStep
@@ -1568,6 +1572,10 @@ class WorkflowExecutor:
             return AssertStep(step_config, **common_kwargs)
         elif step_type == "json_assert":
             return JsonAssertStep(step_config, **common_kwargs)
+        elif step_type == "assert_log_absent":
+            return AssertLogAbsentStep(step_config, **common_kwargs)
+        elif step_type == "assert_log_present":
+            return AssertLogPresentStep(step_config, **common_kwargs)
         elif step_type == "get_proposal":
             return GetProposalStep(step_config, **common_kwargs)
         elif step_type == "list_proposals":

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -2,6 +2,10 @@
 Steps module - Individual step implementations for workflow execution.
 """
 
+from merobox.commands.bootstrap.steps.assert_log import (
+    AssertLogAbsentStep,
+    AssertLogPresentStep,
+)
 from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.bootstrap.steps.blob import UploadBlobStep
@@ -126,6 +130,8 @@ __all__ = [
     "ParallelStep",
     "ScriptStep",
     "AssertStep",
+    "AssertLogAbsentStep",
+    "AssertLogPresentStep",
     "JsonAssertStep",
     "UploadBlobStep",
     "CreateMeshStep",

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -166,10 +166,12 @@ class AssertLogAbsentStep(_AssertLogStepBase):
         matchers = [(p, self._compile_matcher(p)) for p in patterns]
 
         all_ok = True
+        nodes_scanned = 0
         for node_name in target_nodes:
             log = self._fetch_log(node_name)
             if log is None:
                 continue
+            nodes_scanned += 1
             for line_no, line in enumerate(self._iter_lines(log), start=1):
                 for pattern, matches in matchers:
                     if matches(line):
@@ -181,11 +183,21 @@ class AssertLogAbsentStep(_AssertLogStepBase):
                         )
                         all_ok = False
 
+        # If no logs were retrievable across ANY target node, treat the step
+        # as a failure rather than silently passing. Otherwise a typo in
+        # `nodes:` would turn the regression gate into a no-op.
+        if nodes_scanned == 0:
+            console.print(
+                f"[red]✗ assert_log_absent failed: no logs retrievable "
+                f"from any of {len(target_nodes)} target node(s)[/red]"
+            )
+            return False
+
         if all_ok:
             console.print(
                 f"[green]✓ assert_log_absent: none of "
                 f"{len(patterns)} pattern(s) matched across "
-                f"{len(target_nodes)} node(s)[/green]"
+                f"{nodes_scanned} node(s)[/green]"
             )
         return all_ok
 
@@ -233,15 +245,27 @@ class AssertLogPresentStep(_AssertLogStepBase):
         hits: dict[str, int] = dict.fromkeys(patterns, 0)
         sample_hits: dict[str, tuple[str, int, str]] = {}
 
+        nodes_scanned = 0
         for node_name in target_nodes:
             log = self._fetch_log(node_name)
             if log is None:
                 continue
+            nodes_scanned += 1
             for line_no, line in enumerate(self._iter_lines(log), start=1):
                 for pattern, matches in matchers:
                     if matches(line):
                         hits[pattern] += 1
                         sample_hits.setdefault(pattern, (node_name, line_no, line))
+
+        # The patterns-missing branch below already fails on zero hits, but a
+        # dedicated message makes the no-logs-retrievable mode debuggable
+        # without forcing the user to infer it from "had 0 hit(s)".
+        if nodes_scanned == 0:
+            console.print(
+                f"[red]✗ assert_log_present failed: no logs retrievable "
+                f"from any of {len(target_nodes)} target node(s)[/red]"
+            )
+            return False
 
         missing = [p for p in patterns if hits[p] < min_matches]
         if missing:

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -292,10 +292,15 @@ class AssertLogPresentStep(_AssertLogStepBase):
         missing = [p for p in patterns if hits[p] < min_matches]
         if missing:
             for pattern in missing:
+                # markup=False so a pattern containing literal Rich markup
+                # characters (e.g. "[red]" embedded in the pattern itself)
+                # isn't interpreted as a console tag.
                 console.print(
-                    f"[red]✗ assert_log_present failed: pattern "
+                    f"✗ assert_log_present failed: pattern "
                     f"{pattern!r} had {hits[pattern]} hit(s), "
-                    f"expected >= {min_matches}[/red]"
+                    f"expected >= {min_matches}",
+                    style="red",
+                    markup=False,
                 )
             return False
 

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -76,11 +76,20 @@ class _AssertLogStepBase(BaseStep):
         if self.manager is None:
             return []
         if self._is_binary_mode():
-            listed = self.manager.list_nodes() or []
+            try:
+                listed = self.manager.list_nodes() or []
+            except Exception as e:
+                console.print(
+                    f"[yellow]⚠️  manager.list_nodes() failed: {e}[/yellow]"
+                )
+                return []
             return [n["name"] for n in listed if isinstance(n, dict) and "name" in n]
         try:
             return list(self.manager.get_running_nodes() or [])
-        except Exception:
+        except Exception as e:
+            console.print(
+                f"[yellow]⚠️  manager.get_running_nodes() failed: {e}[/yellow]"
+            )
             return []
 
     def _fetch_log(self, node_name: str) -> str | None:
@@ -184,10 +193,14 @@ class AssertLogAbsentStep(_AssertLogStepBase):
                 for pattern, matches in matchers:
                     if matches(line):
                         trimmed = line if len(line) <= 200 else line[:197] + "..."
+                        # markup=False so log content containing [..] or {..}
+                        # isn't interpreted by Rich as console markup.
                         console.print(
-                            f"[red]✗ assert_log_absent failed on node "
+                            f"✗ assert_log_absent failed on node "
                             f"'{node_name}' line {line_no}: matched pattern "
-                            f"{pattern!r} -> {trimmed!r}[/red]"
+                            f"{pattern!r} -> {trimmed!r}",
+                            style="red",
+                            markup=False,
                         )
                         all_ok = False
 
@@ -288,9 +301,13 @@ class AssertLogPresentStep(_AssertLogStepBase):
         for pattern in patterns:
             node_name, line_no, line = sample_hits[pattern]
             trimmed = line if len(line) <= 200 else line[:197] + "..."
+            # markup=False so log content containing [..] or {..} isn't
+            # interpreted by Rich as console markup.
             console.print(
-                f"[green]✓ assert_log_present: {pattern!r} matched "
+                f"✓ assert_log_present: {pattern!r} matched "
                 f"{hits[pattern]} time(s) (first: node '{node_name}' line "
-                f"{line_no} -> {trimmed!r})[/green]"
+                f"{line_no} -> {trimmed!r})",
+                style="green",
+                markup=False,
             )
         return True

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -158,11 +158,15 @@ class AssertLogAbsentStep(_AssertLogStepBase):
     ) -> bool:
         target_nodes = self._resolve_target_nodes()
         if not target_nodes:
+            # Symmetric with the no-logs-retrievable failure mode added in
+            # 1edf6aa: a guard that resolves to zero target nodes is a no-op
+            # gate, not a vacuous pass. Fail loudly so CI surfaces the bug.
             console.print(
-                "[yellow]⚠️  assert_log_absent: no target nodes resolved; "
-                "treating as pass[/yellow]"
+                "[red]✗ assert_log_absent failed: no target nodes resolved "
+                "(check the nodes: list or whether any nodes are running)"
+                "[/red]"
             )
-            return True
+            return False
 
         # Deduplicate patterns to avoid double-counting and duplicate reports
         # when a user accidentally lists the same pattern twice.

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -1,0 +1,238 @@
+"""Log-grep regression-gate steps: assert_log_absent / assert_log_present.
+
+These steps let workflow YAMLs express log-grep regression gates inline
+instead of relying on out-of-band CI shell steps to download docker log
+artefacts and grep them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import console
+
+# Sentinel passed to docker-py for "scan everything" in container.logs(tail=...).
+_DOCKER_TAIL_ALL = "all"
+# Large value used as the "scan everything" knob for BinaryManager.get_node_logs,
+# which always slices ``all_lines[-lines:]`` and has no native "unbounded" form.
+_BINARY_TAIL_ALL = 10**9
+
+
+class _AssertLogStepBase(BaseStep):
+    """Shared field validation and log retrieval for the assert_log_* steps."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["nodes", "patterns"]
+
+    def _validate_field_types(self) -> None:
+        # nodes: list of strings. Empty list is allowed and means "all running
+        # nodes" (resolved at execute time via the manager).
+        self._validate_list_field("nodes", allow_empty=True, element_type=str)
+        self._validate_list_field("patterns", allow_empty=False, element_type=str)
+        if "regex" in self.config:
+            self._validate_boolean_field("regex")
+        if "case_sensitive" in self.config:
+            self._validate_boolean_field("case_sensitive")
+        if "tail_lines" in self.config and self.config["tail_lines"] is not None:
+            self._validate_integer_field("tail_lines", positive=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_binary_mode(self) -> bool:
+        return (
+            self.manager is not None
+            and getattr(self.manager, "binary_path", None) is not None
+        )
+
+    def _resolve_target_nodes(self) -> list[str]:
+        nodes = list(self.config.get("nodes", []))
+        if nodes:
+            return nodes
+        # Empty list => all running nodes
+        if self.manager is None:
+            return []
+        if self._is_binary_mode():
+            listed = self.manager.list_nodes() or []
+            return [n["name"] for n in listed if isinstance(n, dict) and "name" in n]
+        try:
+            return list(self.manager.get_running_nodes() or [])
+        except Exception:
+            return []
+
+    def _fetch_log(self, node_name: str) -> str | None:
+        tail_lines = self.config.get("tail_lines")
+        if self.manager is None:
+            return None
+        if self._is_binary_mode():
+            lines = tail_lines if tail_lines is not None else _BINARY_TAIL_ALL
+            try:
+                return self.manager.get_node_logs(node_name, lines=lines)
+            except Exception as e:
+                console.print(
+                    f"[yellow]⚠️  Could not retrieve logs for {node_name}: {e}[/yellow]"
+                )
+                return None
+        # Docker mode
+        try:
+            container = (
+                self.manager.nodes.get(node_name)
+                if hasattr(self.manager, "nodes")
+                else None
+            )
+            if container is None:
+                container = self.manager.client.containers.get(node_name)
+            tail = tail_lines if tail_lines is not None else _DOCKER_TAIL_ALL
+            raw = container.logs(tail=tail, timestamps=True)
+            if isinstance(raw, bytes):
+                return raw.decode("utf-8", errors="replace")
+            return str(raw)
+        except Exception as e:
+            console.print(
+                f"[yellow]⚠️  Could not retrieve logs for {node_name}: {e}[/yellow]"
+            )
+            return None
+
+    def _compile_matcher(self, pattern: str):
+        """Return a callable(line: str) -> bool for a single pattern."""
+        use_regex = bool(self.config.get("regex", False))
+        case_sensitive = bool(self.config.get("case_sensitive", True))
+        if use_regex:
+            flags = 0 if case_sensitive else re.IGNORECASE
+            compiled = re.compile(pattern, flags)
+            return lambda line: compiled.search(line) is not None
+        if case_sensitive:
+            needle = pattern
+            return lambda line: needle in line
+        needle = pattern.lower()
+        return lambda line: needle in line.lower()
+
+    def _iter_lines(self, log: str) -> list[str]:
+        return log.splitlines() if log else []
+
+
+class AssertLogAbsentStep(_AssertLogStepBase):
+    """Fail if any pattern matches in any of the named nodes' logs.
+
+    Configuration::
+
+        - name: Regression guard — no rejection spam
+          type: assert_log_absent
+          nodes: [af-no-spam-node-1, af-no-spam-node-2]
+          patterns:
+            - "context not materialised within join race window"
+            - "inbound stream for unknown context"
+    """
+
+    async def execute(
+        self,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> bool:
+        target_nodes = self._resolve_target_nodes()
+        if not target_nodes:
+            console.print(
+                "[yellow]⚠️  assert_log_absent: no target nodes resolved; "
+                "treating as pass[/yellow]"
+            )
+            return True
+
+        patterns: list[str] = list(self.config["patterns"])
+        matchers = [(p, self._compile_matcher(p)) for p in patterns]
+
+        all_ok = True
+        for node_name in target_nodes:
+            log = self._fetch_log(node_name)
+            if log is None:
+                continue
+            for line_no, line in enumerate(self._iter_lines(log), start=1):
+                for pattern, matches in matchers:
+                    if matches(line):
+                        trimmed = line if len(line) <= 200 else line[:197] + "..."
+                        console.print(
+                            f"[red]✗ assert_log_absent failed on node "
+                            f"'{node_name}' line {line_no}: matched pattern "
+                            f"{pattern!r} -> {trimmed!r}[/red]"
+                        )
+                        all_ok = False
+
+        if all_ok:
+            console.print(
+                f"[green]✓ assert_log_absent: none of "
+                f"{len(patterns)} pattern(s) matched across "
+                f"{len(target_nodes)} node(s)[/green]"
+            )
+        return all_ok
+
+
+class AssertLogPresentStep(_AssertLogStepBase):
+    """Fail unless every pattern matches at least ``min_matches`` times.
+
+    Hits are aggregated across the union of the named nodes (not per-node).
+
+    Configuration::
+
+        - name: Regression guard — sync completed
+          type: assert_log_present
+          nodes: [bootstrap-node-1]
+          patterns:
+            - "Sync session complete"
+          tail_lines: 5000
+    """
+
+    def _validate_field_types(self) -> None:
+        super()._validate_field_types()
+        if "min_matches" in self.config:
+            self._validate_integer_field("min_matches", positive=True)
+
+    async def execute(
+        self,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> bool:
+        target_nodes = self._resolve_target_nodes()
+        if not target_nodes:
+            console.print(
+                "[red]✗ assert_log_present failed: no target nodes resolved[/red]"
+            )
+            return False
+
+        patterns: list[str] = list(self.config["patterns"])
+        min_matches = int(self.config.get("min_matches", 1))
+        matchers = [(p, self._compile_matcher(p)) for p in patterns]
+
+        hits: dict[str, int] = dict.fromkeys(patterns, 0)
+        sample_hits: dict[str, tuple[str, int, str]] = {}
+
+        for node_name in target_nodes:
+            log = self._fetch_log(node_name)
+            if log is None:
+                continue
+            for line_no, line in enumerate(self._iter_lines(log), start=1):
+                for pattern, matches in matchers:
+                    if matches(line):
+                        hits[pattern] += 1
+                        sample_hits.setdefault(pattern, (node_name, line_no, line))
+
+        missing = [p for p in patterns if hits[p] < min_matches]
+        if missing:
+            for pattern in missing:
+                console.print(
+                    f"[red]✗ assert_log_present failed: pattern "
+                    f"{pattern!r} had {hits[pattern]} hit(s), "
+                    f"expected >= {min_matches}[/red]"
+                )
+            return False
+
+        for pattern in patterns:
+            node_name, line_no, line = sample_hits[pattern]
+            trimmed = line if len(line) <= 200 else line[:197] + "..."
+            console.print(
+                f"[green]✓ assert_log_present: {pattern!r} matched "
+                f"{hits[pattern]} time(s) (first: node '{node_name}' line "
+                f"{line_no} -> {trimmed!r})[/green]"
+            )
+        return True

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -69,7 +69,10 @@ class _AssertLogStepBase(BaseStep):
         )
 
     def _resolve_target_nodes(self) -> list[str]:
-        nodes = list(self.config.get("nodes", []))
+        # Deduplicate while preserving order: a user listing the same node
+        # twice would otherwise have its log scanned twice and double-count
+        # in assert_log_present's aggregated hits.
+        nodes = list(dict.fromkeys(self.config.get("nodes", [])))
         if nodes:
             return nodes
         # Empty list => all running nodes

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -79,9 +79,7 @@ class _AssertLogStepBase(BaseStep):
             try:
                 listed = self.manager.list_nodes() or []
             except Exception as e:
-                console.print(
-                    f"[yellow]⚠️  manager.list_nodes() failed: {e}[/yellow]"
-                )
+                console.print(f"[yellow]⚠️  manager.list_nodes() failed: {e}[/yellow]")
                 return []
             return [n["name"] for n in listed if isinstance(n, dict) and "name" in n]
         try:

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -31,12 +31,32 @@ class _AssertLogStepBase(BaseStep):
         # nodes" (resolved at execute time via the manager).
         self._validate_list_field("nodes", allow_empty=True, element_type=str)
         self._validate_list_field("patterns", allow_empty=False, element_type=str)
+        # Empty-string patterns trivially match every line, which makes the
+        # step meaningless and is almost always a YAML typo. Reject early.
+        for idx, pattern in enumerate(self.config["patterns"]):
+            if pattern == "":
+                raise ValueError(
+                    f"Step '{self._get_step_name()}': 'patterns[{idx}]' "
+                    f"must not be an empty string"
+                )
         if "regex" in self.config:
             self._validate_boolean_field("regex")
         if "case_sensitive" in self.config:
             self._validate_boolean_field("case_sensitive")
         if "tail_lines" in self.config and self.config["tail_lines"] is not None:
             self._validate_integer_field("tail_lines", positive=True)
+        # If regex=True, compile each pattern at validation time so malformed
+        # regexes surface as a clean ValueError instead of crashing the step
+        # mid-execution with re.error.
+        if self.config.get("regex"):
+            for idx, pattern in enumerate(self.config["patterns"]):
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    raise ValueError(
+                        f"Step '{self._get_step_name()}': 'patterns[{idx}]' "
+                        f"is not a valid regex ({exc})"
+                    ) from exc
 
     # ------------------------------------------------------------------
     # Helpers
@@ -140,7 +160,9 @@ class AssertLogAbsentStep(_AssertLogStepBase):
             )
             return True
 
-        patterns: list[str] = list(self.config["patterns"])
+        # Deduplicate patterns to avoid double-counting and duplicate reports
+        # when a user accidentally lists the same pattern twice.
+        patterns: list[str] = list(dict.fromkeys(self.config["patterns"]))
         matchers = [(p, self._compile_matcher(p)) for p in patterns]
 
         all_ok = True
@@ -200,7 +222,11 @@ class AssertLogPresentStep(_AssertLogStepBase):
             )
             return False
 
-        patterns: list[str] = list(self.config["patterns"])
+        # Deduplicate patterns: with duplicates a single matching line would
+        # increment hits[pattern] multiple times via the duplicate matcher
+        # entries, letting a pattern that only hits min_matches/N times still
+        # pass an aggregated min_matches threshold.
+        patterns: list[str] = list(dict.fromkeys(self.config["patterns"]))
         min_matches = int(self.config.get("min_matches", 1))
         matchers = [(p, self._compile_matcher(p)) for p in patterns]
 

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -106,7 +106,11 @@ class _AssertLogStepBase(BaseStep):
             if container is None:
                 container = self.manager.client.containers.get(node_name)
             tail = tail_lines if tail_lines is not None else _DOCKER_TAIL_ALL
-            raw = container.logs(tail=tail, timestamps=True)
+            # timestamps=False so that anchored regex patterns (e.g. ^WARN)
+            # behave predictably and the failure-report line content isn't
+            # prefixed with noise. line_no in our own enumeration still gives
+            # the user a position reference.
+            raw = container.logs(tail=tail, timestamps=False)
             if isinstance(raw, bytes):
                 return raw.decode("utf-8", errors="replace")
             return str(raw)

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -5,6 +5,10 @@ This module provides comprehensive validation for workflow configurations
 without requiring full workflow execution.
 """
 
+from merobox.commands.bootstrap.steps.assert_log import (
+    AssertLogAbsentStep,
+    AssertLogPresentStep,
+)
 from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
@@ -203,6 +207,10 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = AssertStep
         elif step_type == "json_assert":
             step_class = JsonAssertStep
+        elif step_type == "assert_log_absent":
+            step_class = AssertLogAbsentStep
+        elif step_type == "assert_log_present":
+            step_class = AssertLogPresentStep
         elif step_type == "get_proposal":
             step_class = GetProposalStep
         elif step_type == "list_proposals":

--- a/merobox/tests/unit/test_assert_log_step.py
+++ b/merobox/tests/unit/test_assert_log_step.py
@@ -136,6 +136,45 @@ class TestAssertLogAbsentValidation:
             manager=MagicMock(),
         )
 
+    def test_empty_string_pattern_rejected(self):
+        # An empty-string pattern matches every line — almost certainly a YAML
+        # templating bug, so reject at construction time.
+        with pytest.raises(ValueError, match="empty string"):
+            AssertLogAbsentStep(
+                {
+                    "type": "assert_log_absent",
+                    "nodes": ["node-1"],
+                    "patterns": ["valid", ""],
+                },
+                manager=MagicMock(),
+            )
+
+    def test_invalid_regex_pattern_rejected_at_construction(self):
+        # When regex=True, malformed patterns should fail validation rather
+        # than crash mid-execute with re.error.
+        with pytest.raises(ValueError, match="not a valid regex"):
+            AssertLogAbsentStep(
+                {
+                    "type": "assert_log_absent",
+                    "nodes": ["node-1"],
+                    "patterns": ["[invalid"],
+                    "regex": True,
+                },
+                manager=MagicMock(),
+            )
+
+    def test_invalid_regex_only_validated_when_regex_flag_true(self):
+        # Without regex=True the same string is a literal substring and should
+        # not trigger a regex validation error.
+        AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": ["[not-a-regex"],
+            },
+            manager=MagicMock(),
+        )
+
 
 class TestAssertLogPresentValidation:
     def test_min_matches_must_be_positive(self):
@@ -405,6 +444,22 @@ class TestAssertLogPresentBehaviour:
             manager=manager,
         )
         assert _run(step.execute({}, {})) is True
+
+    def test_duplicate_patterns_do_not_double_count_hits(self):
+        # Regression for meroreviewer critical: a pattern listed twice must
+        # not let a single matching line satisfy min_matches=2. The user's
+        # intent for duplicates is unambiguous (same pattern = one rule).
+        manager = _docker_manager_with_logs({"node-1": "Sync session complete\n"})
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1"],
+                "patterns": ["Sync session complete", "Sync session complete"],
+                "min_matches": 2,
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
 
     def test_binary_mode_used_for_present(self):
         manager = _binary_manager_with_logs({"node-1": "Sync session complete\n"})

--- a/merobox/tests/unit/test_assert_log_step.py
+++ b/merobox/tests/unit/test_assert_log_step.py
@@ -481,6 +481,23 @@ class TestAssertLogPresentBehaviour:
         )
         assert _run(step.execute({}, {})) is False
 
+    def test_duplicate_nodes_do_not_double_count_hits(self):
+        # If a user accidentally lists the same node twice, _fetch_log would
+        # be called twice for the same content and each matching line would
+        # be counted twice — letting a pattern with hits/2 satisfy
+        # min_matches=2. Dedupe target_nodes at resolution time.
+        manager = _docker_manager_with_logs({"node-1": "Sync session complete\n"})
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1", "node-1"],
+                "patterns": ["Sync session complete"],
+                "min_matches": 2,
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+
     def test_duplicate_patterns_do_not_double_count_hits(self):
         # Regression for meroreviewer critical: a pattern listed twice must
         # not let a single matching line satisfy min_matches=2. The user's

--- a/merobox/tests/unit/test_assert_log_step.py
+++ b/merobox/tests/unit/test_assert_log_step.py
@@ -1,0 +1,464 @@
+"""Unit tests for assert_log_absent / assert_log_present step types."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from merobox.commands.bootstrap.steps.assert_log import (
+    AssertLogAbsentStep,
+    AssertLogPresentStep,
+)
+
+
+def _docker_manager_with_logs(node_logs: dict[str, str]) -> MagicMock:
+    """Build a MagicMock that imitates DockerManager.
+
+    Each entry in ``node_logs`` becomes a container whose ``logs(...)`` call
+    returns the bytes form of the canned log content. Mirrors the access path
+    used in BaseStep._print_node_logs_on_failure: manager.nodes[name].logs(...)
+    falling back to manager.client.containers.get(name).
+    """
+    manager = MagicMock()
+    # No binary_path => docker mode
+    del manager.binary_path
+
+    containers: dict[str, MagicMock] = {}
+    for name, content in node_logs.items():
+        container = MagicMock()
+
+        def _logs(tail="all", timestamps=False, _content=content):
+            text = _content
+            if isinstance(tail, int):
+                text = "\n".join(text.splitlines()[-tail:])
+                if _content.endswith("\n"):
+                    text += "\n"
+            return text.encode("utf-8")
+
+        container.logs.side_effect = _logs
+        containers[name] = container
+
+    manager.nodes = containers
+    manager.client.containers.get.side_effect = lambda n: containers[n]
+    manager.get_running_nodes.return_value = list(node_logs.keys())
+    return manager
+
+
+def _binary_manager_with_logs(node_logs: dict[str, str]) -> MagicMock:
+    """Build a MagicMock that imitates BinaryManager."""
+    manager = MagicMock()
+    manager.binary_path = "/usr/local/bin/merod"
+    manager.get_node_logs.side_effect = lambda name, lines=50: node_logs.get(name)
+    manager.list_nodes.return_value = [{"name": n} for n in node_logs.keys()]
+    return manager
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ============================================================================
+# Schema / validation
+# ============================================================================
+
+
+class TestAssertLogAbsentValidation:
+    def test_missing_nodes_field_raises(self):
+        with pytest.raises(ValueError, match="nodes"):
+            AssertLogAbsentStep(
+                {"type": "assert_log_absent", "patterns": ["foo"]},
+                manager=MagicMock(),
+            )
+
+    def test_missing_patterns_field_raises(self):
+        with pytest.raises(ValueError, match="patterns"):
+            AssertLogAbsentStep(
+                {"type": "assert_log_absent", "nodes": ["node-1"]},
+                manager=MagicMock(),
+            )
+
+    def test_empty_patterns_rejected(self):
+        with pytest.raises(ValueError, match="patterns"):
+            AssertLogAbsentStep(
+                {
+                    "type": "assert_log_absent",
+                    "nodes": ["node-1"],
+                    "patterns": [],
+                },
+                manager=MagicMock(),
+            )
+
+    def test_non_string_pattern_rejected(self):
+        with pytest.raises(ValueError, match="patterns"):
+            AssertLogAbsentStep(
+                {
+                    "type": "assert_log_absent",
+                    "nodes": ["node-1"],
+                    "patterns": [123],
+                },
+                manager=MagicMock(),
+            )
+
+    def test_regex_must_be_boolean(self):
+        with pytest.raises(ValueError, match="regex"):
+            AssertLogAbsentStep(
+                {
+                    "type": "assert_log_absent",
+                    "nodes": ["node-1"],
+                    "patterns": ["foo"],
+                    "regex": "yes",
+                },
+                manager=MagicMock(),
+            )
+
+    def test_tail_lines_must_be_positive(self):
+        with pytest.raises(ValueError, match="tail_lines"):
+            AssertLogAbsentStep(
+                {
+                    "type": "assert_log_absent",
+                    "nodes": ["node-1"],
+                    "patterns": ["foo"],
+                    "tail_lines": 0,
+                },
+                manager=MagicMock(),
+            )
+
+    def test_empty_nodes_list_is_allowed_meaning_all_running(self):
+        # Empty list semantically means "all running nodes" per the spec
+        AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": [],
+                "patterns": ["foo"],
+            },
+            manager=MagicMock(),
+        )
+
+
+class TestAssertLogPresentValidation:
+    def test_min_matches_must_be_positive(self):
+        with pytest.raises(ValueError, match="min_matches"):
+            AssertLogPresentStep(
+                {
+                    "type": "assert_log_present",
+                    "nodes": ["node-1"],
+                    "patterns": ["foo"],
+                    "min_matches": 0,
+                },
+                manager=MagicMock(),
+            )
+
+    def test_case_sensitive_must_be_boolean(self):
+        with pytest.raises(ValueError, match="case_sensitive"):
+            AssertLogPresentStep(
+                {
+                    "type": "assert_log_present",
+                    "nodes": ["node-1"],
+                    "patterns": ["foo"],
+                    "case_sensitive": "yes",
+                },
+                manager=MagicMock(),
+            )
+
+
+# ============================================================================
+# assert_log_absent behaviour
+# ============================================================================
+
+
+class TestAssertLogAbsentBehaviour:
+    def test_passes_when_no_pattern_matches(self):
+        manager = _docker_manager_with_logs(
+            {"node-1": "boot complete\nready\n", "node-2": "ready\n"}
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1", "node-2"],
+                "patterns": ["context not materialised", "unknown context"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is True
+
+    def test_fails_when_any_pattern_matches_any_node(self):
+        manager = _docker_manager_with_logs(
+            {
+                "node-1": "boot complete\nready\n",
+                "node-2": "WARN inbound stream for unknown context\n",
+            }
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1", "node-2"],
+                "patterns": [
+                    "context not materialised",
+                    "inbound stream for unknown context",
+                ],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+
+    def test_regex_flag_treats_patterns_as_regex(self):
+        manager = _docker_manager_with_logs(
+            {"node-1": "ERROR ctx=abc123 not materialised within join race\n"}
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": [r"ctx=\w+ not materialised"],
+                "regex": True,
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+
+    def test_regex_disabled_treats_patterns_as_literal(self):
+        # The regex meta-chars in the pattern would match if regex=True, but
+        # with regex disabled the literal substring must match exactly.
+        manager = _docker_manager_with_logs(
+            {"node-1": "ERROR ctx=abc123 not materialised within join race\n"}
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": [r"ctx=\w+ not materialised"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is True
+
+    def test_tail_lines_limits_search_window(self):
+        # Pattern only appears early in the log. With tail_lines=2 we shouldn't
+        # see it; without tail_lines we should.
+        full_log = (
+            "no owned identities found for context\n"
+            "boot complete\n"
+            "step 1 done\n"
+            "step 2 done\n"
+        )
+        manager = _docker_manager_with_logs({"node-1": full_log})
+        step_limited = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": ["no owned identities found"],
+                "tail_lines": 2,
+            },
+            manager=manager,
+        )
+        assert _run(step_limited.execute({}, {})) is True
+
+        # Confirm the same pattern *would* match without a tail bound.
+        manager2 = _docker_manager_with_logs({"node-1": full_log})
+        step_unbounded = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": ["no owned identities found"],
+            },
+            manager=manager2,
+        )
+        assert _run(step_unbounded.execute({}, {})) is False
+
+    def test_case_insensitive_match(self):
+        manager = _docker_manager_with_logs(
+            {"node-1": "WARN INBOUND STREAM FOR UNKNOWN CONTEXT\n"}
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": ["inbound stream for unknown context"],
+                "case_sensitive": False,
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+
+    def test_empty_nodes_list_means_all_running_nodes(self):
+        manager = _docker_manager_with_logs(
+            {
+                "node-a": "ok\n",
+                "node-b": "context not materialised within join race window\n",
+            }
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": [],
+                "patterns": ["context not materialised"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+        manager.get_running_nodes.assert_called()
+
+    def test_binary_mode_uses_manager_get_node_logs(self):
+        manager = _binary_manager_with_logs(
+            {"node-1": "ready\nWARN inbound stream for unknown context\n"}
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": ["inbound stream for unknown context"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+        # Must have gone through the binary path, not docker.
+        manager.get_node_logs.assert_called()
+
+
+# ============================================================================
+# assert_log_present behaviour
+# ============================================================================
+
+
+class TestAssertLogPresentBehaviour:
+    def test_passes_when_every_pattern_appears_in_any_node(self):
+        manager = _docker_manager_with_logs(
+            {
+                "boot-node": "Sync session complete\nGoodbye\n",
+                "follower": "Replayed 3 ops\n",
+            }
+        )
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["boot-node", "follower"],
+                "patterns": ["Sync session complete", "Replayed"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is True
+
+    def test_fails_when_pattern_missing_in_all_nodes(self):
+        manager = _docker_manager_with_logs(
+            {"boot-node": "Booting...\n", "follower": "follower up\n"}
+        )
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["boot-node", "follower"],
+                "patterns": ["Sync session complete"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+
+    def test_min_matches_aggregates_across_nodes(self):
+        # Pattern appears once in each node => 2 total across the union.
+        # Default min_matches=1 should pass; min_matches=3 should fail.
+        manager = _docker_manager_with_logs(
+            {
+                "node-1": "Sync session complete\nmore\n",
+                "node-2": "Sync session complete\n",
+            }
+        )
+        pass_step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1", "node-2"],
+                "patterns": ["Sync session complete"],
+                "min_matches": 2,
+            },
+            manager=manager,
+        )
+        assert _run(pass_step.execute({}, {})) is True
+
+        manager2 = _docker_manager_with_logs(
+            {
+                "node-1": "Sync session complete\nmore\n",
+                "node-2": "Sync session complete\n",
+            }
+        )
+        fail_step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1", "node-2"],
+                "patterns": ["Sync session complete"],
+                "min_matches": 3,
+            },
+            manager=manager2,
+        )
+        assert _run(fail_step.execute({}, {})) is False
+
+    def test_regex_flag_in_present(self):
+        manager = _docker_manager_with_logs(
+            {"node-1": "Sync session complete in 1234ms\n"}
+        )
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1"],
+                "patterns": [r"Sync session complete in \d+ms"],
+                "regex": True,
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is True
+
+    def test_binary_mode_used_for_present(self):
+        manager = _binary_manager_with_logs({"node-1": "Sync session complete\n"})
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1"],
+                "patterns": ["Sync session complete"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is True
+        manager.get_node_logs.assert_called()
+
+
+# ============================================================================
+# Failure reporting
+# ============================================================================
+
+
+class TestFailureReporting:
+    def test_absent_failure_reports_match_details(self, capsys):
+        manager = _docker_manager_with_logs(
+            {"node-1": "boot complete\nWARN inbound stream for unknown context\n"}
+        )
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["node-1"],
+                "patterns": ["inbound stream for unknown context"],
+            },
+            manager=manager,
+        )
+        result = _run(step.execute({}, {}))
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Failure output must call out the offending node, pattern, and line
+        # so CI doesn't need the log artifact to diagnose the failure.
+        assert "node-1" in combined
+        assert "inbound stream for unknown context" in combined
+
+    def test_present_failure_lists_missing_patterns(self, capsys):
+        manager = _docker_manager_with_logs({"node-1": "boot complete\n"})
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["node-1"],
+                "patterns": ["Sync session complete"],
+            },
+            manager=manager,
+        )
+        result = _run(step.execute({}, {}))
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Sync session complete" in combined

--- a/merobox/tests/unit/test_assert_log_step.py
+++ b/merobox/tests/unit/test_assert_log_step.py
@@ -339,6 +339,24 @@ class TestAssertLogAbsentBehaviour:
         assert _run(step.execute({}, {})) is False
         manager.get_running_nodes.assert_called()
 
+    def test_fails_when_no_logs_retrievable_from_any_node(self):
+        # Regression for Cursor Bugbot: a typo'd nodes list (every fetch
+        # returns None) must not silently pass — that turns the gate into
+        # a no-op and lets regressions slip through.
+        manager = MagicMock()
+        del manager.binary_path
+        manager.nodes = {}
+        manager.client.containers.get.side_effect = Exception("no such container")
+        step = AssertLogAbsentStep(
+            {
+                "type": "assert_log_absent",
+                "nodes": ["typoed-node-1", "typoed-node-2"],
+                "patterns": ["context not materialised"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+
     def test_binary_mode_uses_manager_get_node_logs(self):
         manager = _binary_manager_with_logs(
             {"node-1": "ready\nWARN inbound stream for unknown context\n"}
@@ -444,6 +462,24 @@ class TestAssertLogPresentBehaviour:
             manager=manager,
         )
         assert _run(step.execute({}, {})) is True
+
+    def test_present_fails_when_no_logs_retrievable(self):
+        # Symmetric to the absent case: if every fetch returns None,
+        # report it explicitly instead of relying on the patterns-missing
+        # branch's generic "had 0 hit(s)" message.
+        manager = _docker_manager_with_logs({"node-1": "ok\n"})
+        # Replace the container.logs to fail for every node
+        manager.client.containers.get.side_effect = Exception("no such container")
+        manager.nodes = {}
+        step = AssertLogPresentStep(
+            {
+                "type": "assert_log_present",
+                "nodes": ["ghost"],
+                "patterns": ["anything"],
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
 
     def test_duplicate_patterns_do_not_double_count_hits(self):
         # Regression for meroreviewer critical: a pattern listed twice must

--- a/merobox/tests/unit/test_assert_log_step.py
+++ b/merobox/tests/unit/test_assert_log_step.py
@@ -56,7 +56,19 @@ def _binary_manager_with_logs(node_logs: dict[str, str]) -> MagicMock:
 
 
 def _run(coro):
-    return asyncio.run(coro)
+    # asyncio.run() calls set_event_loop(None) in its finally block on
+    # Python 3.10+, which leaks across tests: subsequent test files that
+    # use the deprecated asyncio.get_event_loop().run_until_complete(...)
+    # pattern then crash with "There is no current event loop in thread
+    # 'MainThread'". Restore an event loop after each call so our tests
+    # don't break other test files in the suite.
+    try:
+        return asyncio.run(coro)
+    finally:
+        try:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+        except Exception:
+            pass
 
 
 # ============================================================================

--- a/workflow-examples/workflow-assert-log-example.yml
+++ b/workflow-examples/workflow-assert-log-example.yml
@@ -1,0 +1,89 @@
+description: Example workflow showcasing assert_log_absent and assert_log_present steps
+name: Assert Log Example
+
+# Single node — these steps assert on node logs, no need for a multi-node mesh.
+nodes:
+  count: 1
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: assert-log-node
+  base_port: 9030
+  base_rpc_port: 9130
+
+steps:
+  # Do some real work so the node has something to log: install an app,
+  # create a namespace, create a context. This gives both step types
+  # something interesting to scan.
+  - name: Install Application
+    type: install_application
+    node: assert-log-node-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace
+    type: create_namespace
+    node: assert-log-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Context
+    type: create_context
+    node: assert-log-node-1
+    application_id: "{{app_id}}"
+    group_id: "{{namespace_id}}"
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+
+  # Let log output settle so the scans below see a stable window.
+  - name: Wait for log output to settle
+    type: wait
+    seconds: 3
+
+  # ── assert_log_absent: guard against Rust panic + fatal-level output ──
+  # These patterns are language- / framework-level signatures, so they
+  # don't depend on merod's specific log format. A healthy run should
+  # never produce them.
+  - name: Regression guard — no panic / fatal
+    type: assert_log_absent
+    nodes: [assert-log-node-1]
+    patterns:
+      - "panicked at"
+      - "thread 'main' panicked"
+      - "FATAL"
+
+  # ── assert_log_present: confirm the node actually emitted log output ──
+  # `INFO` is the default tracing level — any healthy merod run produces
+  # at least one INFO line during startup. min_matches: 1 is the default.
+  - name: Confirm node emitted tracing output
+    type: assert_log_present
+    nodes: [assert-log-node-1]
+    patterns:
+      - "INFO"
+
+  # ── Demonstrate the full schema in a single step ──
+  # case_sensitive: false — match "WARN", "warn", "Warn", etc.
+  # tail_lines: 1000     — only scan the last 1000 lines per node.
+  # regex: false         — patterns are literal substrings (the default).
+  - name: Bounded-window guard (regex / case_sensitive / tail_lines / min_matches)
+    type: assert_log_absent
+    nodes: [assert-log-node-1]
+    patterns:
+      - "segmentation fault"
+      - "Out of memory"
+    regex: false
+    case_sensitive: false
+    tail_lines: 1000
+
+  # ── Demonstrate the empty-nodes-list shorthand: scan ALL running nodes ──
+  - name: Cluster-wide panic guard (nodes:[] = all running nodes)
+    type: assert_log_absent
+    nodes: []
+    patterns:
+      - "panicked at"
+
+stop_all_nodes: true
+restart: false
+wait_timeout: 60


### PR DESCRIPTION
## Summary

Closes #243. Adds two workflow step types that assert on the contents of a node's docker logs, so regression workflows can express log-grep gates inline instead of relying on out-of-band CI shell steps that download log artefacts and grep them.

- **`assert_log_absent`** — fails if any pattern matches in any of the named nodes' logs. Reports the offending node, line number, matched line, and pattern, so the CI log surfaces the failure without needing the artefact download.
- **`assert_log_present`** — fails unless every pattern has at least `min_matches` hits aggregated across the union of the named nodes.

Shared knobs (per the schema in #243):

| Field | Type | Default | Notes |
|---|---|---|---|
| `nodes` | `list[str]` | required | Empty list = all running nodes |
| `patterns` | `list[str]` | required | Literal substrings by default |
| `regex` | `bool` | `false` | Treat patterns as Python regex |
| `tail_lines` | `int` | unbounded | Limit search to last N lines per node |
| `case_sensitive` | `bool` | `true` | |
| `min_matches` | `int` | `1` | `present` only; aggregated across nodes |

Docker mode uses `container.logs(tail=..., timestamps=True)`; binary mode uses `BinaryManager.get_node_logs(name, lines=...)`. Both retrieval paths already exist in `BaseStep._print_node_logs_on_failure`.

## Example

```yaml
- name: Regression guard — no rejection spam
  type: assert_log_absent
  nodes: [af-no-spam-node-1, af-no-spam-node-2]
  patterns:
    - "context not materialised within join race window"
    - "inbound stream for unknown context"
    - "no owned identities found for context"

- name: Regression guard — sync completed
  type: assert_log_present
  nodes: [bootstrap-node-1]
  patterns:
    - "Sync session complete"
  tail_lines: 5000
```

## Registration sites

Mirrors the `AssertStep` precedent at four sites:

- `merobox/commands/bootstrap/config.py` — `AssertLogAbsentStepConfig` / `AssertLogPresentStepConfig` pydantic models + `STEP_TYPE_MODELS` entries + `VALID_STEP_TYPES` set
- `merobox/commands/bootstrap/validate/validator.py` — import + `elif step_type == "assert_log_absent" / "assert_log_present"` dispatcher branches
- `merobox/commands/bootstrap/steps/__init__.py` — re-export + `__all__`
- `merobox/commands/bootstrap/run/executor.py` — import + executor dispatcher branches

## Test plan

- [x] 24 new unit tests in `merobox/tests/unit/test_assert_log_step.py` cover:
  - schema validation (missing/empty/non-string `patterns`, non-bool `regex`/`case_sensitive`, non-positive `tail_lines`/`min_matches`, empty-`nodes` allowed)
  - `assert_log_absent` pass on clean logs, fail on any match across any node
  - `assert_log_present` pass when every pattern hits, fail when one is missing, `min_matches` aggregation across nodes
  - `regex` flag toggles between literal and regex matching
  - `tail_lines` limits the search window (pattern outside the window doesn't trigger)
  - `case_sensitive=false` lower-cases both sides of the comparison
  - empty `nodes:` list calls `manager.get_running_nodes()`
  - binary mode dispatches through `manager.get_node_logs(name, lines=...)` instead of `container.logs`
  - failure output contains the offending node + matched line + pattern
- [x] All 24 pass; full unit suite (`merobox/tests/unit/`) has zero new failures vs. master baseline
- [x] `ruff check` and `black --check` clean on touched files
- [x] Smoke-tested YAML round-trip through `validate_workflow_config` — both new step types accepted; missing `patterns` correctly rejected

## Consumer migration

After merge + release (per the issue):
1. Bump merobox version pin in `calimero-network/core`.
2. Replace the inline `run: grep ...` in `sync-regression.yml`'s #2356 guard with `assert_log_absent` inside the merobox workflow YAMLs.
3. Add `assert_log_absent` steps inline in `apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml` and `asymmetric-context-membership.yml` to close the regression-detection gap that core#2431 inherited when the dedicated runner was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new workflow step types that read and scan node logs in both Docker and binary modes, which can change workflow execution outcomes and introduce new failure modes if log retrieval behaves differently across environments.
> 
> **Overview**
> Adds two new workflow step types, `assert_log_absent` and `assert_log_present`, to let workflows enforce log-based regression gates inline (with options for `regex`, `case_sensitive`, `tail_lines`, and `min_matches`).
> 
> Registers these steps across schema validation (`config.py`), runtime execution (`run/executor.py`), and config-only validation (`validate/validator.py`), and re-exports them from `steps/__init__.py`.
> 
> Implements the log scanning logic in new `steps/assert_log.py` (including handling for empty `nodes: []` = all running nodes, Docker vs binary log retrieval, and explicit failures when no logs are retrievable), adds comprehensive unit tests, and includes an example workflow YAML demonstrating usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318bfb707a9036c1361bef3d72f26442c3e90ab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->