### PR TITLE
fix(nat): avoid LAN/public subnet overlap + diagnose reachability failures

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.26"
+__version__ = "0.6.27"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/tests/unit/test_nat_topology.py
+++ b/merobox/tests/unit/test_nat_topology.py
@@ -716,6 +716,91 @@ def test_pick_lan_subnet_returns_valid_rfc1918_24():
 
 
 # ---------------------------------------------------------------------------
+# _pick_lan_subnet — overlap avoidance (the peer-restart-symmetric fix)
+#
+# The public network is created with a Docker-AUTO-assigned subnet
+# BEFORE the LAN. Docker's pool can hand the public bridge a /16 (e.g.
+# 172.30.0.0/16) that swallows the hashed LAN /24. Overlapping ranges on
+# the gateway's two interfaces make the kernel's reverse-path lookup for
+# return traffic ambiguous, silently killing the return path — the
+# client SYN leaves but the reply never comes back, and the reachability
+# probe hangs until `timeout` SIGTERMs it. When a `client` is supplied,
+# the picker must dodge every existing network's subnet.
+# ---------------------------------------------------------------------------
+
+
+def _fake_docker_client_with_subnets(subnets):
+    """Build a stub Docker client whose `networks.list()` returns
+    networks carrying the given subnets, shaped like docker-py's
+    `.attrs["IPAM"]["Config"]`."""
+
+    class _FakeNet:
+        def __init__(self, name, subnet):
+            self.name = name
+            self.attrs = {"IPAM": {"Config": [{"Subnet": subnet}]}}
+
+    class _FakeNetworks:
+        def __init__(self, nets):
+            self._nets = nets
+
+        def list(self):
+            return self._nets
+
+    class _FakeClient:
+        def __init__(self, nets):
+            self.networks = _FakeNetworks(nets)
+
+    return _FakeClient([_FakeNet(f"net-{i}", s) for i, s in enumerate(subnets)])
+
+
+def test_pick_lan_subnet_client_none_matches_pure_hash():
+    """Passing no client preserves the historical pure-hash behaviour,
+    so reruns on a clean host still reuse their own subnet."""
+    assert _pick_lan_subnet("some-workflow", None) == _pick_lan_subnet("some-workflow")
+
+
+def test_pick_lan_subnet_avoids_overlapping_public_16():
+    """If the auto-assigned public network grabbed the /16 that
+    contains the hashed /24, the picker must return a /24 that does
+    NOT overlap it."""
+    import ipaddress
+
+    name = "Sync Resilience — Peer Restart (NAT symmetric)"
+    hashed = _pick_lan_subnet(name)  # pure hash, no client
+    # Simulate the public bridge swallowing the hashed /24 inside a /16.
+    hashed_net = ipaddress.ip_network(hashed)
+    public_16 = ipaddress.ip_network("172.30.0.0/16")
+    assert hashed_net.overlaps(public_16)  # precondition for the bug
+
+    client = _fake_docker_client_with_subnets(["172.30.0.0/16", "172.17.0.0/16"])
+    chosen = _pick_lan_subnet(name, client)
+    chosen_net = ipaddress.ip_network(chosen)
+    # Must not overlap any existing network.
+    assert not chosen_net.overlaps(public_16)
+    assert not chosen_net.overlaps(ipaddress.ip_network("172.17.0.0/16"))
+
+
+def test_pick_lan_subnet_falls_back_to_10_range_when_17230_exhausted():
+    """If all of 172.30.0.0/16 is occupied, the picker falls back to a
+    10.x /24 rather than returning an overlapping subnet."""
+    import ipaddress
+
+    client = _fake_docker_client_with_subnets(["172.30.0.0/16"])
+    chosen = _pick_lan_subnet("whatever-workflow", client)
+    chosen_net = ipaddress.ip_network(chosen)
+    assert not chosen_net.overlaps(ipaddress.ip_network("172.30.0.0/16"))
+    assert chosen.startswith("10.")
+
+
+def test_pick_lan_subnet_returns_hashed_start_when_no_overlap():
+    """With a client present but no conflicting networks, the picker
+    still returns the deterministic hashed /24 (the search starts there
+    and the first candidate is free)."""
+    client = _fake_docker_client_with_subnets(["172.18.0.0/16", "172.17.0.0/16"])
+    assert _pick_lan_subnet("cone-smoke", client) == _pick_lan_subnet("cone-smoke")
+
+
+# ---------------------------------------------------------------------------
 # teardown_nat_topology
 # ---------------------------------------------------------------------------
 #

--- a/merobox/topology/nat.py
+++ b/merobox/topology/nat.py
@@ -686,6 +686,20 @@ def wait_for_client_reachability(
                 f"→ boot-node: {e}"
             ) from e
         time.sleep(NAT_CONNECTIVITY_PROBE_INTERVAL_SECONDS)
+    # The probe never succeeded. This is the failure that was
+    # previously blind: the bare "could not reach" error gives no
+    # gateway-side state, so a CI failure here (e.g. a dead return
+    # path that presents as `nc` hanging until `timeout` SIGTERMs it,
+    # exit 143) is undiagnosable from the log alone. Dump the full
+    # topology state — gateway forwarding sysctls, FORWARD/nat chain
+    # counters, conntrack, per-client routes, and the Docker network
+    # subnets (to surface a public/LAN overlap) — before raising, so
+    # the next failure is diagnosable from the artifact. Best-effort:
+    # a dump that itself fails must not mask the original error.
+    try:
+        _dump_topology_diagnostics(client, state)
+    except Exception as diag_exc:
+        console.print(f"[yellow]Topology diagnostics dump failed: {diag_exc}[/yellow]")
     raise RuntimeError(
         f"{client_container_name} could not reach the boot-node "
         f"({state.boot_node_public_ip}:{BOOT_NODE_PORT}) within "
@@ -739,28 +753,102 @@ def _spawn_boot_node(
     return container
 
 
-def _pick_lan_subnet(workflow_name: str) -> str:
-    """Choose a deterministic LAN-bridge subnet for the workflow.
+def _existing_network_subnets(
+    client: docker.DockerClient,
+) -> list:
+    """Collect the IPv4 subnets of every Docker network the daemon
+    currently knows about, so a freshly-pinned LAN subnet can avoid
+    overlapping any of them.
+
+    Best-effort: the whole scan is wrapped so a daemon hiccup just
+    yields an empty list (callers then fall back to the deterministic
+    hash), and a single network whose IPAM has no/garbage subnet is
+    skipped rather than aborting the scan.
+    """
+    import ipaddress
+
+    subnets = []
+    try:
+        networks = client.networks.list()
+    except Exception:
+        return subnets
+    for net in networks:
+        ipam = (getattr(net, "attrs", {}) or {}).get("IPAM") or {}
+        for cfg in ipam.get("Config") or []:
+            raw = cfg.get("Subnet")
+            if not raw:
+                continue
+            try:
+                subnets.append(ipaddress.ip_network(raw, strict=False))
+            except ValueError:
+                continue
+    return subnets
+
+
+def _pick_lan_subnet(
+    workflow_name: str, client: docker.DockerClient | None = None
+) -> str:
+    """Choose a deterministic LAN-bridge /24 for the workflow that does
+    not overlap any network the Docker daemon already has.
 
     The subnet has to be user-configured (not Docker-auto-assigned)
     because `_spawn_nat_gateway` connects the gateway with
-    `ipv4_address=`, and Docker rejects explicit IPs on
-    auto-subnetted networks. Determinism per workflow name lets a
-    rerun pick up the same subnet a previous crashed run created;
-    different workflow names yield different subnets so parallel
-    workflows don't collide.
+    `ipv4_address=`, and Docker rejects explicit IPs on auto-subnetted
+    networks.
 
-    Layout: `172.30.<hash & 0xff>.0/24`. The 172.16.0.0/12 range is
-    RFC1918 private and rarely in use on CI runners (which use
-    172.17.x for the default Docker bridge). 256 distinct subnets
-    is plenty — collisions would only matter if a single host ran
-    more than ~256 NAT workflows in parallel, which we're nowhere
-    near.
+    Determinism: the search STARTS at
+    `172.30.<sha256(name) & 0xff>.0/24`, so a rerun of the same workflow
+    on a clean host reuses the same subnet (and finds its own leftover
+    network from a crashed run); different workflow names start at
+    different octets.
+
+    Overlap guard (`client` provided): the *public* network is created
+    with a Docker-AUTO-assigned subnet BEFORE the LAN, and Docker's
+    address pool can hand that public bridge a /16 (e.g. 172.30.0.0/16)
+    that swallows the hashed LAN /24. Two interfaces on overlapping
+    ranges inside the gateway's netns make the kernel's reverse-path
+    lookup for return traffic ambiguous — the client's SYN leaves fine
+    but the boot-node's reply has no deterministic way back, so the
+    reachability probe hangs until its `timeout` SIGTERMs it (the
+    `exit 143` seen in CI). When the hashed start /24 overlaps an
+    existing network we walk forward through 172.30.0.0/16 to the first
+    free /24, then fall back to a 10.x range if the whole block is
+    somehow occupied.
+
+    With `client=None` the function is pure (hash only) — preserves the
+    historical behaviour for callers/tests that don't need the guard.
     """
     import hashlib
+    import ipaddress
 
-    octet = int(hashlib.sha256(workflow_name.encode()).hexdigest(), 16) & 0xFF
-    return f"172.30.{octet}.0/24"
+    start = int(hashlib.sha256(workflow_name.encode()).hexdigest(), 16) & 0xFF
+    existing = _existing_network_subnets(client) if client is not None else []
+
+    def _free(candidate: str) -> bool:
+        net = ipaddress.ip_network(candidate)
+        return not any(net.overlaps(e) for e in existing)
+
+    # Primary range: walk 172.30.0.0/16 from the deterministic start.
+    # With no existing subnets to dodge, the first candidate (the pure
+    # hash) is returned immediately, matching the historical layout.
+    for i in range(256):
+        candidate = f"172.30.{(start + i) & 0xFF}.0/24"
+        if not existing or _free(candidate):
+            return candidate
+
+    # 172.30.0.0/16 fully occupied (pathological — a host carrying
+    # 256 overlapping bridges). Fall back to a deterministic-ish /24
+    # in 10.0.0.0/8 and scan that too.
+    for i in range(256):
+        candidate = f"10.{(start + i) & 0xFF}.{start & 0xFF}.0/24"
+        if _free(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "could not find a free /24 for the LAN bridge: 172.30.0.0/16 and "
+        "the 10.x fallback are both fully occupied by existing Docker "
+        "networks. Prune unused networks (`docker network prune`)."
+    )
 
 
 def _pick_gateway_lan_ip(lan_network: docker.models.networks.Network) -> str:
@@ -1409,11 +1497,12 @@ def setup_nat_topology(
             internal=False,
             # User-configured subnet is REQUIRED because the gateway
             # gets attached with an explicit `ipv4_address=` (see
-            # `_spawn_nat_gateway`). The actual subnet doesn't matter
-            # — picking a deterministic-per-workflow value from a
-            # private range keeps parallel workflows from colliding
-            # while still letting reruns find their own leftover state.
-            subnet=_pick_lan_subnet(workflow_name),
+            # `_spawn_nat_gateway`). Pass `client` so the picker can
+            # dodge the already-created public network's auto-assigned
+            # subnet — Docker's pool can hand the public bridge a /16
+            # that swallows the hashed LAN /24, and the resulting
+            # overlap silently kills the gateway's return path.
+            subnet=_pick_lan_subnet(workflow_name, client),
         )
 
         # Step 3: boot-node.
@@ -1681,6 +1770,55 @@ def _dump_topology_diagnostics(
     down a relay-reservation timeout. Called from the readiness-gate
     failure path; safe to call ad hoc as well."""
     console.print("[yellow]── NAT topology diagnostics ──[/yellow]")
+    # Docker network subnets. A LAN /24 that overlaps the
+    # auto-assigned public /16 (or any other bridge) makes the
+    # gateway's reverse-path lookup ambiguous and silently kills the
+    # return path — exactly the "SYN out, nothing back" symptom. List
+    # every network's name + subnet so an overlap is visible at a
+    # glance. rp_filter and conntrack appear further down; this block
+    # is the cheapest thing to check first.
+    try:
+        import ipaddress
+
+        rows = []
+        for net in client.networks.list():
+            ipam = (getattr(net, "attrs", {}) or {}).get("IPAM") or {}
+            subs = [
+                cfg.get("Subnet")
+                for cfg in (ipam.get("Config") or [])
+                if cfg.get("Subnet")
+            ]
+            rows.append(f"  {net.name}: {', '.join(subs) or '<none>'}")
+        # Flag any pair of subnets that overlap — that's the smoking gun.
+        nets = []
+        for net in client.networks.list():
+            ipam = (getattr(net, "attrs", {}) or {}).get("IPAM") or {}
+            for cfg in ipam.get("Config") or []:
+                raw = cfg.get("Subnet")
+                if raw:
+                    try:
+                        nets.append((net.name, ipaddress.ip_network(raw, strict=False)))
+                    except ValueError:
+                        pass
+        overlaps = [
+            f"  {a_name} {a} OVERLAPS {b_name} {b}"
+            for i, (a_name, a) in enumerate(nets)
+            for (b_name, b) in nets[i + 1 :]
+            if a.overlaps(b)
+        ]
+        console.print(
+            "[yellow]--- docker networks (name: subnet) ---\n"
+            + "\n".join(rows)
+            + (
+                "\n--- OVERLAPPING SUBNETS (likely return-path culprit) ---\n"
+                + "\n".join(overlaps)
+                if overlaps
+                else "\n(no overlapping subnets detected)"
+            )
+            + "[/yellow]"
+        )
+    except Exception as e:
+        console.print(f"[yellow]Failed to enumerate docker networks: {e}[/yellow]")
     # Gateway logs (entrypoint output: iptables rules, ip routes,
     # any FATAL the script emitted).
     try:
@@ -1714,6 +1852,13 @@ def _dump_topology_diagnostics(
                     " echo '--- per-iface forwarding ---';"
                     " for f in /proc/sys/net/ipv4/conf/*/forwarding;"
                     '   do printf \'%s = \' "$f"; cat "$f"; done;'
+                    " echo '--- per-iface rp_filter ---';"
+                    " for f in /proc/sys/net/ipv4/conf/*/rp_filter;"
+                    '   do printf \'%s = \' "$f"; cat "$f"; done;'
+                    " echo '--- ip addr (gateway eth0/eth1 subnets) ---';"
+                    " (ip -4 addr 2>&1 || echo 'ip unavailable');"
+                    " echo '--- ip route ---';"
+                    " (ip -4 route 2>&1 || echo 'ip unavailable');"
                     " echo '--- FORWARD chain ---';"
                     " iptables -L FORWARD -nv;"
                     " echo '--- nat table ---';"


### PR DESCRIPTION
## Summary

Stacked on #264. Targets the `peer-restart-symmetric` setup failure where the client→boot-node reachability probe times out for 60s with every `nc` hanging until `timeout` SIGTERMs it (`exit 143`) — packets leave the client but **nothing comes back**, even though the gateway's forwarding is verified and MASQUERADE installed.

## Root cause (candidate)

The LAN bridge subnet is pinned to `172.30.<sha256(workflow_name) & 0xff>.0/24`, but the **public** network is created with a Docker-**auto**-assigned subnet *before* the LAN. Docker's address pool can hand the public bridge a `/16` (e.g. `172.30.0.0/16`) that **swallows the hashed LAN `/24`**. Overlapping ranges on the gateway's two interfaces make the kernel's reverse-path lookup for return traffic ambiguous → return path silently dead. Because the subnet is derived from the (fixed) workflow name, this reproduces **deterministically** for the unlucky name on its own runner — which matches the observed behaviour (matrix jobs run on separate runners; `peer-restart-symmetric` fails 2/2 while same-topology `peer-pause-symmetric`/`network-partition-symmetric` pass).

## Fix

- `_pick_lan_subnet(workflow_name, client)` now walks forward from the deterministic hashed `/24` to the first `/24` that doesn't overlap any existing Docker network (falls back to a `10.x` range if `172.30/16` is full). With `client=None` it stays pure-hash, preserving rerun determinism for callers/tests that don't need the guard.

## Diagnostics (so this failure is never blind again)

The existing `_dump_topology_diagnostics` only fired on the relay-readiness path, not on the initial reachability probe. Now:
- `wait_for_client_reachability` runs the dump before raising its timeout error.
- the dump gains a **docker-networks-with-subnets** section that flags any overlapping pair, plus gateway **`rp_filter`**, **`ip addr`**, and **`ip route`** — so if the subnet-overlap theory is wrong, the next CI run still shows the exact mechanism (rp_filter, conntrack, forwarding) in the artifact.

## Tests

- 4 new overlap-avoidance unit tests (client=None pure-hash parity; avoids overlapping `/16`; falls back to `10.x` when `172.30/16` exhausted; returns hashed start when no conflict).
- `black`/`ruff` clean; `test_nat_topology.py` + `test_fault_injection_steps.py` = 89 passed.

Bumps 0.6.26 → 0.6.27.

> Note: I could not reproduce locally (Docker unavailable in my env), so the subnet-overlap mechanism is the leading-evidence candidate rather than a confirmed repro — the added diagnostics are the backstop that will confirm or redirect on the next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how LAN subnets are chosen for all NAT workflows (network addressing only, but wrong overlap logic could break topology); diagnostics are additive and best-effort on failure paths.
> 
> **Overview**
> NAT topology setup now picks a LAN `/24` that does not overlap subnets Docker already assigned (especially the auto-subnetted public bridge created first), walking from the workflow-hash start through `172.30.0.0/16` and falling back to `10.x` if needed. **`setup_nat_topology`** passes the Docker client into **`_pick_lan_subnet`**; with **`client=None`**, behavior stays the pure hash for tests and backward compatibility.
> 
> When the client→boot-node reachability probe times out, **`wait_for_client_reachability`** runs **`_dump_topology_diagnostics`** before raising. That dump now lists every network’s subnet and flags overlaps, and adds gateway **`rp_filter`**, **`ip addr`**, and **`ip route`** alongside existing iptables/forwarding output.
> 
> Four unit tests cover overlap avoidance; version **0.6.26 → 0.6.27**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27db66756f86c9b697c4cc413f93248a554d9030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->