### PR TITLE
feat(workflow): add preserve_default_bootstrap opt-out (closes #252); bump 0.6.17 -> 0.6.18

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.17"
+__version__ = "0.6.18"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/binary_manager.py
+++ b/merobox/commands/binary_manager.py
@@ -207,6 +207,8 @@ class BinaryManager(CleanupMixin):
         bootstrap_nodes: list[str] = None,  # bootstrap nodes to connect to
         auth_mode: Optional[str] = None,  # Authentication mode (embedded, proxy)
         merod_args: Optional[str] = None,  # Additional arguments to pass to merod run
+        preserve_default_bootstrap: bool = False,  # keep merod-init bootstrap.nodes in e2e mode
+        **_ignored,  # tolerate Docker-only kwargs (mdns, network_admin, etc.)
     ) -> bool:
         """
         Run a Calimero node as a native binary process.
@@ -355,7 +357,12 @@ class BinaryManager(CleanupMixin):
 
             # Apply e2e-style configuration for reliable testing (only if e2e_mode is enabled)
             if e2e_mode:
-                apply_e2e_defaults(actual_config_file, node_name, workflow_id)
+                apply_e2e_defaults(
+                    actual_config_file,
+                    node_name,
+                    workflow_id,
+                    preserve_default_bootstrap=preserve_default_bootstrap,
+                )
 
             # Apply bootstrap nodes configuration (works regardless of e2e_mode)
             if bootstrap_nodes:
@@ -828,6 +835,8 @@ class BinaryManager(CleanupMixin):
         bootstrap_nodes: list[str] = None,  # bootstrap nodes to connect to
         auth_mode: Optional[str] = None,  # Authentication mode (embedded, proxy)
         merod_args: Optional[str] = None,  # Additional arguments to pass to merod run
+        preserve_default_bootstrap: bool = False,  # keep merod-init bootstrap.nodes in e2e mode
+        **_ignored,  # tolerate Docker-only kwargs
     ) -> bool:
         """
         Start multiple nodes with sequential naming.
@@ -905,6 +914,7 @@ class BinaryManager(CleanupMixin):
                 bootstrap_nodes=bootstrap_nodes,
                 auth_mode=auth_mode,
                 merod_args=merod_args,
+                preserve_default_bootstrap=preserve_default_bootstrap,
             )
 
         with ThreadPoolExecutor(max_workers=count) as pool:

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1260,7 +1260,7 @@ class WorkflowConfig(BaseModel):
     bootstrap_nodes: Optional[list[str]] = Field(
         None, description="Bootstrap nodes to connect to"
     )
-    preserve_default_bootstrap: Optional[bool] = Field(
+    preserve_default_bootstrap: bool = Field(
         False,
         description=(
             "When `--e2e-mode` is in effect, skip clearing `bootstrap.nodes` "

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1260,6 +1260,18 @@ class WorkflowConfig(BaseModel):
     bootstrap_nodes: Optional[list[str]] = Field(
         None, description="Bootstrap nodes to connect to"
     )
+    preserve_default_bootstrap: Optional[bool] = Field(
+        False,
+        description=(
+            "When `--e2e-mode` is in effect, skip clearing `bootstrap.nodes` "
+            "in apply_e2e_defaults. The default boot-node list that "
+            "`merod init` writes (the public devnet boot-node from "
+            "calimero-network/core) is preserved instead. Useful for "
+            "workflows that need a stable rendezvous server outside the "
+            "test cluster but don't want to hard-code the exact boot-node "
+            "addresses in the workflow YAML."
+        ),
+    )
 
 
 def _format_pydantic_error(error: dict[str, Any]) -> str:

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -839,6 +839,7 @@ class WorkflowExecutor:
             "e2e_mode": self.e2e_mode,
             "config_path": config_path,
             "bootstrap_nodes": self.bootstrap_nodes,
+            # keep merod-init bootstrap.nodes when True (opt-out of e2e isolation)
             "preserve_default_bootstrap": self.preserve_default_bootstrap,
         }
         if self.is_binary_mode:
@@ -919,6 +920,10 @@ class WorkflowExecutor:
                     "workflow_id": self.workflow_id,
                     "e2e_mode": self.e2e_mode,
                     "bootstrap_nodes": self.bootstrap_nodes,
+                    # Mirror _build_run_node_kwargs so the restart+count
+                    # path doesn't silently drop the opt-out when the
+                    # workflow sets preserve_default_bootstrap: true.
+                    "preserve_default_bootstrap": self.preserve_default_bootstrap,
                 }
                 if not self.is_binary_mode:
                     if "mdns" in nodes_config:

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -180,6 +180,15 @@ class WorkflowExecutor:
         # Bootstrap nodes can be specified in workflow config to override e2e_mode's empty default
         self.bootstrap_nodes = config.get("bootstrap_nodes", None)
 
+        # When true and e2e_mode is in effect, apply_e2e_defaults skips the
+        # "bootstrap.nodes": [] clear, so the public boot-node from
+        # `merod init` survives. Off by default to preserve test
+        # isolation; opt-in for workflows that need a stable rendezvous
+        # server outside the test cluster.
+        self.preserve_default_bootstrap = config.get(
+            "preserve_default_bootstrap", False
+        )
+
         # Generate unique workflow ID for test isolation (like e2e tests)
         self.workflow_id = str(uuid.uuid4())[:8]
 
@@ -830,6 +839,7 @@ class WorkflowExecutor:
             "e2e_mode": self.e2e_mode,
             "config_path": config_path,
             "bootstrap_nodes": self.bootstrap_nodes,
+            "preserve_default_bootstrap": self.preserve_default_bootstrap,
         }
         if self.is_binary_mode:
             if self.auth_mode:

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -185,8 +185,12 @@ class WorkflowExecutor:
         # `merod init` survives. Off by default to preserve test
         # isolation; opt-in for workflows that need a stable rendezvous
         # server outside the test cluster.
-        self.preserve_default_bootstrap = config.get(
-            "preserve_default_bootstrap", False
+        # bool() cast guards against a non-bool truthy in the YAML
+        # (e.g. the string "yes") that Pydantic would have rejected on
+        # the model path — `config` here is the raw dict, not the
+        # validated model.
+        self.preserve_default_bootstrap = bool(
+            config.get("preserve_default_bootstrap", False)
         )
 
         # Generate unique workflow ID for test isolation (like e2e tests)

--- a/merobox/commands/config_utils.py
+++ b/merobox/commands/config_utils.py
@@ -231,6 +231,7 @@ def apply_e2e_defaults(
     config_file: Union[Path, str],
     node_name: str,
     workflow_id: Optional[str] = None,
+    preserve_default_bootstrap: bool = False,
 ) -> bool:
     """
     Apply e2e-style defaults for reliable testing.
@@ -239,6 +240,11 @@ def apply_e2e_defaults(
         config_file: Path to the config.toml file (Path or str)
         node_name: Name of the node (for logging)
         workflow_id: Optional workflow ID for test isolation. Generated if not provided.
+        preserve_default_bootstrap: When True, skip clearing `bootstrap.nodes`,
+            leaving whatever `merod init` wrote (the public devnet boot-node).
+            Off by default so the e2e defaults remain isolated from any
+            outside network; opt-in for workflows that explicitly want a
+            stable rendezvous server outside the test cluster.
     """
     try:
         # Generate unique workflow ID if not provided
@@ -258,8 +264,6 @@ def apply_e2e_defaults(
         # Note: Only bootstrap, discovery, and sync settings are configured here.
         # Protocol-specific config (Ethereum, ICP, etc.) should be handled separately.
         e2e_config = {
-            # Disable bootstrap nodes for test isolation
-            "bootstrap.nodes": [],
             # Use unique rendezvous namespace per workflow (like e2e tests)
             "discovery.rendezvous.namespace": f"calimero/merobox-tests/{workflow_id}",
             # Keep mDNS as backup (like e2e tests)
@@ -271,6 +275,14 @@ def apply_e2e_defaults(
             # 1s periodic checks (ensures rapid sync in tests)
             "sync.frequency_ms": 1000,
         }
+
+        # By default, clear bootstrap.nodes to fully isolate the cluster
+        # from any outside network. Workflows can opt out via the
+        # `preserve_default_bootstrap` field to keep whatever `merod
+        # init` wrote (the public devnet boot-node) as a stable
+        # rendezvous server.
+        if not preserve_default_bootstrap:
+            e2e_config["bootstrap.nodes"] = []
 
         # Apply each configuration
         for key, value in e2e_config.items():

--- a/merobox/commands/config_utils.py
+++ b/merobox/commands/config_utils.py
@@ -136,6 +136,36 @@ def apply_mdns_setting(
         return False
 
 
+def read_bootstrap_nodes(config_file: Union[Path, str]) -> list[str]:
+    """Read the current ``bootstrap.nodes`` list from a node's config.toml.
+
+    The list reflects whatever was last written by ``merod init`` (the
+    public devnet boot-node), ``apply_e2e_defaults`` (cleared to ``[]``
+    by default; preserved when ``preserve_default_bootstrap=True``), or
+    ``apply_bootstrap_nodes`` (an explicit workflow-supplied list).
+    Callers that need to *extend* the existing list rather than
+    overwrite it — e.g. cluster-wiring code that appends sibling addrs
+    after the per-node config has already been written — read it here
+    so the preceding writes survive.
+
+    Returns an empty list if the file is missing, the key is absent, or
+    the stored value isn't a list.
+    """
+    try:
+        config_path = Path(config_file)
+        if not config_path.exists():
+            return []
+        with open(config_path, encoding="utf-8") as f:
+            config = toml.load(f)
+        nodes = config.get("bootstrap", {}).get("nodes", [])
+        return list(nodes) if isinstance(nodes, list) else []
+    except Exception as e:
+        console.print(
+            f"[red]✗ Failed to read bootstrap.nodes from {config_file}: {e}[/red]"
+        )
+        return []
+
+
 def read_peer_id(config_file: Union[Path, str]) -> Optional[str]:
     """
     Read the libp2p peer ID from a node's config.toml.

--- a/merobox/commands/config_utils.py
+++ b/merobox/commands/config_utils.py
@@ -263,18 +263,7 @@ def apply_e2e_defaults(
         # Apply e2e-style defaults for reliable testing
         # Note: Only bootstrap, discovery, and sync settings are configured here.
         # Protocol-specific config (Ethereum, ICP, etc.) should be handled separately.
-        e2e_config = {
-            # Use unique rendezvous namespace per workflow (like e2e tests)
-            "discovery.rendezvous.namespace": f"calimero/merobox-tests/{workflow_id}",
-            # Keep mDNS as backup (like e2e tests)
-            "discovery.mdns": True,
-            # Aggressive sync settings from e2e tests for reliable testing
-            "sync.timeout_ms": 30000,  # 30s timeout (matches production)
-            # 500ms between syncs (very aggressive for tests)
-            "sync.interval_ms": 500,
-            # 1s periodic checks (ensures rapid sync in tests)
-            "sync.frequency_ms": 1000,
-        }
+        e2e_config = {}
 
         # By default, clear bootstrap.nodes to fully isolate the cluster
         # from any outside network. Workflows can opt out via the
@@ -283,6 +272,21 @@ def apply_e2e_defaults(
         # rendezvous server.
         if not preserve_default_bootstrap:
             e2e_config["bootstrap.nodes"] = []
+
+        e2e_config.update(
+            {
+                # Use unique rendezvous namespace per workflow (like e2e tests)
+                "discovery.rendezvous.namespace": f"calimero/merobox-tests/{workflow_id}",
+                # Keep mDNS as backup (like e2e tests)
+                "discovery.mdns": True,
+                # Aggressive sync settings from e2e tests for reliable testing
+                "sync.timeout_ms": 30000,  # 30s timeout (matches production)
+                # 500ms between syncs (very aggressive for tests)
+                "sync.interval_ms": 500,
+                # 1s periodic checks (ensures rapid sync in tests)
+                "sync.frequency_ms": 1000,
+            }
+        )
 
         # Apply each configuration
         for key, value in e2e_config.items():

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -23,6 +23,7 @@ from merobox.commands.config_utils import (
     apply_e2e_defaults,
     apply_mdns_setting,
     build_sibling_bootstrap_addrs,
+    read_bootstrap_nodes,
     read_peer_id,
 )
 from merobox.commands.constants import (
@@ -1518,11 +1519,25 @@ class DockerManager(CleanupMixin):
             endpoints = {n: (ip, pid) for n, (ip, pid, _) in resolved.items()}
             restarted: list[str] = []
             for node_name, (_ip, _pid, config_file) in resolved.items():
+                # `apply_bootstrap_nodes` further down REPLACES bootstrap.nodes
+                # wholesale, so anything we want to keep across the wiring step
+                # has to be folded into `existing` here. Read the on-disk list
+                # so a preserved merod-init boot-node (under
+                # `preserve_default_bootstrap=True`) and any prior write from
+                # an explicit workflow `bootstrap_nodes:` field both survive
+                # alongside the sibling addrs we're about to compute.
+                # `dict.fromkeys` keeps insertion order while deduping in case
+                # the workflow's `bootstrap_nodes:` (passed in here as
+                # `base_bootstrap_nodes`) and the on-disk list overlap.
+                existing_on_disk = read_bootstrap_nodes(config_file)
+                merged_existing = list(
+                    dict.fromkeys(list(base_bootstrap_nodes or []) + existing_on_disk)
+                )
                 addrs = build_sibling_bootstrap_addrs(
                     node_name,
                     endpoints,
                     DEFAULT_P2P_PORT,
-                    existing=base_bootstrap_nodes,
+                    existing=merged_existing,
                 )
                 if not addrs:
                     continue

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -338,6 +338,7 @@ class DockerManager(CleanupMixin):
         network: str = None,  # user-defined Docker network to attach the node to
         mdns: Optional[bool] = None,  # force discovery.mdns in node config
         network_admin: bool = True,  # add NET_ADMIN cap for fault-injection steps
+        preserve_default_bootstrap: bool = False,  # keep merod-init bootstrap.nodes in e2e mode
     ) -> bool:
         """Run a Calimero node container."""
         try:
@@ -715,7 +716,12 @@ class DockerManager(CleanupMixin):
                 # Apply e2e-style configuration for reliable testing (only if e2e_mode is enabled)
                 if e2e_mode:
                     self._fix_permissions(node_data_dir)
-                    apply_e2e_defaults(config_file, node_name, workflow_id)
+                    apply_e2e_defaults(
+                        config_file,
+                        node_name,
+                        workflow_id,
+                        preserve_default_bootstrap=preserve_default_bootstrap,
+                    )
 
                 # Apply bootstrap nodes configuration (works regardless of e2e_mode)
                 if bootstrap_nodes:
@@ -731,7 +737,12 @@ class DockerManager(CleanupMixin):
                     console.print(
                         f"[cyan]Applying e2e defaults to {node_name} for test isolation...[/cyan]"
                     )
-                    apply_e2e_defaults(config_file, node_name, workflow_id)
+                    apply_e2e_defaults(
+                        config_file,
+                        node_name,
+                        workflow_id,
+                        preserve_default_bootstrap=preserve_default_bootstrap,
+                    )
 
             # Now start the actual node
             console.print(f"[yellow]Starting node {node_name}...[/yellow]")
@@ -1268,6 +1279,7 @@ class DockerManager(CleanupMixin):
         cors_allowed_origins: list[str] = None,  # explicit CORS origin allowlist
         mdns: Optional[bool] = None,
         network_admin: bool = True,
+        preserve_default_bootstrap: bool = False,  # keep merod-init bootstrap.nodes in e2e mode
     ) -> bool:
         """Run multiple Calimero nodes with automatic port allocation."""
         console.print(f"[bold]Starting {count} Calimero nodes...[/bold]")
@@ -1328,6 +1340,7 @@ class DockerManager(CleanupMixin):
                 network=cluster_network,
                 mdns=mdns,
                 network_admin=network_admin,
+                preserve_default_bootstrap=preserve_default_bootstrap,
             )
 
         success_count = 0

--- a/merobox/tests/unit/test_config_utils.py
+++ b/merobox/tests/unit/test_config_utils.py
@@ -145,7 +145,12 @@ def test_apply_e2e_defaults_clears_existing_bootstrap_by_default():
     `test_apply_e2e_defaults` case above starts from an empty config and
     therefore doesn't exercise the *clearing* behaviour against a
     populated list; this test does."""
-    devnet_boot = "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooW" + "X" * 44
+    # Synthetic multiaddr — localhost + `12D3KooW` + 44 X's. The peer-id
+    # body is structurally a base58btc-shaped placeholder, not a real
+    # peer; the IP is loopback so there's no coupling to any external
+    # service. The test only cares that `apply_e2e_defaults` sees a
+    # non-empty `bootstrap.nodes` and handles it correctly.
+    devnet_boot = "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW" + "X" * 44
 
     with patch("merobox.commands.config_utils.toml") as mock_toml:
         mock_toml.load.return_value = {"bootstrap": {"nodes": [devnet_boot]}}
@@ -190,7 +195,12 @@ def test_apply_e2e_defaults_preserve_default_bootstrap():
     applies the rest of the e2e defaults (discovery + sync)."""
     # Simulate what `merod init` writes by default: a single public
     # devnet boot-node in the bootstrap list.
-    devnet_boot = "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooW" + "X" * 44
+    # Synthetic multiaddr — localhost + `12D3KooW` + 44 X's. The peer-id
+    # body is structurally a base58btc-shaped placeholder, not a real
+    # peer; the IP is loopback so there's no coupling to any external
+    # service. The test only cares that `apply_e2e_defaults` sees a
+    # non-empty `bootstrap.nodes` and handles it correctly.
+    devnet_boot = "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW" + "X" * 44
     initial_config = {"bootstrap": {"nodes": [devnet_boot]}}
 
     with patch("merobox.commands.config_utils.toml") as mock_toml:

--- a/merobox/tests/unit/test_config_utils.py
+++ b/merobox/tests/unit/test_config_utils.py
@@ -139,6 +139,50 @@ def test_apply_e2e_defaults_file_not_found():
         assert result is False
 
 
+def test_apply_e2e_defaults_preserve_default_bootstrap():
+    """preserve_default_bootstrap=True keeps whatever bootstrap.nodes was
+    written by `merod init` (the public devnet boot-node), and still
+    applies the rest of the e2e defaults (discovery + sync)."""
+    # Simulate what `merod init` writes by default: a single public
+    # devnet boot-node in the bootstrap list.
+    devnet_boot = "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooW" + "X" * 44
+    initial_config = {"bootstrap": {"nodes": [devnet_boot]}}
+
+    with patch("merobox.commands.config_utils.toml") as mock_toml:
+        mock_toml.load.return_value = {
+            "bootstrap": {"nodes": list(initial_config["bootstrap"]["nodes"])}
+        }
+
+        with patch("builtins.open", mock_open()):
+            with (
+                patch("pathlib.Path.exists", return_value=True),
+                patch("pathlib.Path.chmod"),
+                patch("pathlib.Path.stat"),
+            ):
+                result = apply_e2e_defaults(
+                    Path("/tmp/config.toml"),
+                    "node1",
+                    workflow_id="test-keep-boot",
+                    preserve_default_bootstrap=True,
+                )
+
+                assert result is True
+
+                args, _ = mock_toml.dump.call_args
+                config_dict = args[0]
+
+                # The boot-node from `merod init` survives — this is the
+                # whole point of the opt-out.
+                assert config_dict["bootstrap"]["nodes"] == [devnet_boot]
+                # Discovery + sync defaults still applied.
+                assert (
+                    config_dict["discovery"]["rendezvous"]["namespace"]
+                    == "calimero/merobox-tests/test-keep-boot"
+                )
+                assert config_dict["discovery"]["mdns"] is True
+                assert config_dict["sync"]["timeout_ms"] == 30000
+
+
 # ---------------------------------------------------------------------------
 # read_peer_id
 # ---------------------------------------------------------------------------

--- a/merobox/tests/unit/test_config_utils.py
+++ b/merobox/tests/unit/test_config_utils.py
@@ -170,6 +170,18 @@ def test_apply_e2e_defaults_clears_existing_bootstrap_by_default():
 
                 # Pre-existing boot-node was cleared (the isolation default).
                 assert config_dict["bootstrap"]["nodes"] == []
+                # Clearing the boot-node must NOT skip the discovery/sync
+                # defaults — guards against a refactor regression where
+                # the conditional bootstrap.nodes block accidentally
+                # short-circuits the rest of the e2e_config dict.
+                assert (
+                    config_dict["discovery"]["rendezvous"]["namespace"]
+                    == "calimero/merobox-tests/test-clear-boot"
+                )
+                assert config_dict["discovery"]["mdns"] is True
+                assert config_dict["sync"]["timeout_ms"] == 30000
+                assert config_dict["sync"]["interval_ms"] == 500
+                assert config_dict["sync"]["frequency_ms"] == 1000
 
 
 def test_apply_e2e_defaults_preserve_default_bootstrap():

--- a/merobox/tests/unit/test_config_utils.py
+++ b/merobox/tests/unit/test_config_utils.py
@@ -5,6 +5,7 @@ from merobox.commands.config_utils import (
     apply_bootstrap_nodes,
     apply_e2e_defaults,
     build_sibling_bootstrap_addrs,
+    read_bootstrap_nodes,
     read_peer_id,
     set_nested_config,
 )
@@ -267,6 +268,54 @@ def test_read_peer_id_file_not_found_returns_none():
     """read_peer_id returns None when the config file does not exist."""
     with patch("pathlib.Path.exists", return_value=False):
         assert read_peer_id(Path("/missing/config.toml")) is None
+
+
+# ---------------------------------------------------------------------------
+# read_bootstrap_nodes
+# ---------------------------------------------------------------------------
+
+
+def test_read_bootstrap_nodes_returns_existing_list():
+    """read_bootstrap_nodes echoes the bootstrap.nodes list verbatim — the
+    cluster-wiring code relies on this to recover the preserved merod-init
+    boot-node before it appends sibling addrs."""
+    devnet = "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW" + "Y" * 44
+    config = {"bootstrap": {"nodes": [devnet]}, "discovery": {"mdns": True}}
+
+    with patch("merobox.commands.config_utils.toml") as mock_toml:
+        mock_toml.load.return_value = config
+        with patch("builtins.open", mock_open()):
+            with patch("pathlib.Path.exists", return_value=True):
+                assert read_bootstrap_nodes(Path("/tmp/config.toml")) == [devnet]
+
+
+def test_read_bootstrap_nodes_missing_key_returns_empty():
+    """When `apply_e2e_defaults` has cleared the list (the default
+    isolation behaviour) the wiring code must treat the absence the same
+    as an explicit empty list and not raise."""
+    with patch("merobox.commands.config_utils.toml") as mock_toml:
+        mock_toml.load.return_value = {"discovery": {"mdns": True}}
+        with patch("builtins.open", mock_open()):
+            with patch("pathlib.Path.exists", return_value=True):
+                assert read_bootstrap_nodes(Path("/tmp/config.toml")) == []
+
+
+def test_read_bootstrap_nodes_file_not_found_returns_empty():
+    """No config file (e.g. the node hasn't been initialised yet) must
+    return [] so callers can fall through to their own defaults."""
+    with patch("pathlib.Path.exists", return_value=False):
+        assert read_bootstrap_nodes(Path("/missing/config.toml")) == []
+
+
+def test_read_bootstrap_nodes_non_list_value_returns_empty():
+    """Defensive: if the on-disk config has been corrupted and the value
+    is a scalar (or anything non-list), don't propagate the bad shape to
+    the wiring code — return [] and let it fall back."""
+    with patch("merobox.commands.config_utils.toml") as mock_toml:
+        mock_toml.load.return_value = {"bootstrap": {"nodes": "not-a-list"}}
+        with patch("builtins.open", mock_open()):
+            with patch("pathlib.Path.exists", return_value=True):
+                assert read_bootstrap_nodes(Path("/tmp/config.toml")) == []
 
 
 # ---------------------------------------------------------------------------

--- a/merobox/tests/unit/test_config_utils.py
+++ b/merobox/tests/unit/test_config_utils.py
@@ -139,6 +139,39 @@ def test_apply_e2e_defaults_file_not_found():
         assert result is False
 
 
+def test_apply_e2e_defaults_clears_existing_bootstrap_by_default():
+    """The default (preserve_default_bootstrap=False) clears a pre-existing
+    boot-node list — confirming the e2e-isolation guarantee. The
+    `test_apply_e2e_defaults` case above starts from an empty config and
+    therefore doesn't exercise the *clearing* behaviour against a
+    populated list; this test does."""
+    devnet_boot = "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooW" + "X" * 44
+
+    with patch("merobox.commands.config_utils.toml") as mock_toml:
+        mock_toml.load.return_value = {"bootstrap": {"nodes": [devnet_boot]}}
+
+        with patch("builtins.open", mock_open()):
+            with (
+                patch("pathlib.Path.exists", return_value=True),
+                patch("pathlib.Path.chmod"),
+                patch("pathlib.Path.stat"),
+            ):
+                result = apply_e2e_defaults(
+                    Path("/tmp/config.toml"),
+                    "node1",
+                    workflow_id="test-clear-boot",
+                    # preserve_default_bootstrap omitted = default False
+                )
+
+                assert result is True
+
+                args, _ = mock_toml.dump.call_args
+                config_dict = args[0]
+
+                # Pre-existing boot-node was cleared (the isolation default).
+                assert config_dict["bootstrap"]["nodes"] == []
+
+
 def test_apply_e2e_defaults_preserve_default_bootstrap():
     """preserve_default_bootstrap=True keeps whatever bootstrap.nodes was
     written by `merod init` (the public devnet boot-node), and still

--- a/workflow-examples/workflow-preserve-default-bootstrap-cluster.yml
+++ b/workflow-examples/workflow-preserve-default-bootstrap-cluster.yml
@@ -1,0 +1,117 @@
+description: >
+  Multi-node companion to workflow-preserve-default-bootstrap.yml.
+
+  The single-node workflow proves `preserve_default_bootstrap: true`
+  is respected by `apply_e2e_defaults`. This one proves the preserved
+  boot-node *survives* the cluster-bootstrap-wiring step.
+
+  Why a separate workflow
+  -----------------------
+
+  In Docker mode with count >= 2, after every node's config has been
+  written by `apply_e2e_defaults`, merobox runs
+  `_wire_cluster_bootstrap_peers` to populate each node's
+  `bootstrap.nodes` with the *other* nodes' libp2p addresses (so the
+  cluster can connect without relying on mDNS). That step calls
+  `apply_bootstrap_nodes`, which REPLACES the on-disk list wholesale.
+  If the wiring code doesn't fold the existing list back in, the
+  merod-init devnet boot-node that `preserve_default_bootstrap=True`
+  saved is silently lost — the user's opt-out becomes a no-op for
+  every multi-node cluster.
+
+  The fix at `_wire_cluster_bootstrap_peers` reads the on-disk
+  `bootstrap.nodes` (via `read_bootstrap_nodes`) and merges it into
+  the wiring step's `existing` list. This workflow regress-tests
+  that fix: with 2 nodes in Docker mode, the wiring step actually
+  runs, and the `assert_log_present` for the public devnet peer ID
+  would fail (the devnet would not be dialed) if the merge weren't
+  in place.
+
+  See also: workflow-examples/workflow-preserve-default-bootstrap.yml
+  for the single-node smoke test (which doesn't trigger
+  `_wire_cluster_bootstrap_peers` and so doesn't exercise this code
+  path).
+name: Preserve Default Bootstrap — Cluster
+
+# Two nodes — minimum for `_wire_cluster_bootstrap_peers` to engage
+# (`len(resolved) < 2` short-circuits with a warning and returns
+# False otherwise; see manager.py).
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: preserve-boot-cluster
+  base_port: 9050
+  base_rpc_port: 9150
+
+# The opt-out under test.
+preserve_default_bootstrap: true
+
+steps:
+  # Smoke: install an app + create a context. Proves the bootstrap-
+  # write paths (apply_e2e_defaults, apply_bootstrap_nodes via the
+  # wiring step, container restart) didn't blow up under the new
+  # field in the multi-node code path.
+  - name: Install Application on node-1
+    type: install_application
+    node: preserve-boot-cluster-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace on node-1
+    type: create_namespace
+    node: preserve-boot-cluster-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Context on node-1
+    type: create_context
+    node: preserve-boot-cluster-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      context_id: contextId
+
+  # Both nodes restarted by the wiring step; give libp2p time to
+  # emit its first round of bootstrap-dial logs after that restart.
+  - name: Wait for post-wiring bootstrap dials
+    type: wait
+    seconds: 10
+
+  # The regression assertion. The devnet boot-node peer ID must
+  # appear in BOTH nodes' logs, because both nodes were given the
+  # devnet entry by `merod init`, both had it preserved by
+  # `apply_e2e_defaults`, and the wiring step must have folded it
+  # back in before writing the sibling-augmented list.
+  #
+  # The same banner-warning rule from the single-node workflow
+  # applies: rotating the public devnet boot-node in
+  # `crates/network/primitives/src/config.rs` requires updating
+  # this peer ID in both workflow files.
+  - name: Assert preserved boot-node survives cluster wiring on node-1
+    type: assert_log_present
+    nodes: [preserve-boot-cluster-1]
+    patterns:
+      - "12D3KooWR5V4zmisVtVdGE6i8jfFwtgRNq5t8eDGxfckKuhXu7Eh"
+
+  - name: Assert preserved boot-node survives cluster wiring on node-2
+    type: assert_log_present
+    nodes: [preserve-boot-cluster-2]
+    patterns:
+      - "12D3KooWR5V4zmisVtVdGE6i8jfFwtgRNq5t8eDGxfckKuhXu7Eh"
+
+  # Regression guard against the wiring path introducing a startup
+  # crash under the new field.
+  - name: No panics or fatal errors on either node
+    type: assert_log_absent
+    nodes:
+      - preserve-boot-cluster-1
+      - preserve-boot-cluster-2
+    patterns:
+      - "panicked at"
+      - "thread 'main' panicked"
+      - "FATAL"
+
+stop_all_nodes: true

--- a/workflow-examples/workflow-preserve-default-bootstrap.yml
+++ b/workflow-examples/workflow-preserve-default-bootstrap.yml
@@ -1,0 +1,103 @@
+description: >
+  End-to-end test for `preserve_default_bootstrap: true`.
+
+  The default behaviour under `--e2e-mode` is for `apply_e2e_defaults`
+  to clear `bootstrap.nodes` to `[]` for test isolation. Setting
+  `preserve_default_bootstrap: true` opts out, leaving whatever
+  `merod init` wrote in place — the public devnet boot-node from
+  calimero-network/core's stock config.
+
+  Test strategy
+  -------------
+
+  We can't ergonomically introspect the on-disk config.toml from
+  inside a workflow step. So we rely on libp2p emitting log lines
+  about its bootstrap behaviour: when the boot-node list is non-empty,
+  the node dials it on startup, and the dial attempt (or the
+  resulting identify exchange) names the boot-node peer ID in the
+  log stream. If `apply_e2e_defaults` had wiped the list, no such
+  log lines would exist.
+
+  Specifically we assert on the public devnet boot-node peer ID
+  `12D3KooWR5V4zmisVtVdGE6i8jfFwtgRNq5t8eDGxfckKuhXu7Eh`, which is
+  the value `merod init` writes to fresh configs (see
+  `crates/network/primitives/src/config.rs` in calimero-network/core).
+  CI runners are not guaranteed to actually reach the public boot-node,
+  but the dial *attempt* is logged regardless of success — which is
+  exactly the signal we want, since a successful dial is orthogonal to
+  the field's plumbing.
+
+  Counter-checks
+  --------------
+
+  * The node still installs an app and creates a context normally —
+    proves the flag doesn't break the bootstrap-config write path.
+  * `assert_log_absent` for `panicked at` / `FATAL` — guards against
+    the flag introducing a startup crash.
+name: Preserve Default Bootstrap
+
+# Single node — the field only affects how each node's config is
+# written, no multi-node behaviour to exercise.
+nodes:
+  count: 1
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: preserve-boot-node
+  base_port: 9040
+  base_rpc_port: 9140
+
+# The opt-out under test.
+preserve_default_bootstrap: true
+
+steps:
+  # Smoke: install an app + create a context. Proves the node's
+  # bootstrap/config write path didn't blow up under the new field.
+  - name: Install Application
+    type: install_application
+    node: preserve-boot-node-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace
+    type: create_namespace
+    node: preserve-boot-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Context
+    type: create_context
+    node: preserve-boot-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      context_id: contextId
+
+  # Give libp2p time to emit its first round of bootstrap-dial logs.
+  # Default boot-node dial happens within the first few seconds of
+  # startup, but a margin avoids racing the assert step.
+  - name: Wait for bootstrap dial attempts
+    type: wait
+    seconds: 10
+
+  # The core assertion: the boot-node peer ID from `merod init` shows
+  # up in the merod log stream. If `preserve_default_bootstrap` had
+  # been ignored (or apply_e2e_defaults had wiped the list anyway),
+  # this peer ID would not appear because no dial would be attempted.
+  - name: Assert preserved boot-node was dialed
+    type: assert_log_present
+    nodes: [preserve-boot-node-1]
+    patterns:
+      - "12D3KooWR5V4zmisVtVdGE6i8jfFwtgRNq5t8eDGxfckKuhXu7Eh"
+
+  # Regression guard against the field causing a startup crash.
+  - name: No panics or fatal errors
+    type: assert_log_absent
+    nodes: [preserve-boot-node-1]
+    patterns:
+      - "panicked at"
+      - "thread 'main' panicked"
+      - "FATAL"
+
+stop_all_nodes: true

--- a/workflow-examples/workflow-preserve-default-bootstrap.yml
+++ b/workflow-examples/workflow-preserve-default-bootstrap.yml
@@ -85,6 +85,23 @@ steps:
   # up in the merod log stream. If `preserve_default_bootstrap` had
   # been ignored (or apply_e2e_defaults had wiped the list anyway),
   # this peer ID would not appear because no dial would be attempted.
+  #
+  # !!! BOOT-NODE ROTATION: WHEN YOU CHANGE THE DEFAULT BOOT-NODE !!!
+  # This peer ID must stay in sync with the public devnet boot-node
+  # baked into `crates/network/primitives/src/config.rs` in
+  # calimero-network/core. Rotating the boot-node there without
+  # updating this assertion makes the workflow fail for the wrong
+  # reason (peer ID not found in logs) instead of catching a real
+  # regression. The coupling is intentional: there is no stable
+  # structural log pattern from calimero_network that signals
+  # "bootstrap.nodes was non-empty" on the happy path (the only
+  # bootstrap-related log in calimero_network is `warn!("Failed to
+  # bootstrap Kademlia")` on the error path). Pinning to the peer
+  # ID gives a concrete, falsifiable signal at the cost of having
+  # to update this one line on a rotation. The reviewer-suggested
+  # alternatives (env var, regex over libp2p connection logs) all
+  # either re-introduce the same coupling or weaken the assertion
+  # below the threshold where it would catch a real regression.
   - name: Assert preserved boot-node was dialed
     type: assert_log_present
     nodes: [preserve-boot-node-1]


### PR DESCRIPTION
Closes #252.

## What

Adds a new top-level workflow field `preserve_default_bootstrap: bool` (default `false`). When `true`, `apply_e2e_defaults` skips its usual `bootstrap.nodes = []` clear and leaves whatever `merod init` wrote in place — i.e. the public devnet boot-node from `calimero-network/core`'s stock config.

## Why

`apply_e2e_defaults` clears `bootstrap.nodes` to fully isolate the test cluster from any outside network. That's the right default for the bulk of workflows: tests should not depend on a public service being reachable, and the e2e cluster wires its own sibling-bootstrap addrs into each node via `apply_bootstrap_nodes` after the e2e defaults land.

But some workflows (sync-resilience smoke tests, NAT-topology repros) explicitly *want* a stable rendezvous server outside the test cluster so that nodes can find each other after a Docker bridge reconnect or across symmetric NATs. The pre-existing escape hatch — explicitly writing the public devnet multiaddr into the workflow YAML's `bootstrap_nodes:` field — works, but hard-codes a specific endpoint into every workflow that needs it. The new flag lets a workflow say *"keep whatever `merod init` decided"* instead, which tracks core's default config across boot-node rotations without each workflow needing an edit.

## Plumbing

- new `WorkflowConfig.preserve_default_bootstrap: Optional[bool]`
- `WorkflowExecutor` reads it and passes it through `_build_run_node_kwargs` so both Docker and binary runners get it
- `NodeManager.run_node` / `run_nodes` and `BinaryManager.run_node` / `run_multiple_nodes` accept it as a kwarg
- `apply_e2e_defaults(..., preserve_default_bootstrap=False)` conditionally omits the `bootstrap.nodes = []` line from the e2e defaults dict

Binary-mode `run_node` / `run_multiple_nodes` also gained a `**_ignored` catch-all so they keep tolerating Docker-only kwargs (`mdns`, `network_admin`, …) that the executor builds for both runners.

## Usage

```yaml
description: A workflow that needs a stable rendezvous server outside the test cluster
name: my-workflow
preserve_default_bootstrap: true   # ← keeps merod-init bootstrap.nodes
nodes:
  count: 2
  image: ghcr.io/calimero-network/merod:edge
```

The two nodes will start with the public devnet boot-node already in their `bootstrap.nodes`, alongside the per-cluster sibling addrs that `apply_bootstrap_nodes` still writes.

## Test

New unit test exercises the opt-in path: seed the loaded config with a devnet boot-node, call `apply_e2e_defaults(preserve_default_bootstrap=True)`, assert the boot-node survives while the discovery/sync defaults still apply. All 15 `test_config_utils.py` tests pass locally.

## Version

Bumps `merobox/__init__.py` from `0.6.17` → `0.6.18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `--e2e-mode` rewrites `bootstrap.nodes` and how multi-node clusters merge/overwrite bootstrap lists, which can affect connectivity and test isolation across both Docker and binary runners.
> 
> **Overview**
> Adds a workflow-level opt-out (`preserve_default_bootstrap`) so that when `--e2e-mode` is enabled, `apply_e2e_defaults` can *skip* clearing `bootstrap.nodes` and keep the default boot-node written by `merod init`.
> 
> Plumbs the flag through the workflow schema/executor into both Docker and binary node runners (with binary mode now tolerating Docker-only kwargs via `**_ignored`), and updates multi-node cluster wiring to merge any existing on-disk `bootstrap.nodes` (via new `read_bootstrap_nodes`) before rewriting sibling bootstrap peers so preserved/default entries aren’t lost.
> 
> Adds unit coverage for the new `apply_e2e_defaults` behavior and `read_bootstrap_nodes`, ships two example workflows exercising the opt-out (single-node and cluster), and bumps version to `0.6.18`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d13f6b5793a6ef684fc3fce0ce84f1ea1a477f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->