### PR TITLE
fix(restart): snapshot pre-restart logs to per-restart file

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.21"
+__version__ = "0.6.22"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/restart.py
+++ b/merobox/commands/bootstrap/steps/restart.py
@@ -3,10 +3,22 @@
 Wraps `docker restart` for whole-container restarts. Defaults `wait_healthy`
 to true because a restart that doesn't wait is almost always a footgun in
 test workflows — subsequent steps would race the node's startup.
+
+Also dumps the to-be-killed container's logs to a per-restart file before
+issuing the restart, so a CI artifact-uploader can capture the pre-restart
+incarnation's events. Without this, the CI watcher's `docker logs -f`
+follower (which is keyed on container NAME, not container ID) stays
+attached to the old container ID after `docker restart` swaps the
+underlying container; the new container's logs go uncaptured and any
+post-restart investigation is blind. See
+`apps/scaffolding-e2e/.github/workflows/e2e-rust-apps.yml`'s log-watcher
+loop for the consumer side of this output.
 """
 
 import asyncio
+import os
 import time
+from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
@@ -18,6 +30,15 @@ from merobox.commands.bootstrap.steps._docker_utils import (
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.constants import HEALTH_CHECK_TIMEOUT, NODE_READY_TIMEOUT
 from merobox.commands.utils import console, get_node_rpc_url
+
+# Directory where pre-restart log snapshots get written. CI workflows
+# that want them archived as artifacts should configure their upload
+# step to glob this directory. The default matches the convention
+# `e2e-rust-apps.yml`'s log-watcher uses (`docker-logs/`), so a CI run
+# that already uploads the watcher's output will also pick up the
+# pre-restart snapshots automatically.
+_PRE_RESTART_LOG_DIR_ENV = "MEROBOX_PRE_RESTART_LOG_DIR"
+_PRE_RESTART_LOG_DIR_DEFAULT = "docker-logs"
 
 
 class RestartContainerStep(BaseStep):
@@ -64,6 +85,15 @@ class RestartContainerStep(BaseStep):
         if container is None:
             return False
 
+        # Dump the to-be-killed container's logs BEFORE the restart fires
+        # so the pre-restart incarnation's events survive in a CI
+        # artifact. See module docstring for why the CI watcher alone
+        # isn't enough. Best-effort: a failure to capture must not
+        # block the restart itself — the operator may have asked for
+        # the restart precisely because the container is in a weird
+        # state, and refusing to restart would compound the problem.
+        self._snapshot_pre_restart_logs(container, container_name)
+
         try:
             container.restart()
         except Exception as exc:
@@ -76,6 +106,68 @@ class RestartContainerStep(BaseStep):
             return True
 
         return await self._wait_healthy(container_name, timeout)
+
+    @staticmethod
+    def _snapshot_pre_restart_logs(container: Any, container_name: str) -> None:
+        """Best-effort dump of the container's logs to a numbered file
+        before `docker restart` rotates the underlying container ID.
+
+        Naming convention: ``<dir>/<container>.pre-restart-<utc_ts>.log``
+        where ``<dir>`` is ``$MEROBOX_PRE_RESTART_LOG_DIR`` or, by
+        default, ``docker-logs/`` in the current working directory.
+        The UTC timestamp suffix means multiple restarts of the same
+        container in a single workflow produce distinct files (sortable
+        by name).
+
+        Errors at any step (docker API hiccup, can't create directory,
+        write fails) are logged to the console but never raised — the
+        caller's `container.restart()` must run regardless.
+        """
+        log_dir = os.environ.get(_PRE_RESTART_LOG_DIR_ENV, _PRE_RESTART_LOG_DIR_DEFAULT)
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+        except OSError as exc:
+            console.print(
+                f"[yellow]Could not create pre-restart log dir {log_dir!r}: "
+                f"{exc} (continuing without snapshot)[/yellow]"
+            )
+            return
+
+        # UTC + millisecond precision; the millis matter because rapid
+        # back-to-back restarts in a workflow shouldn't collide.
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        log_path = os.path.join(log_dir, f"{container_name}.pre-restart-{stamp}.log")
+
+        try:
+            # `timestamps=True` so each line carries the docker-side
+            # wall-clock timestamp, matching the format the CI
+            # watcher writes for the post-restart container's logs.
+            log_bytes = container.logs(timestamps=True)
+        except Exception as exc:
+            console.print(
+                f"[yellow]Could not read pre-restart logs for "
+                f"{container_name!r}: {exc} (continuing)[/yellow]"
+            )
+            return
+
+        if isinstance(log_bytes, bytes):
+            log_text = log_bytes.decode("utf-8", errors="replace")
+        else:
+            log_text = str(log_bytes)
+
+        try:
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.write(log_text)
+        except OSError as exc:
+            console.print(
+                f"[yellow]Could not write pre-restart log file "
+                f"{log_path!r}: {exc} (continuing)[/yellow]"
+            )
+            return
+
+        console.print(
+            f"[cyan]Snapshotted pre-restart logs of {container_name!r} → {log_path}[/cyan]"
+        )
 
     async def _wait_healthy(self, container_name: str, timeout: int) -> bool:
         """Poll the node's admin /health endpoint until ready or timeout.

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -249,3 +249,136 @@ class TestDetectNodeNetwork:
         # When container.reload() fails, the function should still pick a
         # network from whatever attrs it has, not crash.
         assert detect_node_network(FlakyContainer()) == "merobox-cluster"
+
+
+# ---------------------------------------------------------------------------
+# RestartContainerStep — pre-restart log snapshot
+#
+# The snapshot fires before `container.restart()` rotates the underlying
+# container ID, so the to-be-killed incarnation's logs survive in a CI
+# artifact. These tests pin the contract:
+#
+#   - Snapshot writes to `<dir>/<container>.pre-restart-<utc>.log`.
+#   - `MEROBOX_PRE_RESTART_LOG_DIR` env var overrides the default dir.
+#   - Failures at every step (mkdir, container.logs, file write) are
+#     logged but never raise — the caller's restart MUST proceed.
+# ---------------------------------------------------------------------------
+
+
+class TestRestartPreRestartLogSnapshot:
+    @staticmethod
+    def _container_with_logs(log_bytes):
+        class _StubContainer:
+            def logs(self, *, timestamps=False):
+                # The implementation passes `timestamps=True`. We don't
+                # care about that detail for the unit test, but accepting
+                # the kwarg keeps the stub honest.
+                _ = timestamps
+                return log_bytes
+
+        return _StubContainer()
+
+    def test_snapshot_writes_expected_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+        RestartContainerStep._snapshot_pre_restart_logs(
+            self._container_with_logs(b"hello\nworld\n"),
+            "sync-resil-node-1",
+        )
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1, f"expected exactly one snapshot file, got {files}"
+        name = files[0].name
+        assert name.startswith("sync-resil-node-1.pre-restart-"), name
+        assert name.endswith(".log"), name
+        # UTC timestamp is the 8-char date + T + 6-char time + 6-char micros + Z.
+        # Just check it's present (any digit-heavy run between the prefix and `.log`).
+        ts = name[len("sync-resil-node-1.pre-restart-") : -len(".log")]
+        assert ts.endswith("Z") and "T" in ts, f"unexpected timestamp shape: {ts!r}"
+        # File contents match what container.logs returned.
+        assert files[0].read_text() == "hello\nworld\n"
+
+    def test_snapshot_handles_str_logs(self, tmp_path, monkeypatch):
+        # docker-py normally returns bytes from container.logs(), but
+        # the helper has a `str` fallback path to defang any wrapper
+        # that decoded it before returning. Pin that path so a future
+        # type change doesn't regress to a TypeError.
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+        RestartContainerStep._snapshot_pre_restart_logs(
+            self._container_with_logs("already-decoded\n"),
+            "n1",
+        )
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].read_text() == "already-decoded\n"
+
+    def test_snapshot_returns_silently_when_container_logs_fail(
+        self, tmp_path, monkeypatch
+    ):
+        # The whole point is to never block a restart. If `container.logs()`
+        # raises (daemon hiccup, container in transient state, anything),
+        # the snapshot must catch and log — not propagate.
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+
+        class _BrokenContainer:
+            def logs(self, *, timestamps=False):
+                _ = timestamps
+                raise RuntimeError("daemon flake")
+
+        # Must NOT raise.
+        RestartContainerStep._snapshot_pre_restart_logs(_BrokenContainer(), "n1")
+        # No file produced.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_snapshot_returns_silently_when_mkdir_fails(self, tmp_path, monkeypatch):
+        # If the snapshot dir can't be created (read-only mount, no
+        # permission, etc.), we must NOT raise. Point the env at a
+        # path under a file (not a directory) so os.makedirs raises
+        # NotADirectoryError, which the helper catches.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        bad_dir = blocker / "logs"
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(bad_dir))
+
+        # Must NOT raise.
+        RestartContainerStep._snapshot_pre_restart_logs(
+            self._container_with_logs(b"unreachable\n"),
+            "n1",
+        )
+
+    def test_snapshot_uses_default_dir_when_env_unset(self, tmp_path, monkeypatch):
+        # No env var → defaults to ./docker-logs/ in CWD.
+        monkeypatch.delenv("MEROBOX_PRE_RESTART_LOG_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        RestartContainerStep._snapshot_pre_restart_logs(
+            self._container_with_logs(b"default-dir\n"),
+            "n1",
+        )
+
+        default_dir = tmp_path / "docker-logs"
+        assert default_dir.is_dir(), "default docker-logs/ should be created"
+        files = list(default_dir.iterdir())
+        assert len(files) == 1
+        assert files[0].read_text() == "default-dir\n"
+
+    def test_snapshot_distinct_files_for_repeated_restarts(self, tmp_path, monkeypatch):
+        # Two snapshots of the same container within the same workflow
+        # must land in distinct files so the second doesn't clobber the
+        # first. Achieved by the microsecond timestamp suffix.
+        import time as _time
+
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+        RestartContainerStep._snapshot_pre_restart_logs(
+            self._container_with_logs(b"first\n"), "n1"
+        )
+        # Sleep ~1ms so the µs-resolution timestamp definitely advances.
+        # Without this the two snapshots could land in the same µs on a
+        # fast machine and clobber.
+        _time.sleep(0.002)
+        RestartContainerStep._snapshot_pre_restart_logs(
+            self._container_with_logs(b"second\n"), "n1"
+        )
+
+        files = sorted(tmp_path.iterdir())
+        assert len(files) == 2, files
+        contents = sorted(f.read_text() for f in files)
+        assert contents == ["first\n", "second\n"]


### PR DESCRIPTION
The CI log-watcher in `e2e-rust-apps.yml` (and similar) tracks containers by NAME via `docker logs -f <name>`. When `restart_ container` calls `container.restart()`, Docker rotates the underlying container ID but keeps the name. The watcher's existing `docker logs -f` process stays attached to the OLD container ID and silently stops receiving updates once Docker GCs that container's stream; the post-restart container's logs go uncaptured.

Result: any investigation of post-restart behavior (relay re-registration, sync recovery, anything that happens after the restart fires) is blind to what the restarted process actually did — confirmed in core#2466's CI artifacts where node-1 has exactly one `TEE not configured; starting without KMS` line that predates the restart by minutes; the post-restart incarnation's startup is completely absent.

## Fix

`RestartContainerStep.execute` now calls a best-effort `_snapshot_pre_restart_logs` helper before issuing `container.restart()`. The helper:

  * Reads the container's logs via docker-py with `timestamps= True` (same format as the watcher writes for the post- restart container's stream).
  * Writes them to `<dir>/<container>.pre-restart-<utc>.log` where `<dir>` is `$MEROBOX_PRE_RESTART_LOG_DIR` or the `docker-logs/` default (matches the watcher's convention, so existing CI artifact-uploaders pick it up automatically).
  * UTC microsecond timestamp suffix → multiple restarts in one workflow produce distinct files, sortable by name.
  * Every failure path (mkdir, container.logs, file write) is logged and swallowed — restart must proceed even if the snapshot fails, because the operator likely asked for the restart precisely because the container is in a weird state.

Pairs with `f7b9c1d`-area CI artifact globs that already pick up `docker-logs/${workflow}*` — adding a new file pattern in the same directory is automatically archived without any CI yaml changes.

## Tests

Six new unit tests in `test_fault_injection_steps.py` covering:

  * Snapshot writes expected file with the timestamp shape
  * Handles `str` return from a wrapped container (defensive)
  * No-raise when `container.logs()` fails
  * No-raise when mkdir fails (read-only mount, bad env path)
  * Default directory used when env var unset
  * Repeated restarts produce distinct files (no clobber)

589/589 unit tests pass (was 583, +6 new).

Bumps merobox 0.6.21 → 0.6.22. Downstream `apt install -y merobox` picks it up via the existing setup-merobox action; no PR-side change required in core#2466.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/CI observability only; snapshot errors are swallowed and do not change restart or health-wait behavior.
> 
> **Overview**
> **`RestartContainerStep`** now **snapshots the dying container’s logs to disk** immediately before `container.restart()`, so CI can retain the pre-restart incarnation’s output when a name-based `docker logs -f` watcher stays bound to the old container ID after Docker rotates the underlying container.
> 
> Snapshots land as `<container>.pre-restart-<utc>.log` under `docker-logs/` by default, overridable via **`MEROBOX_PRE_RESTART_LOG_DIR`**, using timestamped docker logs (`timestamps=True`). Snapshot failures are **best-effort** (warn and continue); the restart still runs.
> 
> **Six unit tests** lock in naming, env override, default dir, non-raising error paths, and distinct files on repeated restarts. Package version **0.6.21 → 0.6.22**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90555452d3f715d539e6bbbd8faf328c3c01b94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->