### PR TITLE
fix(nat): widen reachability probe timeout 20s → 60s + bump to 0.6.21

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.20"
+__version__ = "0.6.21"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/topology/nat.py
+++ b/merobox/topology/nat.py
@@ -563,9 +563,18 @@ def inject_default_route_into_client(
 # return "open" after the default-route injection. CI showed the
 # forwarding path settles intermittently — first probe sometimes
 # hits ICMP unreachable while ARP / forwarding state stabilises;
-# a second probe ~1-2s later succeeds. 20s is generous for a slow
-# CI runner without inflating the overall topology-setup budget.
-NAT_CONNECTIVITY_PROBE_TIMEOUT_SECONDS = 20
+# a second probe ~1-2s later succeeds.
+#
+# Was 20s up to 0.6.20. Bumped to 60s because the inlined-iptables
+# gateway (0.6.20+) does `apk add iptables iproute2` at first spawn,
+# which on a cold-cache CI runner adds ~5-15s before the gateway
+# can start forwarding. Combined with the kernel forwarding-path
+# settle (~1-2s) and runner contention, the 20s budget was racing
+# the probe enough to surface 3-of-6 spurious failures on core
+# #2466's sync-resilience matrix. 60s gives the cold path enough
+# room without making the steady-state retry loop slower (the
+# probe still succeeds on attempt 1 once forwarding is up).
+NAT_CONNECTIVITY_PROBE_TIMEOUT_SECONDS = 60
 NAT_CONNECTIVITY_PROBE_INTERVAL_SECONDS = 1.0
 
 


### PR DESCRIPTION
## Why

The inlined-iptables NAT gateway shipped in 0.6.20 does \`apk add iptables ip6tables iproute2\` at first spawn against alpine package mirrors. On a cold-cache CI runner that adds ~5-15s before the gateway can start forwarding. The previous 20s reachability-probe budget was racing this cold path.

Surfaced in [core#2466](https://github.com/calimero-network/core/pull/2466) on commit \`8ba9dfc\`: **3 of 6** sync-resilience matrix jobs failed at:

\`\`\`
❌ sync-resil-node-1 cannot reach the boot-node via the NAT gateway:
sync-resil-node-1 could not reach the boot-node (172.18.0.2:4001)
within 20s after 7 probe(s).
\`\`\`

The diagnostic: a fourth job in the SAME matrix run (peer-pause-symmetric) reached the boot-node on attempt 1 in <1s — because it ran later and benefited from a warm apk cache from the earlier failed jobs. Confirms this is purely a cold-spawn race, not a real reachability bug.

## What

\`NAT_CONNECTIVITY_PROBE_TIMEOUT_SECONDS\`: 20 → 60.

Per-attempt interval (1s) unchanged, so warm-path latency is unaffected. The probe still succeeds on attempt 1 once forwarding is up; the extra budget only ever gets used by cold-cache cold-spawn paths.

Bumps version 0.6.20 → 0.6.21 so downstream \`apt install -y merobox\` picks up the fix without a Cargo-style version pin.

## Verification

\`black --check\` + \`ruff check\` clean. 583/583 unit tests pass.

After this lands and 0.6.21 publishes to APT, core#2466's CI will auto-pick it up via the existing \`setup-merobox\` action (no PR-side change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and version bump in test-topology tooling; no auth, data, or production runtime behavior changes beyond longer waits on slow CI cold starts.
> 
> **Overview**
> **Release 0.6.21** bumps the package version so downstream installs pick up the NAT timing fix.
> 
> **NAT reachability wait:** `NAT_CONNECTIVITY_PROBE_TIMEOUT_SECONDS` in `merobox/topology/nat.py` goes from **20s to 60s** for `wait_for_client_reachability` (1s probe interval unchanged). The longer budget covers first-spawn `apk add` on the inlined Alpine NAT gateway on cold CI caches (~5–15s) plus forwarding settle time, which was causing intermittent “client cannot reach boot-node within 20s” failures. Warm paths still succeed on the first probe once forwarding is up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf04911411f7d7c03f1fd8d65bfc6d658cd579a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->