### PR TITLE
fix(restart): re-inject NAT default route after docker restart

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.24"
+__version__ = "0.6.25"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -794,6 +794,11 @@ class WorkflowExecutor:
             console.print(f"[yellow]NAT topology teardown raised: {e}[/yellow]")
         finally:
             self._nat_state = None
+            # Drop the manager-side handle in lockstep so a
+            # subsequent restart_container step (in a fresh
+            # workflow that reuses the same manager) doesn't
+            # try to re-inject against a torn-down topology.
+            self.manager.nat_topology_state = None
 
     def _nuke_data(self, prefix: str = None) -> bool:
         """
@@ -1049,6 +1054,22 @@ class WorkflowExecutor:
         except Exception as e:
             console.print(f"[red]❌ NAT topology setup failed: {e}[/red]")
             return False
+
+        # Expose the topology state on the manager so step
+        # executors (specifically `RestartContainerStep`) can
+        # re-invoke `inject_default_route_into_client` on the
+        # client after a `docker restart`. Docker's restart
+        # path resets the container's default route to the
+        # Docker bridge gateway, wiping the merobox-injected
+        # override that points at the NAT gateway. Without
+        # the re-injection, every post-restart packet from
+        # the client goes via Docker's bridge instead of the
+        # NAT gateway, the boot-node connection times out at
+        # the noise handshake (the return path doesn't
+        # transit the MASQUERADE), and downstream relay-
+        # reservation + rendezvous-register never run.
+        # Cleared on teardown alongside `self._nat_state`.
+        self.manager.nat_topology_state = self._nat_state
 
         # Compute the bootstrap multiaddrs the clients need. These
         # override anything the workflow's `bootstrap_nodes:` field

--- a/merobox/commands/bootstrap/steps/restart.py
+++ b/merobox/commands/bootstrap/steps/restart.py
@@ -111,6 +111,25 @@ class RestartContainerStep(BaseStep):
 
         console.print(f"[green]✓ Restarted {container_name}[/green]")
 
+        # Re-inject the NAT-topology default route if applicable.
+        # `docker restart` resets the container's network
+        # configuration to Docker's defaults, which wipes the
+        # `ip route replace default via <gateway-IP>` override
+        # that the topology setup applied via
+        # `inject_default_route_into_client`. Without re-injection,
+        # post-restart packets go via Docker's bridge gateway
+        # instead of the NAT gateway — they leave fine but the
+        # MASQUERADE return path is missing, so noise handshakes
+        # to the boot-node time out (verified via netns
+        # route-watcher in the #2469 keypair-repro v6 run; see
+        # the PR description for the timeline).
+        #
+        # Best-effort: failure to re-inject doesn't fail the
+        # restart itself (the caller may not even be in a NAT
+        # topology — `nat_topology_state` is `None` in that
+        # case). Errors are surfaced to the console.
+        self._reinject_nat_default_route(container_name)
+
         if not wait_healthy:
             # No health gate requested. Snapshot what the new
             # incarnation has logged so far — best-effort, since
@@ -134,6 +153,62 @@ class RestartContainerStep(BaseStep):
         # capture) for the upstream rationale.
         self._snapshot_post_restart_logs(container, container_name)
         return healthy
+
+    def _reinject_nat_default_route(self, container_name: str) -> None:
+        """Re-inject the NAT-gateway default route into the
+        just-restarted container if it belongs to a live NAT
+        topology.
+
+        The `nat_topology_state` attribute is stashed on the
+        manager by `WorkflowExecutor._start_nodes_nat_topology`
+        when the topology comes up, and cleared on teardown. If
+        absent or empty, the restart isn't in a NAT context and
+        this method is a no-op.
+        """
+        state = getattr(self.manager, "nat_topology_state", None)
+        if state is None:
+            # Not a NAT topology — nothing to re-inject.
+            return
+        if container_name not in state.client_names:
+            # Restart targets a container that isn't a NAT
+            # client (e.g. the boot-node or a non-topology
+            # container). Default route is already correct.
+            return
+
+        # Imported here to avoid pulling the NAT module's
+        # docker / iptables deps into the step's import path
+        # when the step is used outside NAT contexts.
+        from merobox.topology.nat import (
+            inject_default_route_into_client,
+            wait_for_client_reachability,
+        )
+
+        client = self.manager.client
+        try:
+            inject_default_route_into_client(client, state, container_name)
+        except Exception as exc:
+            console.print(
+                f"[yellow]Failed to re-inject default route into "
+                f"{container_name!r} post-restart: {exc}[/yellow]"
+            )
+            return
+
+        # Verify the client can still reach the boot-node
+        # through the gateway. This is the same probe the
+        # initial topology setup runs and serves the same
+        # purpose: catch a half-broken topology before the
+        # caller starts asserting on sync behaviour. A failure
+        # here means the route was re-injected but the
+        # forwarding path is broken (e.g. gateway MASQUERADE
+        # rule got dropped somehow) — much more diagnostic
+        # than letting downstream sync time out.
+        try:
+            wait_for_client_reachability(client, state, container_name)
+        except Exception as exc:
+            console.print(
+                f"[yellow]Post-restart reachability check from "
+                f"{container_name!r} → boot-node failed: {exc}[/yellow]"
+            )
 
     @staticmethod
     def _snapshot_pre_restart_logs(container: Any, container_name: str) -> None:

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -609,3 +609,161 @@ class TestRestartLogSnapshotReviewFixes:
         files = list(tmp_path.iterdir())
         assert len(files) == 1
         assert files[0].name.startswith("unnamed.pre-restart-")
+
+
+# ---------------------------------------------------------------------------
+# RestartContainerStep — NAT-topology default-route re-injection
+#
+# `docker restart` resets the container's network configuration to
+# Docker's defaults, which wipes the `ip route replace default via
+# <gateway-IP>` override that the NAT-topology setup applied via
+# `inject_default_route_into_client`. Without re-injection, post-restart
+# packets go via Docker's bridge gateway instead of the NAT gateway —
+# they leave fine but the MASQUERADE return path is missing, so noise
+# handshakes to the boot-node time out. This is core#2469's root cause.
+#
+# These tests pin the re-injection contract on RestartContainerStep:
+#
+#   - Only fires when `manager.nat_topology_state` is non-None AND the
+#     restarted container is one of the topology's clients.
+#   - No-op for boot-node / non-topology container / no-NAT setups.
+#   - Reachability probe surfaces a half-broken topology before the
+#     caller starts asserting on sync behaviour.
+#   - Inject failure → log + continue (don't crash the restart step).
+#   - Reachability failure → log + continue (the route's already
+#     re-injected; the probe is diagnostic, not gating).
+# ---------------------------------------------------------------------------
+
+
+class TestRestartReinjectNatDefaultRoute:
+    @staticmethod
+    def _step():
+        # Construct the step the same way the YAML loader would, then
+        # attach a `manager` shim (the executor normally sets it on the
+        # step right before `execute()` runs).
+        step = RestartContainerStep({"type": "restart_container", "container": "n1"})
+
+        class _ManagerShim:
+            client = object()  # sentinel — never dereferenced
+            nat_topology_state = None
+
+        step.manager = _ManagerShim()
+        return step
+
+    @staticmethod
+    def _nat_state(client_names):
+        # Stand-in for `NatTopologyState` — only `client_names` is
+        # touched by `_reinject_nat_default_route`. Avoid pulling
+        # the real dataclass + its docker deps into the unit test.
+        class _State:
+            def __init__(self, names):
+                self.client_names = names
+
+        return _State(client_names)
+
+    def test_noop_when_no_nat_topology(self, monkeypatch):
+        # nat_topology_state absent / None → re-injection helpers
+        # must NOT be imported or called. Patch them to detonate so
+        # any accidental call surfaces immediately.
+        from merobox.topology import nat as nat_mod
+
+        def _boom(*_a, **_kw):
+            raise AssertionError("must not be called when no NAT topology")
+
+        monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _boom)
+        monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _boom)
+
+        step = self._step()
+        step.manager.nat_topology_state = None
+        # Must NOT raise.
+        step._reinject_nat_default_route("n1")
+
+    def test_noop_when_container_is_not_a_nat_client(self, monkeypatch):
+        # The boot-node and any non-topology container fall through
+        # this branch — they don't have a NAT-gateway default route
+        # in the first place, so re-injection would either no-op or
+        # actively break their networking.
+        from merobox.topology import nat as nat_mod
+
+        def _boom(*_a, **_kw):
+            raise AssertionError("must not be called for non-client containers")
+
+        monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _boom)
+        monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _boom)
+
+        step = self._step()
+        step.manager.nat_topology_state = self._nat_state(["client-1", "client-2"])
+        step._reinject_nat_default_route("boot-node")
+
+    def test_reinjects_and_probes_when_container_is_a_nat_client(self, monkeypatch):
+        # Happy path: state present, container in client_names. Both
+        # the inject and the reachability probe run, in that order.
+        from merobox.topology import nat as nat_mod
+
+        calls: list[tuple[str, str]] = []
+
+        def _inject(_client, _state, name):
+            calls.append(("inject", name))
+
+        def _probe(_client, _state, name):
+            calls.append(("probe", name))
+
+        monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _inject)
+        monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _probe)
+
+        step = self._step()
+        step.manager.nat_topology_state = self._nat_state(["n1", "n2"])
+        step._reinject_nat_default_route("n1")
+
+        # Order matters: inject BEFORE probe. If the probe ran
+        # first it'd flake on an unconfigured route.
+        assert calls == [("inject", "n1"), ("probe", "n1")], calls
+
+    def test_inject_failure_is_logged_and_skips_probe(self, monkeypatch):
+        # If the inject itself raises (e.g. the exec_run for
+        # `ip route replace` fails because the container isn't
+        # ready yet), we log and return — running the probe would
+        # be guaranteed to fail too, with a less useful error.
+        from merobox.topology import nat as nat_mod
+
+        def _broken_inject(*_a, **_kw):
+            raise RuntimeError("ip route replace failed")
+
+        probe_calls: list[str] = []
+
+        def _probe(_client, _state, name):
+            probe_calls.append(name)
+
+        monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _broken_inject)
+        monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _probe)
+
+        step = self._step()
+        step.manager.nat_topology_state = self._nat_state(["n1"])
+        # Must NOT raise.
+        step._reinject_nat_default_route("n1")
+        # Probe was skipped — inject failed, so the route isn't in
+        # a probeable state.
+        assert probe_calls == []
+
+    def test_probe_failure_does_not_propagate(self, monkeypatch):
+        # The reachability probe is purely diagnostic — it tells
+        # the user that the NAT gateway's MASQUERADE rule got
+        # dropped or similar, but the route is already re-injected.
+        # Failing the restart step on a probe miss would mask the
+        # actual bug (whatever made the gateway forwarding break)
+        # behind a less-informative test failure.
+        from merobox.topology import nat as nat_mod
+
+        def _inject(*_a, **_kw):
+            pass
+
+        def _broken_probe(*_a, **_kw):
+            raise RuntimeError("boot-node unreachable")
+
+        monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _inject)
+        monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _broken_probe)
+
+        step = self._step()
+        step.manager.nat_topology_state = self._nat_state(["n1"])
+        # Must NOT raise — probe failure is logged-and-swallowed.
+        step._reinject_nat_default_route("n1")


### PR DESCRIPTION
## Summary

`docker restart` wipes the merobox-injected `default via <nat-gateway>` route, falling back to Docker's bridge gateway. Post-restart packets then leave fine but the return path skips MASQUERADE, so noise handshakes to the boot-node time out. Re-inject the route (and re-run the reachability probe) after `container.restart()` completes.

This is the root cause of [calimero-network/core#2469](https://github.com/calimero-network/core/issues/2469) — sync-resilience peer-restart workflows hang because the restarted client never re-establishes its boot-node connection, never re-acquires its relay reservation, and never re-registers with rendezvous.

## Diagnostic evidence

Captured via a 2-second-interval `ip route show` watcher running in node-1's netns during a NAT-cone topology restart cycle:

```
21:54:13  (pre-merobox-inject)        default via 172.30.2.1   ← Docker bridge
21:54:16  (post inject_default_route) default via 172.30.2.2   ← NAT gateway ✓
21:54:41  (steady state, working)     default via 172.30.2.2
21:54:44  (post `docker restart`,     default via 172.30.2.1   ← REVERTED ✗
           same container CID
           8aa7da5bde3c)
```

Same container ID across the restart (Docker reuses the CID on `restart`), but the netns is recreated and the route table is reset.

## What changed

- **`commands/bootstrap/run/executor.py`** — stash `nat_topology_state` on the manager when NAT setup completes; clear it on teardown. This lets `RestartContainerStep` find the live topology without depending on the executor's internals.
- **`commands/bootstrap/steps/restart.py`** — after `container.restart()` succeeds, if the restarted container is one of the topology's clients, re-invoke `inject_default_route_into_client` followed by `wait_for_client_reachability`. Both are best-effort — failures log but don't propagate (the restart itself already succeeded).
- **5 new unit tests** in `test_fault_injection_steps.py` covering: no-NAT no-op, non-client no-op, happy path order (inject-then-probe), inject failure skips probe, probe failure is swallowed.
- **Version bump** 0.6.24 → 0.6.25.

## Test plan

- [x] \`black --check merobox/\` clean
- [x] \`ruff check merobox/\` clean
- [x] \`pytest merobox/tests/unit/test_fault_injection_steps.py\` — 43 passed (5 new + 38 existing)
- [ ] Re-run core#2466 sync-resilience peer-restart workflows once 0.6.25 ships to confirm #2469 closes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Docker networking for NAT workflow restarts; behavior is best-effort and scoped to NAT clients, but incorrect re-injection could still affect test topology connectivity.
> 
> **Overview**
> **`docker restart` resets NAT client routing** to Docker’s bridge default, so traffic no longer uses the merobox NAT gateway and boot-node noise handshakes can time out (sync-resilience peer-restart hangs).
> 
> The workflow executor now **stores `nat_topology_state` on the manager** when NAT topology starts and **clears it on teardown** so `restart_container` can re-inject routes only while the topology is live. **`RestartContainerStep`** calls **`inject_default_route_into_client`** then **`wait_for_client_reachability`** after a successful restart for NAT topology clients only; failures are logged and do not fail the step. **Five unit tests** lock that contract. Version **0.6.24 → 0.6.25**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bdb6bbf6143ffb1cecbf189adcb317c7af96ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->