### PR TITLE
feat(wait_for_sync): adaptive backoff polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `wait_for_sync` now polls with adaptive backoff instead of a fixed
+  `check_interval` after every missed convergence check. The inter-attempt
+  sleep starts at `initial_check_interval` (default `0.05s`) and grows
+  geometrically by `backoff_factor` (default `2.0`), capped at
+  `check_interval`. Fast syncs that miss the first check are caught in
+  ~50–150ms instead of rounding up to a full `check_interval`; slow or
+  never-converging syncs still poll at no more than `check_interval` in
+  steady state, so RPC load on the slow path is unchanged. The existing
+  per-attempt jitter for de-syncing parallel node pollers is preserved.
+  New optional step fields `initial_check_interval` and `backoff_factor`
+  expose the schedule; existing workflows behave the same or faster
+  without changes. Closes #267.
+
 ## [0.6.23] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.29] - 2026-05-30
+
 ### Changed
 
 - `wait_for_sync` now polls with adaptive backoff instead of a fixed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.28"
+__version__ = "0.6.29"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -334,8 +334,18 @@ class WaitForSyncStep(BaseStepConfig):
     )
     nodes: list[str] = Field(..., description="Nodes to wait for sync")
     timeout: Optional[int] = Field(60, ge=1, description="Timeout in seconds")
-    check_interval: Optional[int] = Field(
-        2, ge=1, description="Check interval in seconds"
+    check_interval: Optional[float] = Field(
+        2, gt=0, description="Steady-state polling cap in seconds (backoff ceiling)"
+    )
+    initial_check_interval: Optional[float] = Field(
+        None,
+        gt=0,
+        description="Starting inter-attempt sleep for adaptive backoff (defaults to 0.05s)",
+    )
+    backoff_factor: Optional[float] = Field(
+        None,
+        ge=1,
+        description="Geometric growth per missed check, capped at check_interval (defaults to 2.0)",
     )
     trigger_sync: Optional[bool] = Field(
         False, description="Trigger sync before waiting"

--- a/merobox/commands/bootstrap/steps/wait_for_sync.py
+++ b/merobox/commands/bootstrap/steps/wait_for_sync.py
@@ -9,7 +9,12 @@ from typing import Any
 
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
-from merobox.commands.constants import SYNC_RETRY_ATTEMPTS, SYNC_RETRY_DELAY
+from merobox.commands.constants import (
+    SYNC_BACKOFF_FACTOR,
+    SYNC_INITIAL_CHECK_INTERVAL,
+    SYNC_RETRY_ATTEMPTS,
+    SYNC_RETRY_DELAY,
+)
 from merobox.commands.utils import console
 
 
@@ -134,6 +139,27 @@ class WaitForSyncStep(BaseStep):
             ):
                 raise ValueError(
                     f"Step '{step_name}': 'check_interval' must be a positive number"
+                )
+
+        # Validate initial_check_interval is positive if provided
+        if "initial_check_interval" in self.config:
+            if (
+                not isinstance(self.config["initial_check_interval"], (int, float))
+                or self.config["initial_check_interval"] <= 0
+            ):
+                raise ValueError(
+                    f"Step '{step_name}': 'initial_check_interval' must be a positive number"
+                )
+
+        # Validate backoff_factor is >= 1 if provided (>= 1 keeps the interval
+        # non-decreasing so it converges to the check_interval cap).
+        if "backoff_factor" in self.config:
+            if (
+                not isinstance(self.config["backoff_factor"], (int, float))
+                or self.config["backoff_factor"] < 1
+            ):
+                raise ValueError(
+                    f"Step '{step_name}': 'backoff_factor' must be a number >= 1"
                 )
 
         # Validate retry_attempts is a positive integer if provided
@@ -292,12 +318,22 @@ class WaitForSyncStep(BaseStep):
         check_interval: float,
         retry_attempts: int | None = None,
         trigger_sync: bool = False,
+        initial_check_interval: float = SYNC_INITIAL_CHECK_INTERVAL,
+        backoff_factor: float = SYNC_BACKOFF_FACTOR,
     ) -> tuple[bool, dict[str, Any]]:
         """
         Wait for all targets to converge across all nodes.
 
         A target converges when every node returns the same hash for it.
         All specified targets must converge for the overall result to succeed.
+
+        Polling uses adaptive backoff: the inter-attempt sleep starts at
+        ``initial_check_interval`` and grows geometrically by
+        ``backoff_factor`` after every miss, capped at ``check_interval``.
+        Fast syncs that miss the first check are caught within a few short
+        steps instead of rounding up to a full ``check_interval``; slow or
+        never-converging syncs still poll at no more than ``check_interval``
+        in steady state, so RPC load is unchanged on the slow path.
         """
         start_time = time.time()
         attempt = 0
@@ -315,13 +351,13 @@ class WaitForSyncStep(BaseStep):
 
         last_per_target: dict[str, dict[str, str | None]] = {}
 
+        # Adaptive backoff: the inter-attempt sleep starts short and grows
+        # geometrically, capped at check_interval. Never start above the cap.
+        backoff_interval = min(initial_check_interval, check_interval)
+
         while (time.time() - start_time < timeout) and (attempt < max_attempts):
             attempt += 1
             elapsed = time.time() - start_time
-
-            if attempt > 1:
-                jitter = 0.1 * (attempt % 3)
-                await asyncio.sleep(jitter)
 
             # Check each target's convergence in parallel.
             target_checks = await asyncio.gather(
@@ -385,7 +421,12 @@ class WaitForSyncStep(BaseStep):
                     for h, ns in hash_groups.items():
                         console.print(f"[dim]      {h}: {', '.join(ns)}[/dim]")
 
-            await asyncio.sleep(check_interval)
+            # Sleep the current backoff interval before the next check, with a
+            # small jitter folded on top to de-sync parallel node pollers, then
+            # grow the interval geometrically toward the check_interval cap.
+            jitter = 0.1 * (attempt % 3)
+            await asyncio.sleep(backoff_interval + jitter)
+            backoff_interval = min(backoff_interval * backoff_factor, check_interval)
 
         # Timeout / max attempts reached — final consistency check.
         elapsed = time.time() - start_time
@@ -469,11 +510,22 @@ class WaitForSyncStep(BaseStep):
         retry_attempts = self.config.get("retry_attempts")
         # Default: enabled — uses sync_context for context targets.
         trigger_sync = self.config.get("trigger_sync", True)
+        initial_check_interval = self.config.get(
+            "initial_check_interval", SYNC_INITIAL_CHECK_INTERVAL
+        )
+        backoff_factor = self.config.get("backoff_factor", SYNC_BACKOFF_FACTOR)
 
         console.print("\n[bold cyan]⏳ Waiting for node synchronization...[/bold cyan]")
 
         synced, details = await self._wait_for_sync(
-            targets, nodes, timeout, check_interval, retry_attempts, trigger_sync
+            targets,
+            nodes,
+            timeout,
+            check_interval,
+            retry_attempts,
+            trigger_sync,
+            initial_check_interval,
+            backoff_factor,
         )
 
         if "outputs" in self.config:

--- a/merobox/commands/constants.py
+++ b/merobox/commands/constants.py
@@ -134,6 +134,14 @@ STATE_RETRY_DELAY = 3.0  # seconds
 SYNC_RETRY_ATTEMPTS = 3
 SYNC_RETRY_DELAY = 0.5  # seconds
 
+# wait_for_sync adaptive backoff polling. Instead of sleeping a full
+# check_interval after every missed convergence check, start with a short
+# interval and grow it geometrically (capped at check_interval). This catches
+# syncs that land just after the first miss in ~50–150ms instead of rounding
+# the wait up to a full check_interval.
+SYNC_INITIAL_CHECK_INTERVAL = 0.05  # seconds; first inter-attempt sleep
+SYNC_BACKOFF_FACTOR = 2.0  # geometric growth per miss, capped at check_interval
+
 # Health check timeout
 HEALTH_CHECK_TIMEOUT = 10  # seconds
 

--- a/merobox/tests/unit/test_wait_for_sync_step.py
+++ b/merobox/tests/unit/test_wait_for_sync_step.py
@@ -1,0 +1,162 @@
+"""Unit tests for the wait_for_sync step's adaptive backoff polling.
+
+These tests exercise ``_wait_for_sync`` directly with a stubbed convergence
+check and a patched ``asyncio.sleep`` so the inter-attempt sleep schedule is
+observable without spinning real nodes or wall-clock waits.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.wait_for_sync import WaitForSyncStep
+
+TARGETS = [{"kind": "context", "id": "ctx-1", "field": "contextStateHash"}]
+NODES = ["calimero-node-1", "calimero-node-2"]
+
+
+def _make_step(extra_config: dict | None = None) -> WaitForSyncStep:
+    config = {
+        "type": "wait_for_sync",
+        "context_id": "ctx-1",
+        "nodes": NODES,
+    }
+    if extra_config:
+        config.update(extra_config)
+    return WaitForSyncStep(config)
+
+
+def _run_with_recorded_sleeps(step, converge_on_attempt, **kwargs):
+    """Run _wait_for_sync, returning (result, details, backoff_only).
+
+    The stubbed convergence check reports "not converged" until
+    ``converge_on_attempt`` (1-indexed), so the loop sleeps once between each
+    pair of attempts. ``asyncio.sleep`` is replaced with a zero-delay recorder
+    so the schedule is captured without real waiting.
+
+    ``backoff_only`` strips the per-attempt jitter (0.1 * (attempt % 3)) back
+    off each recorded sleep, recovering the pure geometric-backoff component.
+    """
+    attempts = {"n": 0}
+    sleeps: list[float] = []
+
+    async def fake_check(target, nodes, trigger_sync):
+        attempts["n"] += 1
+        converged = attempts["n"] >= converge_on_attempt
+        node_hashes = dict.fromkeys(nodes, "h" if converged else None)
+        return converged, node_hashes
+
+    async def fake_sleep(duration):
+        sleeps.append(duration)
+
+    async def run():
+        with (
+            patch.object(step, "_check_target_convergence", side_effect=fake_check),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+        ):
+            return await step._wait_for_sync(TARGETS, NODES, timeout=30, **kwargs)
+
+    result, details = asyncio.run(run())
+    # The i-th sleep (0-indexed) follows attempt (i + 1), whose jitter is
+    # 0.1 * ((i + 1) % 3).
+    backoff_only = [
+        round(sleep - 0.1 * ((i + 1) % 3), 4) for i, sleep in enumerate(sleeps)
+    ]
+    return result, details, backoff_only
+
+
+def test_backoff_schedule_grows_geometrically_and_caps():
+    """Misses sleep initial, then initial*factor, ... capped at check_interval."""
+    step = _make_step()
+    # Converge on the 6th check → attempts 1-5 miss → 5 inter-attempt sleeps.
+    result, _details, backoff_only = _run_with_recorded_sleeps(
+        step,
+        converge_on_attempt=6,
+        check_interval=0.5,
+        initial_check_interval=0.05,
+        backoff_factor=2.0,
+    )
+
+    assert result is True
+    assert backoff_only == [0.05, 0.1, 0.2, 0.4, 0.5]
+
+
+def test_fast_sync_caught_in_a_few_short_steps():
+    """A sync that lands just after the first miss is caught well under the cap."""
+    step = _make_step()
+    result, _details, backoff_only = _run_with_recorded_sleeps(
+        step,
+        converge_on_attempt=3,
+        check_interval=0.5,
+        initial_check_interval=0.05,
+        backoff_factor=2.0,
+    )
+
+    assert result is True
+    # Converged on the 3rd check → only 2 short inter-attempt sleeps happened.
+    assert backoff_only == [0.05, 0.1]
+
+
+def test_initial_interval_never_exceeds_check_interval_cap():
+    """A configured initial larger than the cap is clamped to the cap."""
+    step = _make_step()
+    result, _details, backoff_only = _run_with_recorded_sleeps(
+        step,
+        converge_on_attempt=3,
+        check_interval=0.1,
+        initial_check_interval=5.0,
+        backoff_factor=2.0,
+    )
+
+    assert result is True
+    # Both sleeps pinned to the cap; the oversized initial was clamped down.
+    assert backoff_only == [0.1, 0.1]
+
+
+def test_backoff_factor_one_holds_interval_flat():
+    """factor == 1 reproduces the legacy fixed-interval behavior."""
+    step = _make_step()
+    result, _details, backoff_only = _run_with_recorded_sleeps(
+        step,
+        converge_on_attempt=4,
+        check_interval=0.5,
+        initial_check_interval=0.3,
+        backoff_factor=1.0,
+    )
+
+    assert result is True
+    assert backoff_only == [0.3, 0.3, 0.3]
+
+
+def test_defaults_use_constant_backoff_schedule():
+    """With no overrides, the step uses the module-default 0.05s / 2.0x schedule."""
+    step = _make_step()
+    result, _details, backoff_only = _run_with_recorded_sleeps(
+        step,
+        converge_on_attempt=4,
+        check_interval=0.5,
+    )
+
+    assert result is True
+    assert backoff_only == [0.05, 0.1, 0.2]
+
+
+@pytest.mark.parametrize(
+    "bad_config, field",
+    [
+        ({"initial_check_interval": 0}, "initial_check_interval"),
+        ({"initial_check_interval": -1}, "initial_check_interval"),
+        ({"initial_check_interval": "x"}, "initial_check_interval"),
+        ({"backoff_factor": 0.5}, "backoff_factor"),
+        ({"backoff_factor": "x"}, "backoff_factor"),
+    ],
+)
+def test_invalid_backoff_config_rejected(bad_config, field):
+    with pytest.raises(ValueError, match=field):
+        _make_step(bad_config)
+
+
+def test_backoff_factor_one_is_accepted():
+    # factor == 1 is the lower bound (legacy fixed interval), must validate.
+    _make_step({"backoff_factor": 1})

--- a/merobox/tests/unit/test_wait_for_sync_step.py
+++ b/merobox/tests/unit/test_wait_for_sync_step.py
@@ -37,6 +37,13 @@ def _run_with_recorded_sleeps(step, converge_on_attempt, **kwargs):
 
     ``backoff_only`` strips the per-attempt jitter (0.1 * (attempt % 3)) back
     off each recorded sleep, recovering the pure geometric-backoff component.
+
+    Assumption: the loop sleeps exactly once at the end of every missed
+    attempt and never before the convergence check, so the i-th recorded
+    sleep (0-indexed) always follows attempt ``i + 1``. If convergence is
+    reached on the first check (``converge_on_attempt=1``) the loop sleeps
+    zero times and ``sleeps`` is empty — see
+    ``test_immediate_convergence_does_not_sleep``.
     """
     attempts = {"n": 0}
     sleeps: list[float] = []
@@ -51,9 +58,14 @@ def _run_with_recorded_sleeps(step, converge_on_attempt, **kwargs):
         sleeps.append(duration)
 
     async def run():
+        # Patch sleep on the module under test, not the global asyncio.sleep,
+        # so the target is robust to import aliasing / event-loop differences.
         with (
             patch.object(step, "_check_target_convergence", side_effect=fake_check),
-            patch("asyncio.sleep", side_effect=fake_sleep),
+            patch(
+                "merobox.commands.bootstrap.steps.wait_for_sync.asyncio.sleep",
+                side_effect=fake_sleep,
+            ),
         ):
             return await step._wait_for_sync(TARGETS, NODES, timeout=30, **kwargs)
 
@@ -80,6 +92,20 @@ def test_backoff_schedule_grows_geometrically_and_caps():
 
     assert result is True
     assert backoff_only == [0.05, 0.1, 0.2, 0.4, 0.5]
+
+
+def test_immediate_convergence_does_not_sleep():
+    """Converging on the very first check returns without any backoff sleep."""
+    step = _make_step()
+    result, _details, backoff_only = _run_with_recorded_sleeps(
+        step,
+        converge_on_attempt=1,
+        check_interval=0.5,
+    )
+
+    assert result is True
+    # First check hit → loop never reached the end-of-miss sleep.
+    assert backoff_only == []
 
 
 def test_fast_sync_caught_in_a_few_short_steps():


### PR DESCRIPTION
Closes #267.

## Problem

`wait_for_sync` polls on a fixed `check_interval` (default `0.5s`). Whenever the first convergence check misses, the wait rounds up to a full `check_interval` even if the nodes actually converged ~50–150ms later — the inter-attempt sleep was all-or-nothing.

## Change

Replace the fixed `await asyncio.sleep(check_interval)` after each missed check with adaptive backoff:

- Start at `initial_check_interval` (default `0.05s`).
- After each miss: `interval = min(interval * backoff_factor, check_interval)` (`backoff_factor` default `2.0`).
- `check_interval` stays the steady-state cap — slow/never-converging syncs still poll at ≤ `check_interval`, so RPC load on the slow path is unchanged.
- The existing per-attempt jitter (`0.1 * (attempt % 3)`) is folded onto the computed interval and preserved, so parallel node pollers still de-sync. Attempt 1 still fires immediately.

New optional step fields `initial_check_interval` and `backoff_factor` expose the schedule with sane defaults; existing workflows behave the same or faster with no changes.

Also widens the `check_interval` schema from `int >= 1` to `float > 0` to match the runtime `0.5s` default (latent inconsistency).

Example resulting schedule for `check_interval: 0.5`, defaults: `0.05 → 0.1 → 0.2 → 0.4 → 0.5 → 0.5 …` (plus jitter).

## Acceptance criteria

- [x] Fast syncs that miss the first check converge in ~2–3 short backoff steps (well under `check_interval`).
- [x] Slow/never-converging syncs poll at no more than `check_interval` in steady state (no extra RPC load).
- [x] `check_interval` honored as the cap; existing workflows behave the same or faster.
- [x] `initial_check_interval` / `backoff_factor` exposed as step config with sane defaults.
- [x] Existing jitter behavior for parallel pollers preserved.

## Tests

New `merobox/tests/unit/test_wait_for_sync_step.py` (11 tests) drives `_wait_for_sync` with a stubbed convergence check and patched `asyncio.sleep` to assert the exact backoff schedule, the geometric cap, fast-sync catch in 2 short steps, oversized-initial clamping to the cap, `factor=1` reproducing legacy fixed-interval behavior, defaults, and config validation. Schema/base-validation suites unaffected.

Pairs with #268 (CI log verbosity) — fewer attempts here + quieter attempts there make the e2e sync logs readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only workflow polling timing and schema for an existing step; defaults preserve or shorten waits, with unit tests covering the backoff schedule and validation.
> 
> **Overview**
> The **`wait_for_sync`** workflow step no longer sleeps a full **`check_interval`** after every failed convergence check. It uses **adaptive backoff**: inter-attempt delay starts at **`initial_check_interval`** (default **0.05s**), multiplies by **`backoff_factor`** (default **2.0**) after each miss, and is capped at **`check_interval`** (now documented as the steady-state ceiling). **Jitter** is applied on top of that backoff sleep (not as a separate pre-check sleep). Optional YAML fields **`initial_check_interval`** and **`backoff_factor`** are added in schema and runtime validation; module defaults live in **`constants.py`**. **`check_interval`** validation changes from integer seconds to **positive float** to match runtime defaults like **0.5s**. Release **0.6.29** and a dedicated unit test file assert the sleep schedule, cap clamping, immediate success (no sleep), and invalid config rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d76d55d40894b1fa8b033eed9257b3688387d513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->