### PR TITLE
chore: release 0.6.16 — assert_log_absent / assert_log_present steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.16] - 2026-05-21
+
+### Added
+
+- Two new workflow step types — `assert_log_absent` and `assert_log_present`
+  — that assert on the contents of a node's docker / binary logs, so
+  regression workflows can express log-grep gates inline instead of relying
+  on out-of-band CI shell steps to download log artefacts and post-grep
+  them. `assert_log_absent` fails if any pattern matches in any of the
+  named nodes' logs; `assert_log_present` fails unless every pattern has
+  at least `min_matches` hits aggregated across the union of named nodes.
+  Shared schema knobs: `regex` (default false, literal substring), `tail_lines`
+  (default unbounded), `case_sensitive` (default true), `min_matches`
+  (default 1, present-only). Empty `nodes:` list resolves to all running
+  nodes at execute time. Docker mode uses `container.logs(tail=...,
+  timestamps=False)`; binary mode uses `BinaryManager.get_node_logs`.
+  Closes calimero-network/merobox#243; unblocks restoring the regression
+  gates lost when calimero-network/core#2431 folded the auto-follow
+  workflows into the e2e matrix.
+
 ## [0.6.14] - 2026-05-14
 
 ### Changed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.15"
+__version__ = "0.6.16"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
## Summary

Bumps `__version__` from `0.6.15` to `0.6.16` and adds a 0.6.16 CHANGELOG entry, releasing the `assert_log_absent` / `assert_log_present` step types from #244 (which closed #243).

## Why now

Issue #243 was opened because calimero-network/core#2431 folded five auto-follow regression workflows into the e2e matrix but lost the post-grep regression gates that the old dedicated runner used. Without a release, consumers in `calimero-network/core` can't pin merobox to a version that contains the new step types and restore those gates inline.

## Changes

- `merobox/__init__.py`: `__version__ = "0.6.15"` → `"0.6.16"`
- `CHANGELOG.md`: new `## [0.6.16] - 2026-05-21` section under `[Unreleased]`, documenting the two new step types, their schema, and the motivation (linking back to #243 and core#2431).

No code changes — the step types themselves landed in PR #244 (merged in commit b694dc0).

## Test plan

- [x] `__version__` import resolves: `python -c "import merobox; print(merobox.__version__)"` → `0.6.16`
- [x] Release Pipeline / `Check version bump` job should pass (version increased from master baseline)
- [x] All other CI jobs that ran green on #244 should remain green here (this branch carries no functional changes on top of master beyond the version stamp + changelog)

## Consumer migration (after this merges)

In `calimero-network/core`:
1. Bump the merobox version pin in the apt-repo / install action to `0.6.16`.
2. Replace `sync-regression.yml`'s `#2356` inline `run: grep ...` with `assert_log_absent` inside the merobox workflow YAMLs.
3. Add `assert_log_absent` steps inline in `apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml` and `asymmetric-context-membership.yml` to close the regression-detection gap inherited from #2431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package version and adds a changelog entry; no functional code changes.
> 
> **Overview**
> **Release bookkeeping for `0.6.16`.**
> 
> Updates `merobox.__version__` to `0.6.16` and adds a `CHANGELOG.md` entry describing the newly released workflow steps `assert_log_absent` and `assert_log_present` (log-based regression gates and their key configuration knobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb1cdfc72cb87f9ee59816f7d7e52c9b78b3eb25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->