### PR TITLE
feat(bootstrap): console verbosity control for readable CI logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restores the full per-attempt detail, and failures always dump the full
   per-target/per-node hash state regardless of level. The previously
   unconditional `run_workflow`/`WorkflowExecutor` debug lines are now
-  verbose-only. Closes #268.
+  verbose-only. The same gate is applied to the dominant happy-path log
+  noise: the `execute`/`call` step's per-call JSON-RPC response dump and
+  resolved-values debug, the `repeat` step's per-iteration banners and
+  custom-export confirmations, and the export-machinery's "validated" /
+  "no outputs configured" / "Exporting variables" / per-field "✓ name =
+  value" lines are all now `verbose`-only. At the `normal` default a
+  100-iteration benchmark drops from tens of thousands of log lines to the
+  per-block banner plus the final timing summary; genuine warnings and
+  errors (missing export field, failed call, malformed config) always
+  print. Closes #268.
 
 ## [0.6.29] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.30] - 2026-05-30
+
+### Added
+
+- Console verbosity control for `merobox bootstrap run`, so CI logs are
+  readable on the happy path. A `vprint(msg, level=...)` helper in
+  `commands/utils.py` gates output through a single process-wide level
+  (`quiet` / `normal` / `verbose`), set in priority order by the new
+  `-q/--quiet` and existing `-v/--verbose` flags, then the
+  `MEROBOX_LOG_LEVEL` env var (useful for CI without touching workflow
+  YAML), then the `normal` default. This is merobox's own console
+  verbosity — distinct from `--log-level`, which sets the merod node's
+  RUST_LOG. By default `wait_for_sync` now emits its banner plus a single
+  final success/failure summary and suppresses the per-attempt
+  "not converged yet" blocks; `--verbose` (or `MEROBOX_LOG_LEVEL=verbose`)
+  restores the full per-attempt detail, and failures always dump the full
+  per-target/per-node hash state regardless of level. The previously
+  unconditional `run_workflow`/`WorkflowExecutor` debug lines are now
+  verbose-only. Closes #268.
+
 ## [0.6.29] - 2026-05-30
 
 ### Changed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.29"
+__version__ = "0.6.30"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/bootstrap.py
+++ b/merobox/commands/bootstrap/bootstrap.py
@@ -142,7 +142,21 @@ def bootstrap():
 
 @bootstrap.command()
 @click.argument("config_file", type=click.Path(exists=True), required=True)
-@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Enable verbose output (per-attempt sync detail, debug lines). "
+    "Equivalent to MEROBOX_LOG_LEVEL=verbose.",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Suppress non-essential output (banners, per-attempt detail); "
+    "final summaries and errors are still shown. Equivalent to "
+    "MEROBOX_LOG_LEVEL=quiet. Ignored if --verbose is also set.",
+)
 @click.option(
     "--image",
     help="Custom Docker image to use for Calimero nodes (overrides workflow config)",
@@ -235,6 +249,7 @@ def bootstrap():
 def run(
     config_file,
     verbose,
+    quiet,
     image,
     auth_service,
     auth_image,
@@ -272,6 +287,14 @@ def run(
     These CLI-specified remote nodes are merged with any remote_nodes
     defined in the workflow YAML file, with CLI options taking precedence.
     """
+    # --verbose and --quiet are mutually exclusive; verbose wins (louder is
+    # safer for debugging). Warn so the ignored flag isn't silently dropped.
+    if verbose and quiet:
+        console.print(
+            "[yellow]⚠ --verbose and --quiet are mutually exclusive; "
+            "--verbose takes precedence.[/yellow]"
+        )
+
     # Validate --auth-mode is only used with --no-docker (binary mode)
     if auth_mode and not no_docker:
         console.print(
@@ -303,6 +326,7 @@ def run(
     success = run_workflow_sync(
         config_file,
         verbose,
+        quiet=quiet,
         image=image,
         auth_service=auth_service,
         auth_image=auth_image,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -109,7 +109,12 @@ from merobox.commands.constants import (
 from merobox.commands.health import check_node_health
 from merobox.commands.manager import DockerManager
 from merobox.commands.node_resolver import NodeResolver, get_resolver
-from merobox.commands.utils import console, get_node_rpc_url
+from merobox.commands.utils import (
+    LOG_LEVEL_VERBOSE,
+    console,
+    get_node_rpc_url,
+    vprint,
+)
 
 # Compiled regex pattern for extracting {{variable}} references
 _VAR_PATTERN = re.compile(r"\{\{(\w+)\}\}")
@@ -224,11 +229,13 @@ class WorkflowExecutor:
         self.resolver: Optional[NodeResolver] = None
 
         try:
-            console.print(
-                f"[cyan]WorkflowExecutor: resolved log_level='{self.log_level}', binary_mode={self.is_binary_mode}[/cyan]"
+            vprint(
+                f"[cyan]WorkflowExecutor: resolved log_level='{self.log_level}', binary_mode={self.is_binary_mode}[/cyan]",
+                level=LOG_LEVEL_VERBOSE,
             )
-            console.print(
-                f"[cyan]WorkflowExecutor: workflow_id='{self.workflow_id}' (for test isolation)[/cyan]"
+            vprint(
+                f"[cyan]WorkflowExecutor: workflow_id='{self.workflow_id}' (for test isolation)[/cyan]",
+                level=LOG_LEVEL_VERBOSE,
             )
         except Exception:
             pass

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -240,8 +240,9 @@ class WorkflowExecutor:
         except Exception:
             pass
         try:
-            console.print(
-                f"[cyan]WorkflowExecutor: resolved rust_backtrace='{self.rust_backtrace}', binary_mode={self.is_binary_mode}[/cyan]"
+            vprint(
+                f"[cyan]WorkflowExecutor: resolved rust_backtrace='{self.rust_backtrace}', binary_mode={self.is_binary_mode}[/cyan]",
+                level=LOG_LEVEL_VERBOSE,
             )
         except Exception:
             pass

--- a/merobox/commands/bootstrap/run/run.py
+++ b/merobox/commands/bootstrap/run/run.py
@@ -14,7 +14,13 @@ from typing import Any, Optional
 
 from merobox.commands.bootstrap.config import load_workflow_config
 from merobox.commands.bootstrap.run.executor import WorkflowExecutor
-from merobox.commands.utils import console
+from merobox.commands.utils import (
+    LOG_LEVEL_VERBOSE,
+    console,
+    resolve_log_level,
+    set_log_level,
+    vprint,
+)
 
 
 def merge_remote_nodes_config(
@@ -91,6 +97,7 @@ async def run_workflow(
     auth_username: Optional[str] = None,
     auth_password: Optional[str] = None,
     dry_run: bool = False,
+    quiet: bool = False,
 ) -> bool:
     """
     Execute a Calimero workflow from a YAML configuration file.
@@ -98,6 +105,8 @@ async def run_workflow(
     Args:
         config_file: Path to the workflow configuration file
         verbose: Whether to enable verbose output
+        quiet: Whether to suppress non-essential output (banners, per-attempt
+            detail); final summaries and errors are always shown
         auth_service: Whether to enable authentication service integration
         cli_remote_nodes: Remote nodes config from CLI options (--remote-node/--remote-auth)
         auth_mode: Authentication mode for merod (binary mode only)
@@ -108,6 +117,10 @@ async def run_workflow(
     Returns:
         True if workflow completed successfully, False otherwise
     """
+    # Resolve and apply console verbosity before any step output. Priority:
+    # explicit --verbose/--quiet > MEROBOX_LOG_LEVEL env var > NORMAL default.
+    set_log_level(resolve_log_level(verbose=verbose, quiet=quiet))
+
     try:
         # Load configuration
         config = load_workflow_config(config_file)
@@ -170,18 +183,15 @@ async def run_workflow(
 
             manager = DockerManager()
 
-        # Debug: show incoming log level from CLI/defaults
-        try:
-            from merobox.commands.utils import console as _console
-
-            _console.print(
-                f"[cyan]run_workflow: incoming log_level='{log_level}'[/cyan]"
-            )
-            _console.print(
-                f"[cyan]run_workflow: incoming rust_backtrace='{rust_backtrace}'[/cyan]"
-            )
-        except Exception:
-            pass
+        # Debug: show incoming log level from CLI/defaults (verbose-only).
+        vprint(
+            f"[cyan]run_workflow: incoming log_level='{log_level}'[/cyan]",
+            level=LOG_LEVEL_VERBOSE,
+        )
+        vprint(
+            f"[cyan]run_workflow: incoming rust_backtrace='{rust_backtrace}'[/cyan]",
+            level=LOG_LEVEL_VERBOSE,
+        )
 
         executor = WorkflowExecutor(
             config,
@@ -246,6 +256,7 @@ def run_workflow_sync(
     auth_username: Optional[str] = None,
     auth_password: Optional[str] = None,
     dry_run: bool = False,
+    quiet: bool = False,
 ) -> bool:
     """
     Synchronous wrapper for workflow execution.
@@ -253,6 +264,8 @@ def run_workflow_sync(
     Args:
         config_file: Path to the workflow configuration file
         verbose: Whether to enable verbose output
+        quiet: Whether to suppress non-essential output (banners, per-attempt
+            detail); final summaries and errors are always shown
         auth_service: Whether to enable authentication service integration
         cli_remote_nodes: Remote nodes config from CLI options (--remote-node/--remote-auth)
         auth_mode: Authentication mode for merod (binary mode only)
@@ -283,5 +296,6 @@ def run_workflow_sync(
             auth_username=auth_username,
             auth_password=auth_password,
             dry_run=dry_run,
+            quiet=quiet,
         )
     )

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -7,7 +7,7 @@ import json
 import re
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-from merobox.commands.utils import console, get_node_rpc_url
+from merobox.commands.utils import LOG_LEVEL_VERBOSE, console, get_node_rpc_url, vprint
 
 if TYPE_CHECKING:
     from merobox.commands.node_resolver import NodeResolver
@@ -1033,7 +1033,10 @@ class BaseStep:
         else:
             actual_data = response_data
 
-        console.print(f"[cyan]� Exporting variables from {node_name} response:[/cyan]")
+        vprint(
+            f"[cyan]📝 Exporting variables from {node_name} response:[/cyan]",
+            level=LOG_LEVEL_VERBOSE,
+        )
 
         for exported_variable, assigned_var in outputs_config.items():
             if isinstance(assigned_var, str):
@@ -1070,8 +1073,9 @@ class BaseStep:
                     if len(display_value) > 100:
                         display_value = display_value[:97] + "..."
 
-                    console.print(
-                        f"[green]   ✓[/green] [bold cyan]{exported_variable}[/bold cyan] [dim]=[/dim] {display_value}"
+                    vprint(
+                        f"[green]   ✓[/green] [bold cyan]{exported_variable}[/bold cyan] [dim]=[/dim] {display_value}",
+                        level=LOG_LEVEL_VERBOSE,
                     )
 
             elif isinstance(assigned_var, dict):
@@ -1121,8 +1125,9 @@ class BaseStep:
                         if len(display_value) > 100:
                             display_value = display_value[:97] + "..."
 
-                        console.print(
-                            f"[green]   ✓[/green] [bold cyan]{target_key}[/bold cyan] [dim]=[/dim] {display_value}"
+                        vprint(
+                            f"[green]   ✓[/green] [bold cyan]{target_key}[/bold cyan] [dim]=[/dim] {display_value}",
+                            level=LOG_LEVEL_VERBOSE,
                         )
                 else:
                     console.print(
@@ -1156,11 +1161,14 @@ class BaseStep:
                 response_data, node_name, dynamic_values, protected_keys
             )
         else:
-            console.print(
-                "[yellow]⚠️  No outputs configured for this step. Variables will not be exported automatically.[/yellow]"
+            # Advisory only (most steps intentionally export nothing) — verbose.
+            vprint(
+                "[yellow]⚠️  No outputs configured for this step. Variables will not be exported automatically.[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
             )
-            console.print(
-                "[yellow]   To export variables, add an 'outputs' section to your step configuration.[/yellow]"
+            vprint(
+                "[yellow]   To export variables, add an 'outputs' section to your step configuration.[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
             )
 
     def _validate_export_config(self) -> bool:
@@ -1201,20 +1209,23 @@ class BaseStep:
                     )
                     return False
 
-            console.print(
-                f"[blue]✅ Custom outputs configuration validated: {len(outputs_config)} outputs defined[/blue]"
+            vprint(
+                f"[blue]✅ Custom outputs configuration validated: {len(outputs_config)} outputs defined[/blue]",
+                level=LOG_LEVEL_VERBOSE,
             )
             return True
 
         # Check if automatic exports are configured
         if not hasattr(self, "exportable_variables") or not self.exportable_variables:
-            console.print(
-                f"[yellow]⚠️  Step {self.__class__.__name__} has no exportable variables defined[/yellow]"
+            vprint(
+                f"[yellow]⚠️  Step {self.__class__.__name__} has no exportable variables defined[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
             )
             return False
 
-        console.print(
-            f"[blue]✅ Automatic exports configuration validated: {len(self.exportable_variables)} variables defined[/blue]"
+        vprint(
+            f"[blue]✅ Automatic exports configuration validated: {len(self.exportable_variables)} variables defined[/blue]",
+            level=LOG_LEVEL_VERBOSE,
         )
         return True
 

--- a/merobox/commands/bootstrap/steps/execute.py
+++ b/merobox/commands/bootstrap/steps/execute.py
@@ -8,7 +8,7 @@ from typing import Any
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.call import call_function
 from merobox.commands.constants import STATE_RETRY_ATTEMPTS, STATE_RETRY_DELAY
-from merobox.commands.utils import console
+from merobox.commands.utils import LOG_LEVEL_VERBOSE, console, vprint
 
 
 class ExecuteStep(BaseStep):
@@ -88,18 +88,22 @@ class ExecuteStep(BaseStep):
             args, workflow_results, dynamic_values
         )
 
-        # Validate export configuration
+        # Validate export configuration (advisory — verbose-only).
         if not self._validate_export_config():
-            console.print(
-                "[yellow]⚠️  Execute step export configuration validation failed[/yellow]"
+            vprint(
+                "[yellow]⚠️  Execute step export configuration validation failed[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
             )
 
-        # Debug: Show resolved values
-        console.print("[blue]Debug: Resolved values for execute step:[/blue]")
-        console.print(f"  context_id: {context_id}")
-        console.print(f"  exec_type: {exec_type}")
-        console.print(f"  method: {method}")
-        console.print(f"  args: {resolved_args}")
+        # Debug: Show resolved values (verbose-only).
+        vprint(
+            "[blue]Debug: Resolved values for execute step:[/blue]",
+            level=LOG_LEVEL_VERBOSE,
+        )
+        vprint(f"  context_id: {context_id}", level=LOG_LEVEL_VERBOSE)
+        vprint(f"  exec_type: {exec_type}", level=LOG_LEVEL_VERBOSE)
+        vprint(f"  method: {method}", level=LOG_LEVEL_VERBOSE)
+        vprint(f"  args: {resolved_args}", level=LOG_LEVEL_VERBOSE)
 
         # Resolve node (gets URL and ensures authentication)
         try:
@@ -138,23 +142,25 @@ class ExecuteStep(BaseStep):
                     console.print(f"[red]Unknown execution type: {exec_type}[/red]")
                     return False
 
-                # Log detailed API response
+                # Log detailed API response (verbose-only; the per-call dump is
+                # the single biggest source of CI log noise on the happy path).
                 import json as json_lib
 
-                console.print(
-                    f"[cyan]🔍 Execute API Response for {node_name} (attempt {retry_attempt}/{max_state_retries}):[/cyan]"
+                vprint(
+                    f"[cyan]🔍 Execute API Response for {node_name} (attempt {retry_attempt}/{max_state_retries}):[/cyan]",
+                    level=LOG_LEVEL_VERBOSE,
                 )
-                console.print(f"  Success: {result.get('success')}")
+                vprint(f"  Success: {result.get('success')}", level=LOG_LEVEL_VERBOSE)
 
                 data = result.get("data")
                 if isinstance(data, dict):
                     try:
                         formatted_data = json_lib.dumps(data, indent=2)
-                        console.print(f"  Data:\n{formatted_data}")
+                        vprint(f"  Data:\n{formatted_data}", level=LOG_LEVEL_VERBOSE)
                     except Exception:
-                        console.print(f"  Data: {data}")
+                        vprint(f"  Data: {data}", level=LOG_LEVEL_VERBOSE)
                 else:
-                    console.print(f"  Data: {data}")
+                    vprint(f"  Data: {data}", level=LOG_LEVEL_VERBOSE)
 
                 if not result.get("success"):
                     console.print(f"  Error: {result.get('error')}")

--- a/merobox/commands/bootstrap/steps/repeat.py
+++ b/merobox/commands/bootstrap/steps/repeat.py
@@ -36,7 +36,7 @@ from merobox.commands.bootstrap.steps.subgroup import (
     ReparentGroupStep,
 )
 from merobox.commands.bootstrap.steps.wait import WaitStep
-from merobox.commands.utils import console
+from merobox.commands.utils import LOG_LEVEL_VERBOSE, console, vprint
 
 
 class RepeatStep(BaseStep):
@@ -138,16 +138,18 @@ class RepeatStep(BaseStep):
         repeat_count = self.config.get("count", 1)
         nested_steps = self.config.get("steps", [])
 
-        # Validate export configuration
+        # Validate export configuration (advisory — verbose-only).
         if not self._validate_export_config():
-            console.print(
-                "[yellow]⚠️  Repeat step export configuration validation failed[/yellow]"
+            vprint(
+                "[yellow]⚠️  Repeat step export configuration validation failed[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
             )
 
         if not nested_steps:
             console.print("[yellow]No nested steps specified for repeat[/yellow]")
             return True
 
+        # Per-block banner stays at NORMAL; per-iteration detail below is verbose.
         console.print(
             f"[cyan]🔄 Executing {len(nested_steps)} nested steps {repeat_count} times...[/cyan]"
         )
@@ -155,16 +157,18 @@ class RepeatStep(BaseStep):
         # Export repeat configuration variables
         dynamic_values["total_iterations"] = repeat_count
         dynamic_values["step_count"] = len(nested_steps)
-        console.print(
-            f"[blue]📝 Exported repeat configuration: total_iterations={repeat_count}, step_count={len(nested_steps)}[/blue]"
+        vprint(
+            f"[blue]📝 Exported repeat configuration: total_iterations={repeat_count}, step_count={len(nested_steps)}[/blue]",
+            level=LOG_LEVEL_VERBOSE,
         )
 
         # Track timing for throughput calculation
         start_time = time.perf_counter()  # Use perf_counter for better precision
 
         for iteration in range(repeat_count):
-            console.print(
-                f"\n[bold blue]📋 Iteration {iteration + 1}/{repeat_count}[/bold blue]"
+            vprint(
+                f"\n[bold blue]📋 Iteration {iteration + 1}/{repeat_count}[/bold blue]",
+                level=LOG_LEVEL_VERBOSE,
             )
 
             # Create iteration-specific dynamic values
@@ -190,8 +194,9 @@ class RepeatStep(BaseStep):
                 iteration_dynamic_values["current_step"] = nested_step_name
                 iteration_dynamic_values["current_step_index"] = step_idx + 1
 
-                console.print(
-                    f"  [cyan]Executing {nested_step_name} ({step_type})...[/cyan]"
+                vprint(
+                    f"  [cyan]Executing {nested_step_name} ({step_type})...[/cyan]",
+                    level=LOG_LEVEL_VERBOSE,
                 )
 
                 try:
@@ -214,8 +219,9 @@ class RepeatStep(BaseStep):
                         )
                         return False
 
-                    console.print(
-                        f"  [green]✓ Nested step '{nested_step_name}' completed in iteration {iteration + 1}[/green]"
+                    vprint(
+                        f"  [green]✓ Nested step '{nested_step_name}' completed in iteration {iteration + 1}[/green]",
+                        level=LOG_LEVEL_VERBOSE,
                     )
 
                 except Exception as e:
@@ -272,8 +278,9 @@ class RepeatStep(BaseStep):
         if not outputs_config:
             return
 
-        console.print(
-            f"[blue]📝 Processing custom outputs for iteration {iteration}...[/blue]"
+        vprint(
+            f"[blue]📝 Processing custom outputs for iteration {iteration}...[/blue]",
+            level=LOG_LEVEL_VERBOSE,
         )
 
         for export_name, export_config in outputs_config.items():
@@ -283,8 +290,9 @@ class RepeatStep(BaseStep):
                 if source_field in dynamic_values:
                     source_value = dynamic_values[source_field]
                     dynamic_values[export_name] = source_value
-                    console.print(
-                        f"  📝 Custom export: {source_field} → {export_name}: {source_value}"
+                    vprint(
+                        f"  📝 Custom export: {source_field} → {export_name}: {source_value}",
+                        level=LOG_LEVEL_VERBOSE,
                     )
                 else:
                     console.print(
@@ -299,8 +307,9 @@ class RepeatStep(BaseStep):
                         source_value = dynamic_values[source_field]
                         # For repeat steps, we don't have node names, so just use the source value
                         dynamic_values[export_name] = source_value
-                        console.print(
-                            f"  📝 Custom export: {source_field} → {export_name}: {source_value}"
+                        vprint(
+                            f"  📝 Custom export: {source_field} → {export_name}: {source_value}",
+                            level=LOG_LEVEL_VERBOSE,
                         )
                     else:
                         console.print(
@@ -334,8 +343,9 @@ class RepeatStep(BaseStep):
                         if source_field in timing_variables
                         else "Export"
                     )
-                    console.print(
-                        f"  📝 {label}: {source_field} → {export_name}: {source_value}"
+                    vprint(
+                        f"  📝 {label}: {source_field} → {export_name}: {source_value}",
+                        level=LOG_LEVEL_VERBOSE,
                     )
                 else:
                     console.print(
@@ -355,8 +365,9 @@ class RepeatStep(BaseStep):
                             if source_field in timing_variables
                             else "Export"
                         )
-                        console.print(
-                            f"  📝 {label}: {source_field} → {export_name}: {source_value}"
+                        vprint(
+                            f"  📝 {label}: {source_field} → {export_name}: {source_value}",
+                            level=LOG_LEVEL_VERBOSE,
                         )
                     else:
                         console.print(

--- a/merobox/commands/bootstrap/steps/wait_for_sync.py
+++ b/merobox/commands/bootstrap/steps/wait_for_sync.py
@@ -15,7 +15,12 @@ from merobox.commands.constants import (
     SYNC_RETRY_ATTEMPTS,
     SYNC_RETRY_DELAY,
 )
-from merobox.commands.utils import console
+from merobox.commands.utils import (
+    LOG_LEVEL_NORMAL,
+    LOG_LEVEL_VERBOSE,
+    console,
+    vprint,
+)
 
 
 def _build_success_details(
@@ -339,14 +344,17 @@ class WaitForSyncStep(BaseStep):
         attempt = 0
         max_attempts = retry_attempts or float("inf")
 
+        # Banner: shown at NORMAL+ (suppressed only with --quiet).
         target_labels = ", ".join(self._target_label(t) for t in targets)
-        console.print(
-            f"[cyan]🔄 Waiting for {len(nodes)} node(s) to sync on {len(targets)} target(s): {target_labels}...[/cyan]"
+        vprint(
+            f"[cyan]🔄 Waiting for {len(nodes)} node(s) to sync on {len(targets)} target(s): {target_labels}...[/cyan]",
+            level=LOG_LEVEL_NORMAL,
         )
-        console.print(f"[dim]  Nodes: {', '.join(nodes)}[/dim]")
-        console.print(
+        vprint(f"[dim]  Nodes: {', '.join(nodes)}[/dim]", level=LOG_LEVEL_NORMAL)
+        vprint(
             f"[dim]  Timeout: {timeout}s, Check interval: {check_interval}s"
-            f"{', Trigger sync: enabled' if trigger_sync else ''}[/dim]"
+            f"{', Trigger sync: enabled' if trigger_sync else ''}[/dim]",
+            level=LOG_LEVEL_NORMAL,
         )
 
         last_per_target: dict[str, dict[str, str | None]] = {}
@@ -397,29 +405,39 @@ class WaitForSyncStep(BaseStep):
                     attempt,
                 )
 
-            # Report what didn't converge yet.
-            console.print(
-                f"[yellow]Attempt {attempt} ({elapsed:.1f}s): {len(targets)} target(s) checked, not all converged yet[/yellow]"
+            # Report what didn't converge yet. This per-attempt block is the
+            # main source of CI log noise on the happy path, so it is gated
+            # behind --verbose; the final summary below always reports the
+            # outcome. On failure, the full per-node state is dumped
+            # unconditionally after the loop.
+            vprint(
+                f"[yellow]Attempt {attempt} ({elapsed:.1f}s): {len(targets)} target(s) checked, not all converged yet[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
             )
             for target, (converged, node_hashes) in zip(targets, target_checks):
                 label = self._target_label(target)
                 if converged:
-                    console.print(f"[dim]  ✓ {label} converged[/dim]")
+                    vprint(f"[dim]  ✓ {label} converged[/dim]", level=LOG_LEVEL_VERBOSE)
                     continue
                 failed = [n for n, h in node_hashes.items() if h is None]
                 if failed:
-                    console.print(
-                        f"[dim]  · {label}: missing from {len(failed)} node(s): {', '.join(failed)}[/dim]"
+                    vprint(
+                        f"[dim]  · {label}: missing from {len(failed)} node(s): {', '.join(failed)}[/dim]",
+                        level=LOG_LEVEL_VERBOSE,
                     )
                 else:
                     hash_groups: dict[str, list[str]] = {}
                     for n, h in node_hashes.items():
                         hash_groups.setdefault(h, []).append(n)
-                    console.print(
-                        f"[dim]  · {label}: {len(hash_groups)} unique hash(es)[/dim]"
+                    vprint(
+                        f"[dim]  · {label}: {len(hash_groups)} unique hash(es)[/dim]",
+                        level=LOG_LEVEL_VERBOSE,
                     )
                     for h, ns in hash_groups.items():
-                        console.print(f"[dim]      {h}: {', '.join(ns)}[/dim]")
+                        vprint(
+                            f"[dim]      {h}: {', '.join(ns)}[/dim]",
+                            level=LOG_LEVEL_VERBOSE,
+                        )
 
             # Sleep the current backoff interval before the next check, with a
             # small jitter folded on top to de-sync parallel node pollers, then
@@ -515,7 +533,10 @@ class WaitForSyncStep(BaseStep):
         )
         backoff_factor = self.config.get("backoff_factor", SYNC_BACKOFF_FACTOR)
 
-        console.print("\n[bold cyan]⏳ Waiting for node synchronization...[/bold cyan]")
+        vprint(
+            "\n[bold cyan]⏳ Waiting for node synchronization...[/bold cyan]",
+            level=LOG_LEVEL_NORMAL,
+        )
 
         synced, details = await self._wait_for_sync(
             targets,

--- a/merobox/commands/utils.py
+++ b/merobox/commands/utils.py
@@ -3,6 +3,7 @@ Shared utilities for Calimero CLI commands.
 """
 
 import asyncio
+import contextvars
 import json
 import logging
 import os
@@ -47,10 +48,16 @@ _LOG_LEVEL_NAMES = {
     "debug": LOG_LEVEL_VERBOSE,
 }
 
-# Module-level current verbosity. Set once per run via `set_log_level()`;
-# read by `vprint()`. Defaults to NORMAL so library/test callers that never
-# configure it get the CI-friendly behavior.
-_current_log_level = LOG_LEVEL_NORMAL
+# Current verbosity, scoped per execution context. Set via `set_log_level()`
+# (typically once at the start of `run_workflow`); read by `vprint()`. A
+# ContextVar — rather than a plain module global — means a value set before
+# spawning asyncio tasks is inherited by those tasks (each task copies the
+# context at creation), yet concurrent branches (e.g. ParallelStep) or a
+# library embedding can scope their own level without clobbering each other.
+# Defaults to NORMAL so callers that never configure it get CI-friendly output.
+_log_level_var: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "merobox_log_level", default=LOG_LEVEL_NORMAL
+)
 
 
 def parse_log_level(value: Any, default: int = LOG_LEVEL_NORMAL) -> int:
@@ -59,12 +66,16 @@ def parse_log_level(value: Any, default: int = LOG_LEVEL_NORMAL) -> int:
     Accepts the names in ``_LOG_LEVEL_NAMES`` (case-insensitive) or a numeric
     value (clamped to the valid range). Anything unrecognized falls back to
     ``default`` rather than raising, so a stray env var can never abort a run.
+
+    A bool is the shorthand a per-step ``verbose:`` field yields:
+    ``True`` -> VERBOSE, ``False`` -> NORMAL ("not verbose"). Both ignore
+    ``default`` so the mapping is symmetric and independent of caller context.
     """
     if value is None:
         return default
     if isinstance(value, bool):
-        # bool is an int subclass; treat True as verbose, False as default.
-        return LOG_LEVEL_VERBOSE if value else default
+        # bool is an int subclass, so check it before the int branch.
+        return LOG_LEVEL_VERBOSE if value else LOG_LEVEL_NORMAL
     if isinstance(value, int):
         return max(LOG_LEVEL_QUIET, min(LOG_LEVEL_VERBOSE, value))
     name = str(value).strip().lower()
@@ -94,14 +105,13 @@ def resolve_log_level(verbose: bool = False, quiet: bool = False) -> int:
 
 
 def set_log_level(level: int) -> None:
-    """Set the process-wide console verbosity used by ``vprint()``."""
-    global _current_log_level
-    _current_log_level = level
+    """Set the console verbosity used by ``vprint()`` in the current context."""
+    _log_level_var.set(level)
 
 
 def get_log_level() -> int:
-    """Return the current process-wide console verbosity."""
-    return _current_log_level
+    """Return the current console verbosity for this context."""
+    return _log_level_var.get()
 
 
 def vprint(*args: Any, level: int = LOG_LEVEL_NORMAL, **kwargs: Any) -> None:
@@ -113,7 +123,7 @@ def vprint(*args: Any, level: int = LOG_LEVEL_NORMAL, **kwargs: Any) -> None:
     ``level=LOG_LEVEL_QUIET``) for output that must always appear, such as
     final success/failure summaries.
     """
-    if _current_log_level >= level:
+    if _log_level_var.get() >= level:
         console.print(*args, **kwargs)
 
 

--- a/merobox/commands/utils.py
+++ b/merobox/commands/utils.py
@@ -5,6 +5,7 @@ Shared utilities for Calimero CLI commands.
 import asyncio
 import json
 import logging
+import os
 import sys
 from typing import Any, Optional
 
@@ -18,6 +19,102 @@ from merobox.commands.manager import DockerManager
 
 logger = logging.getLogger(__name__)
 console = Console()
+
+# ---------------------------------------------------------------------------
+# Console verbosity control
+#
+# This governs how much merobox itself prints to the terminal. It is distinct
+# from `--log-level`, which sets the merod *node* RUST_LOG level inside the
+# container — do not conflate the two. Higher numeric level = more output.
+#
+# All gated output flows through `vprint()` so every bootstrap step benefits
+# from a single knob (e.g. wait_for_sync suppressing its per-attempt blocks on
+# the happy path while still showing the banner and final summary).
+# ---------------------------------------------------------------------------
+LOG_LEVEL_QUIET = 0  # essentials only: final summaries and errors
+LOG_LEVEL_NORMAL = 1  # default: banners + summaries, no per-attempt chatter
+LOG_LEVEL_VERBOSE = 2  # everything, including per-poll / per-attempt detail
+
+# Accepted string spellings for MEROBOX_LOG_LEVEL / per-step verbose config.
+_LOG_LEVEL_NAMES = {
+    "quiet": LOG_LEVEL_QUIET,
+    "q": LOG_LEVEL_QUIET,
+    "normal": LOG_LEVEL_NORMAL,
+    "default": LOG_LEVEL_NORMAL,
+    "info": LOG_LEVEL_NORMAL,
+    "verbose": LOG_LEVEL_VERBOSE,
+    "v": LOG_LEVEL_VERBOSE,
+    "debug": LOG_LEVEL_VERBOSE,
+}
+
+# Module-level current verbosity. Set once per run via `set_log_level()`;
+# read by `vprint()`. Defaults to NORMAL so library/test callers that never
+# configure it get the CI-friendly behavior.
+_current_log_level = LOG_LEVEL_NORMAL
+
+
+def parse_log_level(value: Any, default: int = LOG_LEVEL_NORMAL) -> int:
+    """Map a string/int verbosity into a numeric level.
+
+    Accepts the names in ``_LOG_LEVEL_NAMES`` (case-insensitive) or a numeric
+    value (clamped to the valid range). Anything unrecognized falls back to
+    ``default`` rather than raising, so a stray env var can never abort a run.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        # bool is an int subclass; treat True as verbose, False as default.
+        return LOG_LEVEL_VERBOSE if value else default
+    if isinstance(value, int):
+        return max(LOG_LEVEL_QUIET, min(LOG_LEVEL_VERBOSE, value))
+    name = str(value).strip().lower()
+    if name.isdigit():
+        return max(LOG_LEVEL_QUIET, min(LOG_LEVEL_VERBOSE, int(name)))
+    return _LOG_LEVEL_NAMES.get(name, default)
+
+
+def resolve_log_level(verbose: bool = False, quiet: bool = False) -> int:
+    """Resolve effective console verbosity from flags and environment.
+
+    Priority (highest first):
+      1. Explicit ``--verbose`` / ``--quiet`` flags. ``--verbose`` wins if
+         both are somehow set (louder is safer for debugging).
+      2. ``MEROBOX_LOG_LEVEL`` env var (lets CI dial verbosity without
+         editing workflow YAML).
+      3. ``LOG_LEVEL_NORMAL`` default.
+    """
+    if verbose:
+        return LOG_LEVEL_VERBOSE
+    if quiet:
+        return LOG_LEVEL_QUIET
+    env = os.environ.get("MEROBOX_LOG_LEVEL")
+    if env:
+        return parse_log_level(env)
+    return LOG_LEVEL_NORMAL
+
+
+def set_log_level(level: int) -> None:
+    """Set the process-wide console verbosity used by ``vprint()``."""
+    global _current_log_level
+    _current_log_level = level
+
+
+def get_log_level() -> int:
+    """Return the current process-wide console verbosity."""
+    return _current_log_level
+
+
+def vprint(*args: Any, level: int = LOG_LEVEL_NORMAL, **kwargs: Any) -> None:
+    """``console.print`` gated by verbosity.
+
+    Prints only when the current level is at least ``level``. Use
+    ``level=LOG_LEVEL_VERBOSE`` for per-attempt / debug chatter,
+    ``level=LOG_LEVEL_NORMAL`` for banners, and plain ``console.print`` (or
+    ``level=LOG_LEVEL_QUIET``) for output that must always appear, such as
+    final success/failure summaries.
+    """
+    if _current_log_level >= level:
+        console.print(*args, **kwargs)
 
 
 def _normalize_port(port_value: Any) -> Optional[int]:

--- a/merobox/tests/unit/test_log_verbosity.py
+++ b/merobox/tests/unit/test_log_verbosity.py
@@ -1,0 +1,137 @@
+"""Unit tests for the console verbosity controls in ``commands/utils.py``.
+
+Covers level parsing, flag/env resolution priority, and the ``vprint`` gate.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands import utils
+from merobox.commands.utils import (
+    LOG_LEVEL_NORMAL,
+    LOG_LEVEL_QUIET,
+    LOG_LEVEL_VERBOSE,
+    parse_log_level,
+    resolve_log_level,
+    vprint,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_level():
+    """Keep the module-global level from leaking across tests."""
+    original = utils.get_log_level()
+    utils.set_log_level(LOG_LEVEL_NORMAL)
+    yield
+    utils.set_log_level(original)
+
+
+class TestParseLogLevel:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("quiet", LOG_LEVEL_QUIET),
+            ("QUIET", LOG_LEVEL_QUIET),
+            ("normal", LOG_LEVEL_NORMAL),
+            (" verbose ", LOG_LEVEL_VERBOSE),
+            ("debug", LOG_LEVEL_VERBOSE),
+            ("0", LOG_LEVEL_QUIET),
+            ("2", LOG_LEVEL_VERBOSE),
+            (0, LOG_LEVEL_QUIET),
+            (2, LOG_LEVEL_VERBOSE),
+            (True, LOG_LEVEL_VERBOSE),
+            (False, LOG_LEVEL_NORMAL),
+        ],
+    )
+    def test_recognized_values(self, value, expected):
+        assert parse_log_level(value) == expected
+
+    def test_none_returns_default(self):
+        assert parse_log_level(None) == LOG_LEVEL_NORMAL
+        assert parse_log_level(None, default=LOG_LEVEL_QUIET) == LOG_LEVEL_QUIET
+
+    def test_unknown_falls_back_to_default(self):
+        assert parse_log_level("banana") == LOG_LEVEL_NORMAL
+        assert parse_log_level("banana", default=LOG_LEVEL_VERBOSE) == LOG_LEVEL_VERBOSE
+
+    def test_out_of_range_int_is_clamped(self):
+        assert parse_log_level(99) == LOG_LEVEL_VERBOSE
+        assert parse_log_level(-5) == LOG_LEVEL_QUIET
+
+
+class TestResolveLogLevel:
+    def test_verbose_flag_wins(self):
+        assert resolve_log_level(verbose=True) == LOG_LEVEL_VERBOSE
+
+    def test_quiet_flag(self):
+        assert resolve_log_level(quiet=True) == LOG_LEVEL_QUIET
+
+    def test_verbose_beats_quiet_when_both_set(self):
+        assert resolve_log_level(verbose=True, quiet=True) == LOG_LEVEL_VERBOSE
+
+    def test_env_var_used_when_no_flags(self):
+        with patch.dict("os.environ", {"MEROBOX_LOG_LEVEL": "verbose"}):
+            assert resolve_log_level() == LOG_LEVEL_VERBOSE
+        with patch.dict("os.environ", {"MEROBOX_LOG_LEVEL": "quiet"}):
+            assert resolve_log_level() == LOG_LEVEL_QUIET
+
+    def test_flag_beats_env_var(self):
+        with patch.dict("os.environ", {"MEROBOX_LOG_LEVEL": "quiet"}):
+            assert resolve_log_level(verbose=True) == LOG_LEVEL_VERBOSE
+
+    def test_default_is_normal(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert resolve_log_level() == LOG_LEVEL_NORMAL
+
+    def test_unknown_env_var_falls_back_to_normal(self):
+        with patch.dict("os.environ", {"MEROBOX_LOG_LEVEL": "loud"}):
+            assert resolve_log_level() == LOG_LEVEL_NORMAL
+
+
+class TestVprint:
+    def _capture(self):
+        """Patch the module console and return the mock for assertions."""
+        return patch.object(utils, "console", MagicMock())
+
+    def test_verbose_message_suppressed_at_normal(self):
+        utils.set_log_level(LOG_LEVEL_NORMAL)
+        with self._capture() as mock_console:
+            vprint("chatter", level=LOG_LEVEL_VERBOSE)
+            mock_console.print.assert_not_called()
+
+    def test_verbose_message_shown_at_verbose(self):
+        utils.set_log_level(LOG_LEVEL_VERBOSE)
+        with self._capture() as mock_console:
+            vprint("chatter", level=LOG_LEVEL_VERBOSE)
+            mock_console.print.assert_called_once()
+
+    def test_normal_message_shown_at_normal_hidden_at_quiet(self):
+        utils.set_log_level(LOG_LEVEL_NORMAL)
+        with self._capture() as mock_console:
+            vprint("banner", level=LOG_LEVEL_NORMAL)
+            mock_console.print.assert_called_once()
+
+        utils.set_log_level(LOG_LEVEL_QUIET)
+        with self._capture() as mock_console:
+            vprint("banner", level=LOG_LEVEL_NORMAL)
+            mock_console.print.assert_not_called()
+
+    def test_quiet_level_message_always_shown(self):
+        utils.set_log_level(LOG_LEVEL_QUIET)
+        with self._capture() as mock_console:
+            vprint("always", level=LOG_LEVEL_QUIET)
+            mock_console.print.assert_called_once()
+
+    def test_default_level_is_normal(self):
+        # vprint with no explicit level behaves as a NORMAL-level message.
+        utils.set_log_level(LOG_LEVEL_QUIET)
+        with self._capture() as mock_console:
+            vprint("default-level")
+            mock_console.print.assert_not_called()
+
+    def test_forwards_args_and_kwargs(self):
+        utils.set_log_level(LOG_LEVEL_NORMAL)
+        with self._capture() as mock_console:
+            vprint("msg", level=LOG_LEVEL_NORMAL, markup=False)
+            mock_console.print.assert_called_once_with("msg", markup=False)

--- a/merobox/tests/unit/test_log_verbosity.py
+++ b/merobox/tests/unit/test_log_verbosity.py
@@ -1,8 +1,10 @@
 """Unit tests for the console verbosity controls in ``commands/utils.py``.
 
-Covers level parsing, flag/env resolution priority, and the ``vprint`` gate.
+Covers level parsing, flag/env resolution priority, the ``vprint`` gate, and
+the per-context (ContextVar) scoping of the level.
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -135,3 +137,51 @@ class TestVprint:
         with self._capture() as mock_console:
             vprint("msg", level=LOG_LEVEL_NORMAL, markup=False)
             mock_console.print.assert_called_once_with("msg", markup=False)
+
+
+class TestContextScoping:
+    """The level is a ContextVar: child tasks inherit it, but a level set
+    inside a task does not leak back to the parent (so concurrent branches
+    don't clobber each other)."""
+
+    def test_child_task_inherits_parent_level(self):
+        async def scenario():
+            utils.set_log_level(LOG_LEVEL_VERBOSE)
+            seen = {}
+
+            async def child():
+                seen["inherited"] = utils.get_log_level()
+                # Mutate only this task's context.
+                utils.set_log_level(LOG_LEVEL_QUIET)
+                seen["after_local_set"] = utils.get_log_level()
+
+            await asyncio.create_task(child())
+            seen["parent_after_child"] = utils.get_log_level()
+            return seen
+
+        seen = asyncio.run(scenario())
+        assert seen["inherited"] == LOG_LEVEL_VERBOSE
+        assert seen["after_local_set"] == LOG_LEVEL_QUIET
+        # Child's set did not leak back to the parent context.
+        assert seen["parent_after_child"] == LOG_LEVEL_VERBOSE
+
+    def test_concurrent_tasks_are_isolated(self):
+        async def scenario():
+            results = {}
+
+            async def branch(name, level):
+                utils.set_log_level(level)
+                # Yield so the other branch interleaves before we read back.
+                await asyncio.sleep(0)
+                results[name] = utils.get_log_level()
+
+            await asyncio.gather(
+                asyncio.create_task(branch("a", LOG_LEVEL_QUIET)),
+                asyncio.create_task(branch("b", LOG_LEVEL_VERBOSE)),
+            )
+            return results
+
+        results = asyncio.run(scenario())
+        # Each branch reads back its own level despite interleaving.
+        assert results["a"] == LOG_LEVEL_QUIET
+        assert results["b"] == LOG_LEVEL_VERBOSE

--- a/merobox/tests/unit/test_step_output_verbosity.py
+++ b/merobox/tests/unit/test_step_output_verbosity.py
@@ -1,0 +1,82 @@
+"""Verbosity gating for high-volume step output.
+
+The per-call / per-iteration chatter from the export machinery (validated
+config banners, "Exporting variables", per-field "✓ name = value" lines) is
+the dominant source of CI log noise on the happy path. These tests pin that
+output to VERBOSE while keeping genuine warnings (missing field, etc.) always
+visible.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from merobox.commands import utils
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import (
+    LOG_LEVEL_NORMAL,
+    LOG_LEVEL_VERBOSE,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_level():
+    original = utils.get_log_level()
+    yield
+    utils.set_log_level(original)
+
+
+def _capture(level):
+    """Set verbosity and patch the shared Console; return the recorder list."""
+    utils.set_log_level(level)
+    printed: list[str] = []
+    return printed, patch.object(
+        utils.console,
+        "print",
+        side_effect=lambda *a, **k: printed.append(str(a[0]) if a else ""),
+    )
+
+
+def test_validate_export_config_banner_is_verbose_only():
+    step = BaseStep({"name": "s", "outputs": {"out": "field"}})
+
+    printed, cap = _capture(LOG_LEVEL_NORMAL)
+    with cap:
+        assert step._validate_export_config() is True
+    assert not any("Custom outputs configuration validated" in p for p in printed)
+
+    printed, cap = _capture(LOG_LEVEL_VERBOSE)
+    with cap:
+        assert step._validate_export_config() is True
+    assert any("Custom outputs configuration validated" in p for p in printed)
+
+
+def test_export_confirmation_lines_are_verbose_only():
+    step = BaseStep({"name": "s", "outputs": {"my_key": "value"}})
+    response = {"data": {"value": "hello"}}
+
+    printed, cap = _capture(LOG_LEVEL_NORMAL)
+    with cap:
+        dyn: dict = {}
+        step._export_custom_outputs(response, "node-1", dyn)
+    # The value is still exported, just not announced on the console.
+    assert dyn["my_key"] == "hello"
+    assert not any("Exporting variables from" in p for p in printed)
+    assert not any("✓" in p for p in printed)
+
+    printed, cap = _capture(LOG_LEVEL_VERBOSE)
+    with cap:
+        step._export_custom_outputs(response, "node-1", {})
+    assert any("Exporting variables from" in p for p in printed)
+    assert any("✓" in p for p in printed)
+
+
+def test_missing_field_warning_always_shown():
+    step = BaseStep({"name": "s", "outputs": {"my_key": "absent_field"}})
+    response = {"data": {"present": 1}}
+
+    # Even at NORMAL, a genuine export failure must surface.
+    printed, cap = _capture(LOG_LEVEL_NORMAL)
+    with cap:
+        step._export_custom_outputs(response, "node-1", {})
+    assert any("Export failed" in p for p in printed)

--- a/merobox/tests/unit/test_wait_for_sync_verbosity.py
+++ b/merobox/tests/unit/test_wait_for_sync_verbosity.py
@@ -7,7 +7,7 @@ regardless of level.
 """
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -39,17 +39,24 @@ def _make_step() -> WaitForSyncStep:
 def _run_capturing_output(step, level, converge_on_attempt, **kwargs):
     """Run _wait_for_sync at the given verbosity, capturing all printed text.
 
-    Both the shared ``utils.console`` (used by ``vprint``) and the
-    ``console`` name imported into the step module point at the same Console
-    object, so a single shared mock captures banner, per-attempt, and summary
-    output alike.
+    Patches ``print`` on the single shared Console instance rather than
+    rebinding the ``console`` name in each module: ``vprint`` and the step's
+    direct ``console.print`` calls both target that same object, so one patch
+    captures banner, per-attempt, and summary output regardless of how the
+    step routes a given line. Returns ``(result, joined_output, attempts)``;
+    ``attempts`` lets callers assert the loop ran the expected number of
+    rounds, making the tests sensitive to early-exit bugs.
+
+    Note: ``TARGETS`` has a single entry, so the per-call ``fake_check``
+    counter equals the attempt number. With multiple targets it would
+    increment once per target per attempt — fine here, but a multi-target
+    fixture would need a per-round counter.
     """
     utils.set_log_level(level)
     printed: list[str] = []
-    mock_console = MagicMock()
-    mock_console.print.side_effect = lambda *a, **k: printed.append(
-        str(a[0]) if a else ""
-    )
+
+    def _record(*a, **k):
+        printed.append(str(a[0]) if a else "")
 
     attempts = {"n": 0}
 
@@ -64,11 +71,7 @@ def _run_capturing_output(step, level, converge_on_attempt, **kwargs):
 
     async def run():
         with (
-            patch.object(utils, "console", mock_console),
-            patch(
-                "merobox.commands.bootstrap.steps.wait_for_sync.console",
-                mock_console,
-            ),
+            patch.object(utils.console, "print", side_effect=_record),
             patch.object(step, "_check_target_convergence", side_effect=fake_check),
             patch(
                 "merobox.commands.bootstrap.steps.wait_for_sync.asyncio.sleep",
@@ -78,17 +81,18 @@ def _run_capturing_output(step, level, converge_on_attempt, **kwargs):
             return await step._wait_for_sync(TARGETS, NODES, timeout=30, **kwargs)
 
     result, _details = asyncio.run(run())
-    return result, "\n".join(printed)
+    return result, "\n".join(printed), attempts["n"]
 
 
 def test_happy_path_at_normal_hides_per_attempt_shows_summary():
     step = _make_step()
     # Miss the first check, converge on the second.
-    result, output = _run_capturing_output(
+    result, output, attempts = _run_capturing_output(
         step, LOG_LEVEL_NORMAL, converge_on_attempt=2, check_interval=0.01
     )
 
     assert result is True
+    assert attempts == 2  # actually polled twice; not an early exit
     # Banner present, per-attempt block absent, success summary present.
     assert "Waiting for" in output
     assert "not all converged yet" not in output
@@ -97,22 +101,24 @@ def test_happy_path_at_normal_hides_per_attempt_shows_summary():
 
 def test_verbose_restores_per_attempt_detail():
     step = _make_step()
-    result, output = _run_capturing_output(
+    result, output, attempts = _run_capturing_output(
         step, LOG_LEVEL_VERBOSE, converge_on_attempt=2, check_interval=0.01
     )
 
     assert result is True
+    assert attempts == 2
     assert "not all converged yet" in output
     assert "All targets synced" in output
 
 
 def test_quiet_hides_banner_but_keeps_summary():
     step = _make_step()
-    result, output = _run_capturing_output(
+    result, output, attempts = _run_capturing_output(
         step, LOG_LEVEL_QUIET, converge_on_attempt=2, check_interval=0.01
     )
 
     assert result is True
+    assert attempts == 2
     assert "Waiting for" not in output
     assert "not all converged yet" not in output
     # Final summary must always survive, even when quiet.
@@ -122,7 +128,7 @@ def test_quiet_hides_banner_but_keeps_summary():
 def test_failure_dumps_full_state_even_at_normal():
     step = _make_step()
     # Never converge; bound the loop with retry_attempts.
-    result, output = _run_capturing_output(
+    result, output, attempts = _run_capturing_output(
         step,
         LOG_LEVEL_NORMAL,
         converge_on_attempt=999,
@@ -131,6 +137,9 @@ def test_failure_dumps_full_state_even_at_normal():
     )
 
     assert result is False
+    # Ran the full bounded budget (2 loop rounds) before giving up, not an
+    # early exit; the post-loop consistency check polls once more.
+    assert attempts >= 2
     # Diagnostics are never swallowed on failure.
     assert "Sync verification failed" in output
     assert "Final state" in output

--- a/merobox/tests/unit/test_wait_for_sync_verbosity.py
+++ b/merobox/tests/unit/test_wait_for_sync_verbosity.py
@@ -1,0 +1,137 @@
+"""Verbosity gating tests for the wait_for_sync step.
+
+Asserts the CI-friendly default: the happy path emits a banner and a single
+success summary but no per-attempt blocks, verbose mode restores the
+per-attempt detail, and failures always dump the full per-node state
+regardless of level.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands import utils
+from merobox.commands.bootstrap.steps.wait_for_sync import WaitForSyncStep
+from merobox.commands.utils import (
+    LOG_LEVEL_NORMAL,
+    LOG_LEVEL_QUIET,
+    LOG_LEVEL_VERBOSE,
+)
+
+TARGETS = [{"kind": "context", "id": "ctx-1", "field": "contextStateHash"}]
+NODES = ["calimero-node-1", "calimero-node-2"]
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_level():
+    original = utils.get_log_level()
+    yield
+    utils.set_log_level(original)
+
+
+def _make_step() -> WaitForSyncStep:
+    return WaitForSyncStep(
+        {"type": "wait_for_sync", "context_id": "ctx-1", "nodes": NODES}
+    )
+
+
+def _run_capturing_output(step, level, converge_on_attempt, **kwargs):
+    """Run _wait_for_sync at the given verbosity, capturing all printed text.
+
+    Both the shared ``utils.console`` (used by ``vprint``) and the
+    ``console`` name imported into the step module point at the same Console
+    object, so a single shared mock captures banner, per-attempt, and summary
+    output alike.
+    """
+    utils.set_log_level(level)
+    printed: list[str] = []
+    mock_console = MagicMock()
+    mock_console.print.side_effect = lambda *a, **k: printed.append(
+        str(a[0]) if a else ""
+    )
+
+    attempts = {"n": 0}
+
+    async def fake_check(target, nodes, trigger_sync):
+        attempts["n"] += 1
+        converged = attempts["n"] >= converge_on_attempt
+        node_hashes = dict.fromkeys(nodes, "h" if converged else None)
+        return converged, node_hashes
+
+    async def fake_sleep(_duration):
+        return None
+
+    async def run():
+        with (
+            patch.object(utils, "console", mock_console),
+            patch(
+                "merobox.commands.bootstrap.steps.wait_for_sync.console",
+                mock_console,
+            ),
+            patch.object(step, "_check_target_convergence", side_effect=fake_check),
+            patch(
+                "merobox.commands.bootstrap.steps.wait_for_sync.asyncio.sleep",
+                side_effect=fake_sleep,
+            ),
+        ):
+            return await step._wait_for_sync(TARGETS, NODES, timeout=30, **kwargs)
+
+    result, _details = asyncio.run(run())
+    return result, "\n".join(printed)
+
+
+def test_happy_path_at_normal_hides_per_attempt_shows_summary():
+    step = _make_step()
+    # Miss the first check, converge on the second.
+    result, output = _run_capturing_output(
+        step, LOG_LEVEL_NORMAL, converge_on_attempt=2, check_interval=0.01
+    )
+
+    assert result is True
+    # Banner present, per-attempt block absent, success summary present.
+    assert "Waiting for" in output
+    assert "not all converged yet" not in output
+    assert "All targets synced" in output
+
+
+def test_verbose_restores_per_attempt_detail():
+    step = _make_step()
+    result, output = _run_capturing_output(
+        step, LOG_LEVEL_VERBOSE, converge_on_attempt=2, check_interval=0.01
+    )
+
+    assert result is True
+    assert "not all converged yet" in output
+    assert "All targets synced" in output
+
+
+def test_quiet_hides_banner_but_keeps_summary():
+    step = _make_step()
+    result, output = _run_capturing_output(
+        step, LOG_LEVEL_QUIET, converge_on_attempt=2, check_interval=0.01
+    )
+
+    assert result is True
+    assert "Waiting for" not in output
+    assert "not all converged yet" not in output
+    # Final summary must always survive, even when quiet.
+    assert "All targets synced" in output
+
+
+def test_failure_dumps_full_state_even_at_normal():
+    step = _make_step()
+    # Never converge; bound the loop with retry_attempts.
+    result, output = _run_capturing_output(
+        step,
+        LOG_LEVEL_NORMAL,
+        converge_on_attempt=999,
+        check_interval=0.01,
+        retry_attempts=2,
+    )
+
+    assert result is False
+    # Diagnostics are never swallowed on failure.
+    assert "Sync verification failed" in output
+    assert "Final state" in output
+    assert "calimero-node-1" in output


### PR DESCRIPTION
Closes #268. Companion to #267 / #269 (adaptive backoff) — fewer attempts + quieter attempts make the e2e sync logs readable.

## Problem

merobox workflow output is very verbose in CI. The biggest offender is `wait_for_sync`, which prints a full block on **every** poll attempt (`Attempt N (Xs): … not all converged yet` + per-node hash detail). With sub-second polling across many `wait_for_sync` steps, this floods the log even on the happy path. There was no verbosity/quiet/log-level control for merobox's own console output.

## Change

A single verbosity knob, routed through one helper so every step benefits.

**`commands/utils.py`**
- `LOG_LEVEL_QUIET/NORMAL/VERBOSE`, `set_log_level`/`get_log_level`, and `vprint(msg, level=...)` which gates `console.print` on a process-wide level.
- `resolve_log_level(verbose, quiet)` — priority: `-v`/`-q` flags → `MEROBOX_LOG_LEVEL` env var → `normal` default (`-v` wins if both flags set).
- `parse_log_level` accepts names/ints and falls back safely so a stray env var can never abort a run.
- This is merobox's **own** console verbosity — explicitly distinct from `--log-level` (merod's RUST_LOG).

**`bootstrap run`**
- New `-q/--quiet` flag (and clarified `-v/--verbose` help); mutually-exclusive warning. Threaded through `run_workflow_sync`/`run_workflow`, which calls `set_log_level(resolve_log_level(...))` before any step output.

**`wait_for_sync`**
- Banner → `NORMAL` (hidden only with `-q`).
- Per-attempt "not converged yet" blocks → `VERBOSE` only.
- Final success/failure summary → always shown.
- Failure per-target/per-node hash dump → always shown (diagnostics never swallowed).

**Also** gated the previously unconditional `run_workflow` / `WorkflowExecutor` debug lines to verbose-only.

## Behavior

| Level | wait_for_sync output |
|-------|----------------------|
| `-q` / quiet | final summary only |
| default / normal | banner + final summary (no per-attempt) |
| `-v` / verbose / `MEROBOX_LOG_LEVEL=verbose` | full per-attempt detail (unchanged from today) |

Failures always dump the full final per-node state at every level.

## Acceptance criteria

- [x] Happy-path `wait_for_sync` emits a banner + single success summary, not one block per attempt.
- [x] Failures still emit full final per-target/per-node hash state.
- [x] Documented way to re-enable full per-attempt logging (`-v` flag and `MEROBOX_LOG_LEVEL` env var).
- [x] Verbosity helper lives in `utils.py` and is reusable by other steps (already reused for the executor/run debug lines).
- [x] No behavior change when verbose is explicitly requested.

## Tests

`test_log_verbosity.py` (parse/resolve/`vprint` gating, env-vs-flag priority) and `test_wait_for_sync_verbosity.py` (normal hides per-attempt + keeps summary; verbose restores detail; quiet keeps summary; failure dumps full state at normal) — 31 new tests. `run --help` shows both flags. ruff/format clean; existing suites unaffected.

Bumps `0.6.28 → 0.6.30` (0.6.29 is claimed by #269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with explicit verbose opt-in; workflow execution and error reporting paths are preserved, covered by new unit tests.
> 
> **Overview**
> Adds **merobox console verbosity** for `bootstrap run` (separate from merod `--log-level`): `quiet` / `normal` / `verbose` via new `-q/--quiet`, existing `-v/--verbose`, or `MEROBOX_LOG_LEVEL`, resolved at workflow start and applied through `vprint()` in `utils.py` (ContextVar-scoped).
> 
> **Default (`normal`)** keeps banners and final outcomes but drops happy-path noise: `wait_for_sync` per-attempt “not converged” blocks, `execute` JSON-RPC dumps and resolved-value debug, `repeat` per-iteration lines, and export “validated” / per-field ✓ lines. **`--verbose`** restores prior detail; **`--quiet`** hides even banners; **failures** still print full sync diagnostics and real warnings/errors unchanged.
> 
> CLI warns when both `-v` and `-q` are set (`-v` wins). Version **0.6.30** and unit tests for parsing, `vprint`, step export verbosity, and `wait_for_sync` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813d3d1300810fc8ce15efec3e82068c42cc1c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->