### PR TITLE
feat(steps): cascade kwarg on upgrade_group; release 0.6.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.23] - 2026-05-27
+
+### Added
+
+- `cascade` boolean field on the `upgrade_group` workflow step
+  (default `false`). When `true`, dispatches the same
+  `CascadeTargetApplicationSet` op as `cascade_namespace_application`
+  but lets the step accept an optional `migrate_method` for callers
+  that need cascade + per-context migration in a single step. Carries
+  the same `calimero-client-py >= 0.6.15` pre-flight guard the
+  dedicated cascade step uses, gated behind `cascade=true` so existing
+  non-cascade callers still work on older client-py installs.
+  Closes the gap that left
+  `workflows/app-migration/01-namespace-cascade-migration.yml` (in
+  `calimero-network/core`) silently dropping `cascade: true` and
+  failing on the server-side "no contexts to upgrade" check.
+
+## [0.6.22] - 2026-05-27
+
 ### Added
 
 - `workflow-examples/workflow-cascade-namespace-example.yml` — smoke

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.22"
+__version__ = "0.6.23"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1069,6 +1069,14 @@ class UpgradeGroupStepConfig(BaseStepConfig):
     migrate_method: Optional[str] = Field(
         None, description="Optional migration export to invoke during upgrade"
     )
+    cascade: bool = Field(
+        False,
+        description=(
+            "When true, dispatch as a namespace cascade "
+            "(CascadeTargetApplicationSet) instead of a per-group upgrade. "
+            "Requires calimero-client-py >= 0.6.15."
+        ),
+    )
 
 
 class CascadeNamespaceApplicationStepConfig(BaseStepConfig):

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -143,6 +143,11 @@ class UpgradeGroupStep(BaseStep):
             raise ValueError(
                 f"Step '{step_name}': 'migrate_method' must be a string if provided"
             )
+        cascade = self.config.get("cascade")
+        if cascade is not None and not isinstance(cascade, bool):
+            raise ValueError(
+                f"Step '{step_name}': 'cascade' must be a boolean if provided"
+            )
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -162,15 +167,44 @@ class UpgradeGroupStep(BaseStep):
             if migrate_method_raw is not None
             else None
         )
+        cascade = bool(self.config.get("cascade", False))
+
+        # Pre-flight: only enforced when cascade=True. The non-cascade
+        # path (the historical default) does not need the kwarg at all,
+        # so on older client-py versions a workflow that doesn't ask for
+        # cascade keeps working unchanged. Mirrors the version-guard
+        # pattern in CascadeNamespaceApplicationStep — see that step's
+        # comment for the rationale.
+        if cascade and (
+            _CLIENT_PY_VERSION is not None
+            and _CLIENT_PY_VERSION < _CASCADE_MIN_CLIENT_VERSION
+        ):
+            min_str = ".".join(str(p) for p in _CASCADE_MIN_CLIENT_VERSION)
+            msg = (
+                f"upgrade_group(cascade=true) requires "
+                f"calimero-client-py >= {min_str} "
+                f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
+            )
+            if self._is_expected_failure():
+                self._report_expected_failure(msg)
+                return True
+            console.print(f"[red]{msg}[/red]")
+            return False
 
         try:
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
             client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-            api_result = client.upgrade_group(
-                group_id=group_id,
-                target_application_id=target_application_id,
-                migrate_method=migrate_method,
-            )
+            # `cascade` is only forwarded when truthy so callers running
+            # against pre-0.6.15 client-py (where the kwarg doesn't exist)
+            # don't trip a TypeError on the default `cascade=false` path.
+            upgrade_kwargs: dict[str, Any] = {
+                "group_id": group_id,
+                "target_application_id": target_application_id,
+                "migrate_method": migrate_method,
+            }
+            if cascade:
+                upgrade_kwargs["cascade"] = True
+            api_result = client.upgrade_group(**upgrade_kwargs)
             result = ok(api_result)
         except Exception as e:
             result = fail("upgrade_group failed", error=e)

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -1077,6 +1077,17 @@ class TestGroupUpgradeStepSchemas:
         }
         assert config_module.validate_workflow_step(step, 0) == []
 
+    def test_valid_upgrade_group_with_cascade(self, config_module):
+        step = {
+            "type": "upgrade_group",
+            "node": "calimero-node-1",
+            "group_id": "{{namespace_id}}",
+            "target_application_id": "{{app_v2}}",
+            "migrate_method": "migrate_v1_to_v2",
+            "cascade": True,
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
     def test_invalid_upgrade_group_missing_target(self, config_module):
         step = {
             "type": "upgrade_group",


### PR DESCRIPTION
## Summary

Adds a `cascade: bool = false` field to the `upgrade_group` workflow step.

The dedicated `cascade_namespace_application` step (added in 0.6.22 via #259) covers no-migrate cascades, but can't accept a `migrate_method` — leaving workflows that want **cascade + per-context migration** in a single step with no clean option.

Setting `cascade: true` on the existing `upgrade_group` step looked like the natural API, but was silently ignored: `UpgradeGroupStep.execute` never read the field or forwarded it to `client.upgrade_group()`. Workflows authored with that shape — e.g. [`workflows/app-migration/01-namespace-cascade-migration.yml`](https://github.com/calimero-network/core/blob/fix/app-key-creation-inheritance/workflows/app-migration/01-namespace-cascade-migration.yml) in calimero-network/core PR #2507 — reached core without `cascade=true`, fell into the standard non-cascade upgrade path, and failed at the server's ``"group has no contexts to upgrade"`` precondition because the signed group was the namespace root (which by definition holds no contexts of its own).

## Changes

* `UpgradeGroupStepConfig.cascade: bool = False` (pydantic config).
* `UpgradeGroupStep._validate_field_types` rejects a non-bool `cascade`.
* `UpgradeGroupStep.execute` reads the kwarg and forwards it to `client.upgrade_group` **only when truthy**, so pre-0.6.15 client-py installs (which don't have the kwarg) keep working on the default `cascade=false` path.
* Pre-flight `calimero-client-py >= 0.6.15` version check, gated behind `cascade=true`, mirroring the existing `CascadeNamespaceApplicationStep` guard.
* Schema-validation unit test for the new field.
* Version bump `0.6.22 → 0.6.23` + CHANGELOG entry.

## When to use which step

| Need | Use |
|---|---|
| Per-group upgrade (with or without migration) | `upgrade_group` (cascade omitted) |
| Namespace cascade, no migration | `cascade_namespace_application` |
| Namespace cascade WITH per-context migration | `upgrade_group` + `cascade: true` + `migrate_method` |

The dedicated `cascade_namespace_application` step remains the recommended entry point for cascade-only callers; `upgrade_group(cascade=true)` is the bridge for cascade + migration.

## Test plan

- [x] All 107 `test_workflow_schema_validation` tests pass locally (including new `test_valid_upgrade_group_with_cascade`)
- [x] `black` + `ruff` clean
- [ ] CI on this PR (lint + unit)
- [ ] Downstream: calimero-network/core PR #2507's `01-namespace-cascade-migration` workflow turns green once 0.6.23 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-step and client-kwarg wiring with backward-compatible defaults; governance impact is limited to callers who explicitly set `cascade: true` and meet the client-py version guard.
> 
> **Overview**
> Release **0.6.23** fixes a gap where the `upgrade_group` workflow step accepted `cascade: true` in YAML but never read or forwarded it, so namespace cascade migrations (e.g. core’s `01-namespace-cascade-migration.yml`) hit the server as a normal group upgrade and failed with “no contexts to upgrade.”
> 
> The step now has an optional **`cascade`** flag (default `false`) on the Pydantic config, boolean validation in `UpgradeGroupStep`, and runtime behavior that passes `cascade=True` to `client.upgrade_group` only when requested—matching `CascadeTargetApplicationSet` / `cascade_namespace_application` while still allowing **`migrate_method`** for cascade plus per-context migration in one step. A **calimero-client-py >= 0.6.15** pre-flight runs only when `cascade=true`; the default path omits the kwarg so older clients keep working. Changelog, version bump, and a schema unit test cover the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551c08be83dc1f81c0dce333b7bf6902ce776317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->