### PR TITLE
fix(restart): also snapshot post-restart logs + bump 0.6.23

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.23"
+__version__ = "0.6.24"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.22"
+__version__ = "0.6.23"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/restart.py
+++ b/merobox/commands/bootstrap/steps/restart.py
@@ -31,14 +31,23 @@ from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.constants import HEALTH_CHECK_TIMEOUT, NODE_READY_TIMEOUT
 from merobox.commands.utils import console, get_node_rpc_url
 
-# Directory where pre-restart log snapshots get written. CI workflows
-# that want them archived as artifacts should configure their upload
-# step to glob this directory. The default matches the convention
-# `e2e-rust-apps.yml`'s log-watcher uses (`docker-logs/`), so a CI run
-# that already uploads the watcher's output will also pick up the
-# pre-restart snapshots automatically.
-_PRE_RESTART_LOG_DIR_ENV = "MEROBOX_PRE_RESTART_LOG_DIR"
-_PRE_RESTART_LOG_DIR_DEFAULT = "docker-logs"
+# Directory where pre/post-restart log snapshots get written. CI
+# workflows that want them archived as artifacts should configure
+# their upload step to glob this directory. The default matches the
+# convention `e2e-rust-apps.yml`'s log-watcher uses (`docker-logs/`),
+# so a CI run that already uploads the watcher's output will also
+# pick up the snapshots automatically.
+#
+# The primary env var was originally `MEROBOX_PRE_RESTART_LOG_DIR`
+# back when the step only captured the pre-restart phase. Now that
+# it captures BOTH phases into the same directory, the canonical
+# name is `MEROBOX_RESTART_LOG_DIR`. The old name remains as a
+# backward-compat alias so anyone who set it in their CI before
+# 0.6.23 doesn't have to update simultaneously; the new name takes
+# precedence if both are set.
+_RESTART_LOG_DIR_ENV = "MEROBOX_RESTART_LOG_DIR"
+_RESTART_LOG_DIR_ENV_LEGACY = "MEROBOX_PRE_RESTART_LOG_DIR"
+_RESTART_LOG_DIR_DEFAULT = "docker-logs"
 
 
 class RestartContainerStep(BaseStep):
@@ -126,16 +135,18 @@ class RestartContainerStep(BaseStep):
         self._snapshot_post_restart_logs(container, container_name)
         return healthy
 
-    @classmethod
-    def _snapshot_pre_restart_logs(cls, container: Any, container_name: str) -> None:
+    @staticmethod
+    def _snapshot_pre_restart_logs(container: Any, container_name: str) -> None:
         """Pre-restart dump — captures the to-be-killed container's
         logs before `docker restart` cycles it. See `_snapshot_logs`
         for the shared shape; this is a thin wrapper that pins the
         phase to ``pre-restart``."""
-        cls._snapshot_logs(container, container_name, phase="pre-restart")
+        RestartContainerStep._snapshot_logs(
+            container, container_name, phase="pre-restart"
+        )
 
-    @classmethod
-    def _snapshot_post_restart_logs(cls, container: Any, container_name: str) -> None:
+    @staticmethod
+    def _snapshot_post_restart_logs(container: Any, container_name: str) -> None:
         """Post-restart dump — captures the freshly-restarted
         container's logs after `docker restart` returns (and after
         `wait_healthy` succeeds, if it was requested).
@@ -147,30 +158,65 @@ class RestartContainerStep(BaseStep):
         name as already-tracked so it never reattaches. Without
         this dump, the post-restart incarnation's logs go
         unrecorded entirely.
+
+        Reloads the container's attrs first via `container.reload()`
+        because docker-py caches state on the Python-side object.
+        `docker restart` cycles the underlying runtime, so a stale
+        Python container handle returned from before the restart
+        could in principle hand back the wrong incarnation's logs
+        (in practice docker-py's `logs()` re-queries by ID/name on
+        each call, but the reload is cheap insurance against future
+        SDK behavior drift).
         """
-        cls._snapshot_logs(container, container_name, phase="post-restart")
+        try:
+            container.reload()
+        except Exception as exc:
+            # Don't fail the snapshot just because reload glitched;
+            # docker-py's `logs()` re-queries on each call anyway,
+            # so even a stale Python handle gives us the right
+            # logs. Log + proceed.
+            console.print(
+                f"[yellow]Could not reload {container_name!r} before "
+                f"post-restart snapshot: {exc} (continuing)[/yellow]"
+            )
+        RestartContainerStep._snapshot_logs(
+            container, container_name, phase="post-restart"
+        )
 
     @staticmethod
     def _snapshot_logs(container: Any, container_name: str, *, phase: str) -> None:
-        """Best-effort dump of the container's logs to a numbered
+        """Best-effort dump of the container's logs to a timestamped
         file. Pre- and post-restart entry points share this body so
         the failure-handling and naming convention stay in lockstep.
 
-        Naming convention: ``<dir>/<container>.<phase>-<utc_ts>.log``
-        where ``<dir>`` is ``$MEROBOX_PRE_RESTART_LOG_DIR`` or, by
-        default, ``docker-logs/`` in the current working directory.
-        The UTC microsecond timestamp suffix means multiple
-        restarts of the same container in a single workflow
-        produce distinct files (sortable by name), and ordering
-        between a pre-restart snapshot and its paired post-restart
-        snapshot is preserved by the timestamp too.
+        Naming convention: ``<dir>/<safe_name>.<phase>-<utc_ts>.log``
+        where:
+        - ``<dir>`` is ``$MEROBOX_RESTART_LOG_DIR`` (canonical) or
+          the legacy ``$MEROBOX_PRE_RESTART_LOG_DIR`` alias, falling
+          back to ``docker-logs/`` in the current working directory;
+        - ``<safe_name>`` is the container name reduced to its
+          basename component, defending against a `container:`
+          field that resolved (through dynamic-value substitution)
+          to a path-traversal-shaped string. Docker container names
+          are already constrained to ``[a-zA-Z0-9][a-zA-Z0-9_.-]*``
+          so this guard is belt-and-suspenders, but keeping the
+          filesystem-write safe locally is much cheaper than
+          tracking the trust boundary across the workflow YAML +
+          dynamic-value layer;
+        - ``<utc_ts>`` is microsecond-precision so rapid back-to-
+          back snapshots (e.g. pre+post within one restart) land
+          in distinct files, and ordering between paired snapshots
+          is preserved by name.
 
         Errors at any step (docker API hiccup, can't create
         directory, write fails) are logged to the console but
         never raised — the caller's restart flow must proceed
         regardless of whether the snapshot succeeds.
         """
-        log_dir = os.environ.get(_PRE_RESTART_LOG_DIR_ENV, _PRE_RESTART_LOG_DIR_DEFAULT)
+        log_dir = os.environ.get(
+            _RESTART_LOG_DIR_ENV,
+            os.environ.get(_RESTART_LOG_DIR_ENV_LEGACY, _RESTART_LOG_DIR_DEFAULT),
+        )
         try:
             os.makedirs(log_dir, exist_ok=True)
         except OSError as exc:
@@ -184,7 +230,10 @@ class RestartContainerStep(BaseStep):
         # back-to-back snapshots (e.g. pre+post within one restart)
         # need to land in distinct files.
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        log_path = os.path.join(log_dir, f"{container_name}.{phase}-{stamp}.log")
+        # `basename` reduces any path-traversal-shaped container
+        # name (e.g. "../foo") to a single filesystem component.
+        safe_name = os.path.basename(container_name) or "unnamed"
+        log_path = os.path.join(log_dir, f"{safe_name}.{phase}-{stamp}.log")
 
         try:
             # `timestamps=True` so each line carries the docker-side

--- a/merobox/commands/bootstrap/steps/restart.py
+++ b/merobox/commands/bootstrap/steps/restart.py
@@ -103,49 +103,97 @@ class RestartContainerStep(BaseStep):
         console.print(f"[green]✓ Restarted {container_name}[/green]")
 
         if not wait_healthy:
+            # No health gate requested. Snapshot what the new
+            # incarnation has logged so far — best-effort, since
+            # the container may still be very early in startup.
+            self._snapshot_post_restart_logs(container, container_name)
             return True
 
-        return await self._wait_healthy(container_name, timeout)
+        healthy = await self._wait_healthy(container_name, timeout)
+        # Snapshot post-restart logs once the container is up
+        # (or after the wait-healthy timeout — either way, we
+        # want to capture whatever's been written). The OLD
+        # `docker logs -f` follower in the CI watcher doesn't
+        # follow across `docker restart`'s stop+start cycle: it
+        # exits when the pre-restart container's log stream
+        # closes during the stop phase, and the watcher loop
+        # treats the name as already-tracked so it never
+        # reattaches. Without this dump, the post-restart
+        # incarnation's logs never make it to a CI artifact and
+        # any investigation of post-restart behaviour is
+        # blind — see merobox#258 (the pre-restart half of this
+        # capture) for the upstream rationale.
+        self._snapshot_post_restart_logs(container, container_name)
+        return healthy
+
+    @classmethod
+    def _snapshot_pre_restart_logs(cls, container: Any, container_name: str) -> None:
+        """Pre-restart dump — captures the to-be-killed container's
+        logs before `docker restart` cycles it. See `_snapshot_logs`
+        for the shared shape; this is a thin wrapper that pins the
+        phase to ``pre-restart``."""
+        cls._snapshot_logs(container, container_name, phase="pre-restart")
+
+    @classmethod
+    def _snapshot_post_restart_logs(cls, container: Any, container_name: str) -> None:
+        """Post-restart dump — captures the freshly-restarted
+        container's logs after `docker restart` returns (and after
+        `wait_healthy` succeeds, if it was requested).
+
+        The CI watcher (`docker logs -f` keyed on container NAME)
+        DOES NOT follow across the restart's stop+start cycle —
+        the follower exits when the pre-restart container's log
+        stream closes during stop, and the watcher loop sees the
+        name as already-tracked so it never reattaches. Without
+        this dump, the post-restart incarnation's logs go
+        unrecorded entirely.
+        """
+        cls._snapshot_logs(container, container_name, phase="post-restart")
 
     @staticmethod
-    def _snapshot_pre_restart_logs(container: Any, container_name: str) -> None:
-        """Best-effort dump of the container's logs to a numbered file
-        before `docker restart` rotates the underlying container ID.
+    def _snapshot_logs(container: Any, container_name: str, *, phase: str) -> None:
+        """Best-effort dump of the container's logs to a numbered
+        file. Pre- and post-restart entry points share this body so
+        the failure-handling and naming convention stay in lockstep.
 
-        Naming convention: ``<dir>/<container>.pre-restart-<utc_ts>.log``
+        Naming convention: ``<dir>/<container>.<phase>-<utc_ts>.log``
         where ``<dir>`` is ``$MEROBOX_PRE_RESTART_LOG_DIR`` or, by
         default, ``docker-logs/`` in the current working directory.
-        The UTC timestamp suffix means multiple restarts of the same
-        container in a single workflow produce distinct files (sortable
-        by name).
+        The UTC microsecond timestamp suffix means multiple
+        restarts of the same container in a single workflow
+        produce distinct files (sortable by name), and ordering
+        between a pre-restart snapshot and its paired post-restart
+        snapshot is preserved by the timestamp too.
 
-        Errors at any step (docker API hiccup, can't create directory,
-        write fails) are logged to the console but never raised — the
-        caller's `container.restart()` must run regardless.
+        Errors at any step (docker API hiccup, can't create
+        directory, write fails) are logged to the console but
+        never raised — the caller's restart flow must proceed
+        regardless of whether the snapshot succeeds.
         """
         log_dir = os.environ.get(_PRE_RESTART_LOG_DIR_ENV, _PRE_RESTART_LOG_DIR_DEFAULT)
         try:
             os.makedirs(log_dir, exist_ok=True)
         except OSError as exc:
             console.print(
-                f"[yellow]Could not create pre-restart log dir {log_dir!r}: "
+                f"[yellow]Could not create {phase} log dir {log_dir!r}: "
                 f"{exc} (continuing without snapshot)[/yellow]"
             )
             return
 
-        # UTC + millisecond precision; the millis matter because rapid
-        # back-to-back restarts in a workflow shouldn't collide.
+        # UTC + microsecond precision; the µs matter because rapid
+        # back-to-back snapshots (e.g. pre+post within one restart)
+        # need to land in distinct files.
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        log_path = os.path.join(log_dir, f"{container_name}.pre-restart-{stamp}.log")
+        log_path = os.path.join(log_dir, f"{container_name}.{phase}-{stamp}.log")
 
         try:
             # `timestamps=True` so each line carries the docker-side
             # wall-clock timestamp, matching the format the CI
-            # watcher writes for the post-restart container's logs.
+            # watcher writes for the live-streamed container logs.
             log_bytes = container.logs(timestamps=True)
         except Exception as exc:
             console.print(
-                f"[yellow]Could not read pre-restart logs for "
+                f"[yellow]Could not read {phase} logs for "
                 f"{container_name!r}: {exc} (continuing)[/yellow]"
             )
             return
@@ -160,13 +208,13 @@ class RestartContainerStep(BaseStep):
                 f.write(log_text)
         except OSError as exc:
             console.print(
-                f"[yellow]Could not write pre-restart log file "
+                f"[yellow]Could not write {phase} log file "
                 f"{log_path!r}: {exc} (continuing)[/yellow]"
             )
             return
 
         console.print(
-            f"[cyan]Snapshotted pre-restart logs of {container_name!r} → {log_path}[/cyan]"
+            f"[cyan]Snapshotted {phase} logs of {container_name!r} → {log_path}[/cyan]"
         )
 
     async def _wait_healthy(self, container_name: str, timeout: int) -> bool:

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -382,3 +382,87 @@ class TestRestartPreRestartLogSnapshot:
         assert len(files) == 2, files
         contents = sorted(f.read_text() for f in files)
         assert contents == ["first\n", "second\n"]
+
+
+# ---------------------------------------------------------------------------
+# RestartContainerStep — post-restart log snapshot
+#
+# After `container.restart()` and (optionally) wait_healthy, the step ALSO
+# snapshots the newly-restarted container's logs. The CI watcher's
+# `docker logs -f` follower doesn't follow across the stop+start cycle:
+# the pre-restart container's log stream closes during the stop phase,
+# the follower exits, and the watcher loop treats the name as
+# already-tracked so it never reattaches. Without this second snapshot,
+# the post-restart incarnation's logs are lost entirely.
+# ---------------------------------------------------------------------------
+
+
+class TestRestartPostRestartLogSnapshot:
+    @staticmethod
+    def _container_with_logs(log_bytes):
+        class _StubContainer:
+            def logs(self, *, timestamps=False):
+                _ = timestamps
+                return log_bytes
+
+        return _StubContainer()
+
+    def test_pre_and_post_snapshots_land_in_distinct_files(self, tmp_path, monkeypatch):
+        # Both phases write to the same directory. The UTC microsecond
+        # timestamp in the filename guarantees they don't collide even
+        # if called back-to-back within the same `docker restart` cycle.
+        import time as _time
+
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+        c = self._container_with_logs(b"hello\n")
+
+        RestartContainerStep._snapshot_pre_restart_logs(c, "n1")
+        _time.sleep(0.002)  # advance the µs timestamp
+        RestartContainerStep._snapshot_post_restart_logs(c, "n1")
+
+        files = sorted(p.name for p in tmp_path.iterdir())
+        assert len(files) == 2, files
+        pre = [f for f in files if ".pre-restart-" in f]
+        post = [f for f in files if ".post-restart-" in f]
+        assert len(pre) == 1 and pre[0].endswith(".log")
+        assert len(post) == 1 and post[0].endswith(".log")
+        # Filename format: `<container>.<phase>-<utc-ts>.log`
+        assert pre[0].startswith("n1.pre-restart-")
+        assert post[0].startswith("n1.post-restart-")
+
+    def test_post_restart_snapshot_filename_carries_post_marker(
+        self, tmp_path, monkeypatch
+    ):
+        # Pins the exact phase marker in the filename so downstream
+        # tooling (CI artifact globs, log analyzers) can distinguish
+        # the two phases by name alone.
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+        RestartContainerStep._snapshot_post_restart_logs(
+            self._container_with_logs(b"post-startup\n"),
+            "sync-resil-node-1",
+        )
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        name = files[0].name
+        # Spelled exactly `.post-restart-` between the container name
+        # and the timestamp — matches the pre-restart counterpart's
+        # `.pre-restart-` convention.
+        assert name.startswith("sync-resil-node-1.post-restart-")
+        assert name.endswith(".log")
+        assert files[0].read_text() == "post-startup\n"
+
+    def test_post_restart_swallows_logs_failure(self, tmp_path, monkeypatch):
+        # The whole point of best-effort: even if container.logs()
+        # raises, we must not propagate. The restart already happened;
+        # losing the snapshot is bad but losing the workflow run is
+        # worse.
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+
+        class _BrokenContainer:
+            def logs(self, *, timestamps=False):
+                _ = timestamps
+                raise RuntimeError("daemon flake post-restart")
+
+        # Must NOT raise.
+        RestartContainerStep._snapshot_post_restart_logs(_BrokenContainer(), "n1")
+        assert list(tmp_path.iterdir()) == []

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -252,31 +252,57 @@ class TestDetectNodeNetwork:
 
 
 # ---------------------------------------------------------------------------
-# RestartContainerStep — pre-restart log snapshot
+# RestartContainerStep — pre/post-restart log snapshot
 #
-# The snapshot fires before `container.restart()` rotates the underlying
-# container ID, so the to-be-killed incarnation's logs survive in a CI
-# artifact. These tests pin the contract:
+# The snapshot fires both before and after `container.restart()` so the
+# whole restart cycle is captured (the CI watcher's `docker logs -f`
+# follower doesn't survive the stop+start). These tests pin the
+# contract:
 #
-#   - Snapshot writes to `<dir>/<container>.pre-restart-<utc>.log`.
-#   - `MEROBOX_PRE_RESTART_LOG_DIR` env var overrides the default dir.
+#   - Snapshot writes to `<dir>/<container>.<phase>-<utc>.log`.
+#   - `MEROBOX_RESTART_LOG_DIR` env var overrides the default dir;
+#     `MEROBOX_PRE_RESTART_LOG_DIR` (legacy) still works as an alias.
 #   - Failures at every step (mkdir, container.logs, file write) are
 #     logged but never raise — the caller's restart MUST proceed.
+#   - container_name is path-traversal-defanged via os.path.basename
+#     before being used in the snapshot path.
 # ---------------------------------------------------------------------------
+
+
+def _stub_container(log_bytes=b""):
+    """Stub `docker.Container` with a `logs()` method that returns
+    fixed bytes/str. Module-level so both pre- and post-restart test
+    classes can reuse it without duplicating the stub definition.
+    The `reload()` no-op is required by `_snapshot_post_restart_logs`
+    which calls it for cache-freshness — without it the post-restart
+    tests would fail on an AttributeError before reaching the
+    `logs()` call.
+    """
+
+    class _StubContainer:
+        def logs(self, *, timestamps=False):
+            # Implementation passes timestamps=True. The kwarg
+            # is accepted-and-ignored to keep the stub honest.
+            _ = timestamps
+            return log_bytes
+
+        def reload(self):
+            # docker-py's Container.reload() refreshes the in-memory
+            # attrs from the daemon. The unit-test stub doesn't need
+            # to track state; the post-restart path just expects the
+            # method to exist and not raise.
+            return None
+
+    return _StubContainer()
 
 
 class TestRestartPreRestartLogSnapshot:
     @staticmethod
     def _container_with_logs(log_bytes):
-        class _StubContainer:
-            def logs(self, *, timestamps=False):
-                # The implementation passes `timestamps=True`. We don't
-                # care about that detail for the unit test, but accepting
-                # the kwarg keeps the stub honest.
-                _ = timestamps
-                return log_bytes
-
-        return _StubContainer()
+        # Thin wrapper around the module-level `_stub_container` for
+        # readability; preserved here so test bodies still read
+        # `self._container_with_logs(...)`.
+        return _stub_container(log_bytes)
 
     def test_snapshot_writes_expected_file(self, tmp_path, monkeypatch):
         monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
@@ -400,12 +426,9 @@ class TestRestartPreRestartLogSnapshot:
 class TestRestartPostRestartLogSnapshot:
     @staticmethod
     def _container_with_logs(log_bytes):
-        class _StubContainer:
-            def logs(self, *, timestamps=False):
-                _ = timestamps
-                return log_bytes
-
-        return _StubContainer()
+        # Thin wrapper around the module-level `_stub_container`
+        # so this class's test bodies stay readable.
+        return _stub_container(log_bytes)
 
     def test_pre_and_post_snapshots_land_in_distinct_files(self, tmp_path, monkeypatch):
         # Both phases write to the same directory. The UTC microsecond
@@ -466,3 +489,123 @@ class TestRestartPostRestartLogSnapshot:
         # Must NOT raise.
         RestartContainerStep._snapshot_post_restart_logs(_BrokenContainer(), "n1")
         assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Env-var canonical + legacy alias precedence + path-traversal sanitization
+# + post-restart reload — review-comment fixes on merobox#260.
+# ---------------------------------------------------------------------------
+
+
+class TestRestartLogSnapshotReviewFixes:
+    def test_canonical_env_var_takes_precedence_over_legacy(
+        self, tmp_path, monkeypatch
+    ):
+        # Both env vars set; the canonical `MEROBOX_RESTART_LOG_DIR`
+        # must win. This is the path forward for callers updating
+        # from the pre-0.6.23 name.
+        canonical_dir = tmp_path / "canonical"
+        legacy_dir = tmp_path / "legacy"
+        monkeypatch.setenv("MEROBOX_RESTART_LOG_DIR", str(canonical_dir))
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(legacy_dir))
+        RestartContainerStep._snapshot_pre_restart_logs(
+            _stub_container(b"canonical-wins\n"), "n1"
+        )
+        # Canonical dir got the file; legacy dir was never written to.
+        assert list(canonical_dir.iterdir()), "canonical dir must receive the snapshot"
+        assert not legacy_dir.exists() or not list(
+            legacy_dir.iterdir()
+        ), "legacy dir must NOT receive a file when both env vars are set"
+
+    def test_legacy_env_var_still_works_as_alias(self, tmp_path, monkeypatch):
+        # Anyone who set `MEROBOX_PRE_RESTART_LOG_DIR` in their CI
+        # before 0.6.23 shouldn't have to update simultaneously
+        # with merobox.  Only the legacy name set → snapshot lands
+        # in the legacy-named dir.
+        monkeypatch.delenv("MEROBOX_RESTART_LOG_DIR", raising=False)
+        monkeypatch.setenv("MEROBOX_PRE_RESTART_LOG_DIR", str(tmp_path))
+        RestartContainerStep._snapshot_pre_restart_logs(
+            _stub_container(b"legacy-works\n"), "n1"
+        )
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].read_text() == "legacy-works\n"
+
+    def test_post_restart_calls_reload_for_cache_freshness(self, tmp_path, monkeypatch):
+        # docker-py caches container attrs on the Python-side object.
+        # `_snapshot_post_restart_logs` must call `container.reload()`
+        # before reading logs so a stale handle from before
+        # `docker restart` doesn't surface the wrong incarnation's
+        # data. A stub that records calls confirms.
+        monkeypatch.setenv("MEROBOX_RESTART_LOG_DIR", str(tmp_path))
+        calls: list[str] = []
+
+        class _RecordingContainer:
+            def reload(self):
+                calls.append("reload")
+
+            def logs(self, *, timestamps=False):
+                _ = timestamps
+                calls.append("logs")
+                return b"post-restart\n"
+
+        RestartContainerStep._snapshot_post_restart_logs(_RecordingContainer(), "n1")
+        # Order matters: reload BEFORE logs. If logs were read
+        # first, the post-restart snapshot could return stale
+        # pre-restart data on a docker-py version where logs()
+        # uses cached attrs.
+        assert calls == ["reload", "logs"], f"expected reload-then-logs, got {calls}"
+
+    def test_post_restart_continues_when_reload_fails(self, tmp_path, monkeypatch):
+        # The reload is cheap insurance, not a hard requirement.
+        # docker-py's `logs()` re-queries on each call, so even a
+        # stale Python handle gives correct results. If reload
+        # raises (transient daemon issue), the snapshot must still
+        # proceed.
+        monkeypatch.setenv("MEROBOX_RESTART_LOG_DIR", str(tmp_path))
+
+        class _FlakyReloadContainer:
+            def reload(self):
+                raise RuntimeError("daemon flake on reload")
+
+            def logs(self, *, timestamps=False):
+                _ = timestamps
+                return b"despite-reload-flake\n"
+
+        # Must NOT raise.
+        RestartContainerStep._snapshot_post_restart_logs(_FlakyReloadContainer(), "n1")
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].read_text() == "despite-reload-flake\n"
+
+    def test_container_name_path_traversal_is_neutralized(self, tmp_path, monkeypatch):
+        # If the workflow's `container:` field resolves (through
+        # dynamic-value substitution) to a path-traversal-shaped
+        # string, the snapshot filename construction must NOT let
+        # the write escape the log dir. `os.path.basename` reduces
+        # the name to a single filesystem component.
+        monkeypatch.setenv("MEROBOX_RESTART_LOG_DIR", str(tmp_path))
+        # `../../etc/evil` should collapse to just `evil` before
+        # being used in the filename.
+        RestartContainerStep._snapshot_pre_restart_logs(
+            _stub_container(b"sanitized\n"), "../../etc/evil"
+        )
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1, f"expected a single file in {tmp_path}, got {files}"
+        # File lives inside log_dir, no escape.
+        assert files[0].parent == tmp_path
+        # Basename is `evil`, not `../../etc/evil`.
+        assert files[0].name.startswith("evil.pre-restart-")
+
+    def test_empty_basename_falls_back_to_unnamed(self, tmp_path, monkeypatch):
+        # `os.path.basename("/")` returns "" (and similar edge
+        # cases). The snapshot mustn't try to write an
+        # extension-only filename like `.pre-restart-….log`; the
+        # fallback `unnamed` keeps the file readable.
+        monkeypatch.setenv("MEROBOX_RESTART_LOG_DIR", str(tmp_path))
+        RestartContainerStep._snapshot_pre_restart_logs(
+            _stub_container(b"unnamed-fallback\n"), "/"
+        )
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].name.startswith("unnamed.pre-restart-")


### PR DESCRIPTION
## Why

merobox#258 captured pre-restart logs. The diagnostic chain on [core#2466](https://github.com/calimero-network/core/pull/2466)'s rerun confirmed pre-restart capture works, BUT exposed that the post-restart container's startup is STILL missing entirely from the CI artifact:

\`\`\`
Watcher first/last:  15:27:06 → 15:27:34   (pre-restart container only)
Snapshot first/last: 15:27:06 → 15:27:25   (pre-restart, captured at restart-fire)
TEE startup count:   1                      (only the pre-restart one)
Post-restart startup: NEVER CAPTURED
\`\`\`

\`docker logs -f\` does NOT follow across \`docker restart\`'s stop+start cycle — the follower exits when the container's log stream closes during stop, the watcher's name-keyed mark file is still present, and the watcher never reattaches to the new container.

## What

Add \`_snapshot_post_restart_logs\` that fires AFTER \`container.restart()\` returns (and after the optional \`wait_healthy\` resolves, pass or fail). Same best-effort shape as the pre-restart half. Filename: \`<container>.post-restart-<utc>.log\` (pairs with the existing \`.pre-restart-\` files in the same directory).

Refactored both halves to share \`_snapshot_logs(container, name, *, phase)\` so failure-handling and naming convention stay in lockstep. The public \`_snapshot_pre_restart_logs\` is now a thin wrapper — its 6 existing unit tests still pass unchanged.

Bumps version 0.6.22 → 0.6.23.

## Tests

3 new unit tests in \`test_fault_injection_steps.py\`:

- pre+post snapshots land in distinct files (timestamp ordering preserved)
- post-restart filename carries \`.post-restart-\` marker (downstream tools can split phases by name)
- post-restart swallows \`container.logs()\` failures (best-effort guarantee)

592/592 pass (was 589). \`black --check\` + \`ruff check\` clean.

## Downstream

Once 0.6.23 publishes, core#2466's next CI run will finally have BOTH halves in the artifact — pre- and post-restart logs side by side. The keypair-persistence question that's been blocked on this diagnostic gap can finally be answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort local log writes for CI diagnostics only; no changes to auth, RPC, or restart success semantics beyond extra snapshots.
> 
> **Overview**
> **Restart-container** now writes **post-restart** log snapshots (after `docker restart`, with or without `wait_healthy`) so CI artifacts include the new container incarnation—addressing the gap where `docker logs -f` does not reattach across restart.
> 
> Pre- and post-restart capture share **`_snapshot_logs`** with a `phase` suffix in filenames (`*.pre-restart-*` / `*.post-restart-*`). Log directory is **`MEROBOX_RESTART_LOG_DIR`**, with **`MEROBOX_PRE_RESTART_LOG_DIR`** kept as a fallback alias. Snapshot paths use **`os.path.basename`** on the container name (and an `unnamed` fallback); post-restart path calls **`container.reload()`** best-effort before reading logs. Package version **0.6.24**; unit tests cover post-restart behavior, env precedence, reload ordering, and path sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3456ebbfe0e5e7deb055b3b71377e3e5beb5c41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->