### PR TITLE
fix(network): re-inject NAT default route after connect_node reconnect

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.25"
+__version__ = "0.6.26"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/_docker_utils.py
+++ b/merobox/commands/bootstrap/steps/_docker_utils.py
@@ -225,3 +225,70 @@ def warn_if_mdns_enabled(container: Any, node_name: str) -> None:
         f"code paths may not be exercised. Set `mdns: false` in nodes config "
         f"to make this fault test meaningful.[/yellow]"
     )
+
+
+def reinject_nat_default_route(
+    manager: Any, container_name: str, *, context: str
+) -> None:
+    """Re-apply the NAT-gateway default route to a container whose network
+    Docker just reconfigured, if it belongs to a live NAT topology.
+
+    Docker rewrites a container's routing table on any operation that
+    rebuilds its network attachment — both `docker restart` and a
+    `network disconnect` + `network connect` cycle (the partition-heal
+    used by connect_node). Either one wipes the
+    `ip route replace default via <gateway-IP>` override that the topology
+    setup applied via `inject_default_route_into_client` and re-points the
+    default route at Docker's own bridge gateway. Packets then leave fine
+    but their return path skips the NAT gateway's MASQUERADE, so the
+    client's noise handshakes to the boot-node time out and every
+    relay/rendezvous recovery path stalls.
+
+    The `nat_topology_state` attribute is stashed on the manager by
+    `WorkflowExecutor` when the topology comes up and cleared on teardown.
+    If it is absent (not a NAT run) or the container isn't one of the
+    topology's clients (e.g. the boot-node), this is a no-op — those
+    containers don't carry the gateway default route in the first place.
+
+    Best-effort: any failure is logged and swallowed. The caller's
+    operation (restart / reconnect) has already succeeded; losing the
+    route override is a degraded state worth surfacing, not a reason to
+    fail the step. `context` is a short phrase (e.g. "post-restart",
+    "post-reconnect") woven into the log lines so the source operation is
+    identifiable.
+    """
+    state = getattr(manager, "nat_topology_state", None)
+    if state is None:
+        return
+    if container_name not in state.client_names:
+        return
+
+    # Imported lazily so steps used outside NAT contexts don't pull in the
+    # NAT module's docker / iptables dependencies at import time.
+    from merobox.topology.nat import (
+        inject_default_route_into_client,
+        wait_for_client_reachability,
+    )
+
+    client = manager.client
+    try:
+        inject_default_route_into_client(client, state, container_name)
+    except Exception as exc:
+        console.print(
+            f"[yellow]Failed to re-inject default route into "
+            f"{container_name!r} {context}: {exc}[/yellow]"
+        )
+        return
+
+    # Verify the client can still reach the boot-node through the gateway —
+    # the same probe topology setup runs. A failure here means the route
+    # was re-injected but the forwarding path is broken (e.g. a dropped
+    # gateway MASQUERADE rule), which is far more diagnostic than letting
+    # the caller's downstream sync silently time out.
+    try:
+        wait_for_client_reachability(client, state, container_name)
+    except Exception as exc:
+        console.print(
+            f"[yellow]{context} reachability check from "
+            f"{container_name!r} → boot-node failed: {exc}[/yellow]"
+        )

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -29,6 +29,7 @@ from merobox.commands.bootstrap.steps._docker_utils import (
     get_docker_client,
     is_binary_mode,
     partition_network_key,
+    reinject_nat_default_route,
     safe_console_error,
     warn_if_mdns_enabled,
 )
@@ -180,4 +181,13 @@ class ConnectNodeStep(BaseStep):
         dynamic_values.pop(partition_network_key(node_name), None)
 
         console.print(f"[green]✓ Connected {node_name} to {network_name}[/green]")
+
+        # Reconnecting via `network.connect` rebuilds the container's network
+        # attachment, which makes Docker re-point the default route at its
+        # own bridge gateway — wiping the NAT-gateway override the topology
+        # injected. Without re-applying it, the just-healed client routes
+        # around the NAT gateway, its noise handshakes to the boot-node time
+        # out, and the partition never actually "heals" for libp2p. No-op
+        # outside a NAT topology.
+        reinject_nat_default_route(self.manager, node_name, context="post-reconnect")
         return True

--- a/merobox/commands/bootstrap/steps/restart.py
+++ b/merobox/commands/bootstrap/steps/restart.py
@@ -25,6 +25,7 @@ import aiohttp
 
 from merobox.commands.bootstrap.steps._docker_utils import (
     is_binary_mode,
+    reinject_nat_default_route,
     resolve_container,
 )
 from merobox.commands.bootstrap.steps.base import BaseStep
@@ -111,24 +112,12 @@ class RestartContainerStep(BaseStep):
 
         console.print(f"[green]✓ Restarted {container_name}[/green]")
 
-        # Re-inject the NAT-topology default route if applicable.
-        # `docker restart` resets the container's network
-        # configuration to Docker's defaults, which wipes the
-        # `ip route replace default via <gateway-IP>` override
-        # that the topology setup applied via
-        # `inject_default_route_into_client`. Without re-injection,
-        # post-restart packets go via Docker's bridge gateway
-        # instead of the NAT gateway — they leave fine but the
-        # MASQUERADE return path is missing, so noise handshakes
-        # to the boot-node time out (verified via netns
-        # route-watcher in the #2469 keypair-repro v6 run; see
-        # the PR description for the timeline).
-        #
-        # Best-effort: failure to re-inject doesn't fail the
-        # restart itself (the caller may not even be in a NAT
-        # topology — `nat_topology_state` is `None` in that
-        # case). Errors are surfaced to the console.
-        self._reinject_nat_default_route(container_name)
+        # `docker restart` rebuilds the container's network attachment and
+        # wipes the NAT-gateway default route the topology setup injected;
+        # re-apply it (no-op outside a NAT topology). Verified via netns
+        # route-watcher in the #2469 keypair-repro v6 run — see the shared
+        # helper for the full rationale.
+        reinject_nat_default_route(self.manager, container_name, context="post-restart")
 
         if not wait_healthy:
             # No health gate requested. Snapshot what the new
@@ -153,62 +142,6 @@ class RestartContainerStep(BaseStep):
         # capture) for the upstream rationale.
         self._snapshot_post_restart_logs(container, container_name)
         return healthy
-
-    def _reinject_nat_default_route(self, container_name: str) -> None:
-        """Re-inject the NAT-gateway default route into the
-        just-restarted container if it belongs to a live NAT
-        topology.
-
-        The `nat_topology_state` attribute is stashed on the
-        manager by `WorkflowExecutor._start_nodes_nat_topology`
-        when the topology comes up, and cleared on teardown. If
-        absent or empty, the restart isn't in a NAT context and
-        this method is a no-op.
-        """
-        state = getattr(self.manager, "nat_topology_state", None)
-        if state is None:
-            # Not a NAT topology — nothing to re-inject.
-            return
-        if container_name not in state.client_names:
-            # Restart targets a container that isn't a NAT
-            # client (e.g. the boot-node or a non-topology
-            # container). Default route is already correct.
-            return
-
-        # Imported here to avoid pulling the NAT module's
-        # docker / iptables deps into the step's import path
-        # when the step is used outside NAT contexts.
-        from merobox.topology.nat import (
-            inject_default_route_into_client,
-            wait_for_client_reachability,
-        )
-
-        client = self.manager.client
-        try:
-            inject_default_route_into_client(client, state, container_name)
-        except Exception as exc:
-            console.print(
-                f"[yellow]Failed to re-inject default route into "
-                f"{container_name!r} post-restart: {exc}[/yellow]"
-            )
-            return
-
-        # Verify the client can still reach the boot-node
-        # through the gateway. This is the same probe the
-        # initial topology setup runs and serves the same
-        # purpose: catch a half-broken topology before the
-        # caller starts asserting on sync behaviour. A failure
-        # here means the route was re-injected but the
-        # forwarding path is broken (e.g. gateway MASQUERADE
-        # rule got dropped somehow) — much more diagnostic
-        # than letting downstream sync time out.
-        try:
-            wait_for_client_reachability(client, state, container_name)
-        except Exception as exc:
-            console.print(
-                f"[yellow]Post-restart reachability check from "
-                f"{container_name!r} → boot-node failed: {exc}[/yellow]"
-            )
 
     @staticmethod
     def _snapshot_pre_restart_logs(container: Any, container_name: str) -> None:

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -5,8 +5,15 @@ schema layer), which catches misconfigurations even if a workflow bypasses
 schema validation.
 """
 
+import asyncio
+
 import pytest
 
+from merobox.commands.bootstrap.steps import network as network_mod
+from merobox.commands.bootstrap.steps._docker_utils import (
+    partition_network_key,
+    reinject_nat_default_route,
+)
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.network import (
     ConnectNodeStep,
@@ -612,49 +619,50 @@ class TestRestartLogSnapshotReviewFixes:
 
 
 # ---------------------------------------------------------------------------
-# RestartContainerStep — NAT-topology default-route re-injection
+# reinject_nat_default_route — shared NAT default-route re-application
 #
-# `docker restart` resets the container's network configuration to
-# Docker's defaults, which wipes the `ip route replace default via
-# <gateway-IP>` override that the NAT-topology setup applied via
-# `inject_default_route_into_client`. Without re-injection, post-restart
-# packets go via Docker's bridge gateway instead of the NAT gateway —
-# they leave fine but the MASQUERADE return path is missing, so noise
-# handshakes to the boot-node time out. This is core#2469's root cause.
+# Docker rewrites a container's routing table on any operation that
+# rebuilds its network attachment: `docker restart` (RestartContainerStep)
+# AND a `network disconnect` + `connect` cycle (ConnectNodeStep's
+# partition-heal). Either one wipes the `ip route replace default via
+# <gateway-IP>` override the NAT topology injected, re-pointing the
+# default route at Docker's own bridge gateway. Packets then leave fine
+# but their return path skips the gateway's MASQUERADE, so the client's
+# noise handshakes to the boot-node time out. This is core#2469's root
+# cause for restart, and the same mechanism strands a reconnected peer
+# after a network-partition heal.
 #
-# These tests pin the re-injection contract on RestartContainerStep:
+# These tests pin the shared helper's contract:
 #
 #   - Only fires when `manager.nat_topology_state` is non-None AND the
-#     restarted container is one of the topology's clients.
+#     target container is one of the topology's clients.
 #   - No-op for boot-node / non-topology container / no-NAT setups.
 #   - Reachability probe surfaces a half-broken topology before the
 #     caller starts asserting on sync behaviour.
-#   - Inject failure → log + continue (don't crash the restart step).
+#   - Inject failure → log + continue (don't crash the caller's step).
 #   - Reachability failure → log + continue (the route's already
 #     re-injected; the probe is diagnostic, not gating).
 # ---------------------------------------------------------------------------
 
 
-class TestRestartReinjectNatDefaultRoute:
+class TestReinjectNatDefaultRoute:
     @staticmethod
-    def _step():
-        # Construct the step the same way the YAML loader would, then
-        # attach a `manager` shim (the executor normally sets it on the
-        # step right before `execute()` runs).
-        step = RestartContainerStep({"type": "restart_container", "container": "n1"})
-
+    def _manager(nat_topology_state=None):
+        # Minimal stand-in for the workflow manager the executor passes
+        # to steps. The helper only touches `.client` (opaque, forwarded
+        # to the nat module — which we patch) and `.nat_topology_state`.
         class _ManagerShim:
-            client = object()  # sentinel — never dereferenced
-            nat_topology_state = None
+            def __init__(self, state):
+                self.client = object()  # sentinel — never dereferenced
+                self.nat_topology_state = state
 
-        step.manager = _ManagerShim()
-        return step
+        return _ManagerShim(nat_topology_state)
 
     @staticmethod
     def _nat_state(client_names):
-        # Stand-in for `NatTopologyState` — only `client_names` is
-        # touched by `_reinject_nat_default_route`. Avoid pulling
-        # the real dataclass + its docker deps into the unit test.
+        # Stand-in for `NatTopologyState` — only `client_names` is read
+        # by reinject_nat_default_route. Avoid pulling the real dataclass
+        # and its docker deps into the unit test.
         class _State:
             def __init__(self, names):
                 self.client_names = names
@@ -673,10 +681,8 @@ class TestRestartReinjectNatDefaultRoute:
         monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _boom)
         monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _boom)
 
-        step = self._step()
-        step.manager.nat_topology_state = None
         # Must NOT raise.
-        step._reinject_nat_default_route("n1")
+        reinject_nat_default_route(self._manager(None), "n1", context="post-restart")
 
     def test_noop_when_container_is_not_a_nat_client(self, monkeypatch):
         # The boot-node and any non-topology container fall through
@@ -691,9 +697,8 @@ class TestRestartReinjectNatDefaultRoute:
         monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _boom)
         monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _boom)
 
-        step = self._step()
-        step.manager.nat_topology_state = self._nat_state(["client-1", "client-2"])
-        step._reinject_nat_default_route("boot-node")
+        mgr = self._manager(self._nat_state(["client-1", "client-2"]))
+        reinject_nat_default_route(mgr, "boot-node", context="post-reconnect")
 
     def test_reinjects_and_probes_when_container_is_a_nat_client(self, monkeypatch):
         # Happy path: state present, container in client_names. Both
@@ -711,9 +716,8 @@ class TestRestartReinjectNatDefaultRoute:
         monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _inject)
         monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _probe)
 
-        step = self._step()
-        step.manager.nat_topology_state = self._nat_state(["n1", "n2"])
-        step._reinject_nat_default_route("n1")
+        mgr = self._manager(self._nat_state(["n1", "n2"]))
+        reinject_nat_default_route(mgr, "n1", context="post-reconnect")
 
         # Order matters: inject BEFORE probe. If the probe ran
         # first it'd flake on an unconfigured route.
@@ -737,10 +741,9 @@ class TestRestartReinjectNatDefaultRoute:
         monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _broken_inject)
         monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _probe)
 
-        step = self._step()
-        step.manager.nat_topology_state = self._nat_state(["n1"])
+        mgr = self._manager(self._nat_state(["n1"]))
         # Must NOT raise.
-        step._reinject_nat_default_route("n1")
+        reinject_nat_default_route(mgr, "n1", context="post-restart")
         # Probe was skipped — inject failed, so the route isn't in
         # a probeable state.
         assert probe_calls == []
@@ -749,7 +752,7 @@ class TestRestartReinjectNatDefaultRoute:
         # The reachability probe is purely diagnostic — it tells
         # the user that the NAT gateway's MASQUERADE rule got
         # dropped or similar, but the route is already re-injected.
-        # Failing the restart step on a probe miss would mask the
+        # Failing the caller's step on a probe miss would mask the
         # actual bug (whatever made the gateway forwarding break)
         # behind a less-informative test failure.
         from merobox.topology import nat as nat_mod
@@ -763,7 +766,56 @@ class TestRestartReinjectNatDefaultRoute:
         monkeypatch.setattr(nat_mod, "inject_default_route_into_client", _inject)
         monkeypatch.setattr(nat_mod, "wait_for_client_reachability", _broken_probe)
 
-        step = self._step()
-        step.manager.nat_topology_state = self._nat_state(["n1"])
+        mgr = self._manager(self._nat_state(["n1"]))
         # Must NOT raise — probe failure is logged-and-swallowed.
-        step._reinject_nat_default_route("n1")
+        reinject_nat_default_route(mgr, "n1", context="post-reconnect")
+
+
+class TestConnectNodeReinjectsRoute:
+    """ConnectNodeStep must re-apply the NAT default route after a
+    successful reconnect — without it, a peer that 'heals' from a
+    network-partition step routes around the NAT gateway and never
+    actually re-establishes connectivity to the boot-node."""
+
+    def test_connect_node_calls_reinject_after_successful_connect(self, monkeypatch):
+        reinjected: list[tuple[str, str]] = []
+
+        def _spy_reinject(_manager, container_name, *, context):
+            reinjected.append((container_name, context))
+
+        # Patch the symbol as imported into the network module's namespace
+        # (the step calls the bare name, not the _docker_utils-qualified one).
+        monkeypatch.setattr(network_mod, "reinject_nat_default_route", _spy_reinject)
+        monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
+
+        # Stub the docker client so `network.connect` "succeeds" without a
+        # real daemon. detect_node_network isn't reached because a prior
+        # disconnect recorded the partition network in dynamic_values.
+        class _FakeNetwork:
+            def connect(self, _container):
+                return None
+
+        class _FakeClient:
+            class containers:
+                @staticmethod
+                def get(_name):
+                    return object()
+
+            class networks:
+                @staticmethod
+                def get(_name):
+                    return _FakeNetwork()
+
+        monkeypatch.setattr(network_mod, "get_docker_client", lambda _m: _FakeClient())
+
+        step = ConnectNodeStep({"type": "connect_node", "node": "sync-resil-node-2"})
+        step.manager = object()
+
+        dynamic_values = {
+            partition_network_key("sync-resil-node-2"): "some-lan-network",
+        }
+        ok = asyncio.run(step.execute({}, dynamic_values))
+
+        assert ok is True
+        # The reconnected node, tagged with the post-reconnect context.
+        assert reinjected == [("sync-resil-node-2", "post-reconnect")], reinjected

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -5,8 +5,6 @@ schema layer), which catches misconfigurations even if a workflow bypasses
 schema validation.
 """
 
-import asyncio
-
 import pytest
 
 from merobox.commands.bootstrap.steps import network as network_mod
@@ -777,7 +775,10 @@ class TestConnectNodeReinjectsRoute:
     network-partition step routes around the NAT gateway and never
     actually re-establishes connectivity to the boot-node."""
 
-    def test_connect_node_calls_reinject_after_successful_connect(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_connect_node_calls_reinject_after_successful_connect(
+        self, monkeypatch
+    ):
         reinjected: list[tuple[str, str]] = []
 
         def _spy_reinject(_manager, container_name, *, context):
@@ -814,7 +815,7 @@ class TestConnectNodeReinjectsRoute:
         dynamic_values = {
             partition_network_key("sync-resil-node-2"): "some-lan-network",
         }
-        ok = asyncio.run(step.execute({}, dynamic_values))
+        ok = await step.execute({}, dynamic_values)
 
         assert ok is True
         # The reconnected node, tagged with the post-reconnect context.


### PR DESCRIPTION
## Summary

A `network disconnect` + `connect` cycle (the partition-heal `connect_node` performs) rebuilds the container's network attachment, so Docker re-points the default route at its own bridge gateway — the **same clobber `docker restart` causes**, which #263 fixed for restart in 0.6.25. Without re-applying the NAT-gateway override, a peer that "heals" from a `sync-resilience-network-partition` step routes around the NAT gateway: packets leave fine but the return path skips the gateway's MASQUERADE, so its noise handshakes to the boot-node time out and the partition never actually heals for libp2p.

This is one half of the fix for the `sync-resilience-network-partition` workflows (cone + symmetric) hanging at the post-partition `wait_for_sync` in [calimero-network/core#2466](https://github.com/calimero-network/core/pull/2466). The other half (core: close silently-dead connections on repeated ping failure so recovery actually triggers) is a separate core PR.

## What changed

- Extracted the route re-injection from `RestartContainerStep` into a shared `reinject_nat_default_route(manager, container_name, *, context)` helper in `_docker_utils`.
- `restart.py` calls it with `context="post-restart"`; `connect_node` (network.py) now calls it with `context="post-reconnect"` after a successful reconnect.
- No-op outside a NAT topology; best-effort on failure (logged, never raised) — unchanged from the restart behaviour.

## Tests

- The 5 existing re-injection contract tests now target the shared helper directly (no-op cases, inject-then-probe order, inject-failure-skips-probe, probe-failure-swallowed).
- New `connect_node` wiring test asserts the reconnect path invokes the helper with the `post-reconnect` context.
- `black --check` / `ruff check` clean; touched test file passes 44/44.

Bumps version 0.6.25 → 0.6.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to NAT-topology e2e/bootstrap steps with no-op outside NAT runs; behavior matches the existing post-restart path, with tests covering the helper and connect wiring.
> 
> **Overview**
> **NAT partition heal:** After a successful `connect_node` reconnect, merobox now re-applies the NAT-gateway default route (same fix as post-`docker restart` in 0.6.25). Docker’s `network.connect` resets routing to the bridge gateway, so NAT clients could “heal” on paper while libp2p traffic still bypassed MASQUERADE and `wait_for_sync` hung.
> 
> The logic moved from `RestartContainerStep` into shared `reinject_nat_default_route` in `_docker_utils` (inject route, optional boot-node reachability probe, best-effort logging). **Restart** calls it with `post-restart`; **connect** calls it with `post-reconnect`. Version **0.6.26**.
> 
> Unit tests now target the helper directly and add a `ConnectNodeStep` wiring test for `post-reconnect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b972838cfa0d25d7328f4ad01670990c6072efe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->