### PR TITLE
feat(auth): login/refresh/ws_connect workflow steps + negative-auth asserts (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.33] - 2026-06-03
+
+### Added
+
+- First-class **auth support in workflows**, so authenticated (and negative)
+  e2e tests can be written declaratively against a node's embedded auth router
+  (`merod --auth-mode embedded`, no separate `mero-auth` container needed). The
+  embedded router auto-creates a root key with `["admin"]` on the first
+  `POST /auth/token`, so the first login doubles as setup. New step types:
+  - `login` — bootstraps/authenticates against a node and **seeds the on-disk
+    token cache** (`~/.merobox/auth_cache/{node}.json`) so every downstream
+    `call`/`execute`/`ws_connect` on that node is authenticated automatically.
+    Exports `access_token`/`refresh_token` via `outputs`. Set
+    `expected_failure: true` to assert that bad credentials are rejected.
+  - `refresh` — exercises `POST /auth/refresh`: swaps the cached refresh token
+    for a fresh access token and re-seeds the cache.
+  - `ws_connect` / `ws_subscribe` — opens a WebSocket against the node's `/ws`
+    endpoint with the JWT on the `?token=<jwt>` query param (WS clients can't
+    set headers). With a valid cached token the connect must succeed; with
+    `unauthenticated: true` + `expected_failure: true` it asserts the upgrade
+    handshake is rejected. Mirrors `core/scripts/test-websocket-auth.sh`.
+- Negative-test toggle on the `call`/`execute` step: `unauthenticated: true`
+  forces a no-token request so a protected endpoint rejects it; pair with the
+  existing `expected_failure: true` to assert the 401.
+- `expected_failure` on the auth steps is strict: it only passes on a genuine
+  auth rejection (a credential/refresh `AuthenticationError`, or a WebSocket
+  upgrade returning HTTP 401/403). Connectivity faults — unreachable node,
+  connection refused/reset, timeouts, or a non-auth handshake status — fail the
+  step rather than green-lighting a meaningless assert. A mis-asserted negative
+  `login`/`refresh` (auth unexpectedly succeeds) also no longer seeds the token
+  cache, so it can't leave stale credentials behind.
+- `auth_mode: embedded` workflows no longer require `--auth-username` /
+  `--auth-password`. When omitted, the workflow drives auth declaratively via
+  `login` steps; when provided (both together), merobox still auto-authenticates
+  every node up front as before. Supplying only one of the pair is now a
+  validation error.
+- Example workflows under `workflow-examples/`:
+  `workflow-embedded-auth-example.yml` (bootstrap/login, authenticated calls,
+  the unauthenticated negative assert, WebSocket auth, and the refresh flow) and
+  the focused `workflow-websocket-auth-example.yml` (valid token connects, no
+  token / bad token rejected).
+
 ## [0.6.32] - 2026-05-30
 
 ### Added

--- a/LLM.md
+++ b/LLM.md
@@ -356,6 +356,73 @@ Call a method on an application.
     result: "output"
 ```
 
+#### 5a. Embedded Auth Steps (`login`, `refresh`, `ws_connect`)
+
+Drive the **embedded** auth path of a node (`merod --auth-mode embedded`, set
+via top-level `auth_mode: embedded` in binary mode). These let you write
+authenticated and negative e2e tests declaratively.
+
+`login` bootstraps/authenticates and seeds the on-disk token cache so every
+downstream `call`/`execute`/`ws_connect` on that node is authenticated
+automatically. On a fresh node the first login auto-creates a root key with
+`["admin"]` (login == setup).
+
+```yaml
+- type: login
+  node: node-1
+  username: alice
+  password: password123
+  outputs:
+    access_token: access_token
+    refresh_token: refresh_token
+```
+
+Assert that bad credentials are rejected with `expected_failure: true`:
+
+```yaml
+- type: login
+  node: node-1
+  username: alice
+  password: wrong
+  expected_failure: true
+```
+
+Force an unauthenticated request on a `call` and assert the 401:
+
+```yaml
+- type: call
+  node: node-1
+  context_id: "{{context_id}}"
+  method: get
+  args: { key: hello }
+  unauthenticated: true
+  expected_failure: true
+```
+
+Open a WebSocket subscription (`/ws`, JWT on the `?token=` query param). With a
+valid cached token the connect must succeed; the negative case asserts rejection:
+
+```yaml
+- type: ws_connect        # alias: ws_subscribe
+  node: node-1            # uses the token seeded by `login`
+
+- type: ws_connect
+  node: node-1
+  unauthenticated: true
+  expected_failure: true  # no token -> handshake rejected
+```
+
+Refresh the cached access token via `POST /auth/refresh`:
+
+```yaml
+- type: refresh
+  node: node-1
+  outputs:
+    access_token: access_token
+```
+
+See `workflow-examples/workflow-embedded-auth-example.yml` for a full run.
+
 #### 6. Wait Step
 
 Pause execution for a specified duration.

--- a/LLM.md
+++ b/LLM.md
@@ -421,7 +421,9 @@ Refresh the cached access token via `POST /auth/refresh`:
     access_token: access_token
 ```
 
-See `workflow-examples/workflow-embedded-auth-example.yml` for a full run.
+See `workflow-examples/workflow-embedded-auth-example.yml` for a full run, or
+`workflow-examples/workflow-websocket-auth-example.yml` for a WebSocket-focused
+one.
 
 #### 6. Wait Step
 

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.32"
+__version__ = "0.6.33"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/bootstrap.py
+++ b/merobox/commands/bootstrap/bootstrap.py
@@ -303,11 +303,14 @@ def run(
         )
         sys.exit(1)
 
-    # Validate that auth credentials are provided when --auth-mode=embedded
-    if auth_mode == "embedded" and not (auth_username and auth_password):
+    # --auth-username/--auth-password are optional under --auth-mode=embedded:
+    # provide both to auto-authenticate every node up front, or omit both and
+    # drive auth declaratively from the workflow via `login` steps. Providing
+    # only one is a misconfiguration.
+    if auth_mode == "embedded" and bool(auth_username) != bool(auth_password):
         console.print(
-            "[red]When using --auth-mode=embedded, you must provide --auth-username and --auth-password "
-            "for workflow authentication.[/red]"
+            "[red]--auth-username and --auth-password must be provided together "
+            "(or omitted to use declarative `login` steps).[/red]"
         )
         sys.exit(1)
 

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -107,6 +107,10 @@ VALID_STEP_TYPES = frozenset(
         "fuzzy_test",
         "stop_node",
         "start_node",
+        "login",
+        "refresh",
+        "ws_connect",
+        "ws_subscribe",
     }
 )
 
@@ -309,6 +313,64 @@ class CallStep(BaseStepConfig):
     args: Optional[dict[str, Any]] = Field(None, description="Arguments for the call")
     executor_public_key: Optional[str] = Field(
         None, description="Public key of executor"
+    )
+    expected_failure: Optional[bool] = Field(
+        False, description="Assert the call is rejected/fails rather than succeeds"
+    )
+    unauthenticated: Optional[bool] = Field(
+        False,
+        description=(
+            "Force a no-token request (negative auth test). Pair with "
+            "expected_failure: true to assert a 401."
+        ),
+    )
+
+
+class LoginStepConfig(BaseStepConfig):
+    """Configuration for login step (embedded-auth bootstrap/login)."""
+
+    type: Literal["login"] = "login"
+    node: str = Field(..., description="Target node to authenticate against")
+    username: str = Field(
+        ..., description="Username (public key) for user_password auth"
+    )
+    password: str = Field(..., description="Password for user_password auth")
+    expected_failure: Optional[bool] = Field(
+        False,
+        description="Assert that authentication is rejected (e.g. bad credentials)",
+    )
+
+
+class RefreshStepConfig(BaseStepConfig):
+    """Configuration for refresh step (POST /auth/refresh)."""
+
+    type: Literal["refresh"] = "refresh"
+    node: str = Field(..., description="Node whose cached token should be refreshed")
+    expected_failure: Optional[bool] = Field(
+        False, description="Assert that the refresh is rejected (e.g. invalid token)"
+    )
+
+
+class WebSocketConnectStepConfig(BaseStepConfig):
+    """Configuration for ws_connect / ws_subscribe step (WebSocket auth)."""
+
+    type: Literal["ws_connect", "ws_subscribe"] = "ws_connect"
+    node: str = Field(..., description="Target node to open a WebSocket against")
+    unauthenticated: Optional[bool] = Field(
+        False, description="Connect without attaching a token (negative auth test)"
+    )
+    expected_failure: Optional[bool] = Field(
+        False,
+        description="Assert the connection is rejected (use with unauthenticated)",
+    )
+    token: Optional[str] = Field(
+        None, description="Explicit JWT to attach (overrides the cached token)"
+    )
+    message: Optional[str] = Field(
+        None, description="Optional text frame to send once connected"
+    )
+    timeout: Optional[float] = Field(
+        None, gt=0, description="Handshake timeout in seconds"
     )
 
 
@@ -1269,6 +1331,10 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "get_group_upgrade_status": GetGroupUpgradeStatusStepConfig,
     "retry_group_upgrade": RetryGroupUpgradeStepConfig,
     "call": CallStep,
+    "login": LoginStepConfig,
+    "refresh": RefreshStepConfig,
+    "ws_connect": WebSocketConnectStepConfig,
+    "ws_subscribe": WebSocketConnectStepConfig,
     "wait": WaitStep,
     "wait_for_sync": WaitForSyncStep,
     "repeat": RepeatStep,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -2064,6 +2064,20 @@ class WorkflowExecutor:
             return JoinOpenStep(step_config, **common_kwargs)
         elif step_type == "call":
             return ExecuteStep(step_config, **common_kwargs)
+        elif step_type == "login":
+            from merobox.commands.bootstrap.steps.login import LoginStep
+
+            return LoginStep(step_config, **common_kwargs)
+        elif step_type == "refresh":
+            from merobox.commands.bootstrap.steps.refresh import RefreshStep
+
+            return RefreshStep(step_config, **common_kwargs)
+        elif step_type in ("ws_connect", "ws_subscribe"):
+            from merobox.commands.bootstrap.steps.websocket import (
+                WebSocketConnectStep,
+            )
+
+            return WebSocketConnectStep(step_config, **common_kwargs)
         elif step_type == "wait":
             return WaitStep(step_config, **common_kwargs)
         elif step_type == "wait_for_sync":

--- a/merobox/commands/bootstrap/run/run.py
+++ b/merobox/commands/bootstrap/run/run.py
@@ -150,12 +150,16 @@ async def run_workflow(
                 )
                 return False
 
-            if effective_auth_mode == "embedded" and not (
-                auth_username and auth_password
+            # Note: --auth-username/--auth-password are optional. When provided,
+            # merobox auto-authenticates every node up front (legacy convenience).
+            # When omitted, the workflow is expected to drive auth declaratively
+            # via `login` steps, which seed the token cache per node.
+            if effective_auth_mode == "embedded" and bool(auth_username) != bool(
+                auth_password
             ):
                 console.print(
-                    "[red]When using auth_mode=embedded (from CLI or workflow config), you must provide --auth-username and --auth-password "
-                    "for workflow authentication.[/red]"
+                    "[red]--auth-username and --auth-password must be provided "
+                    "together (or omitted to use declarative `login` steps).[/red]"
                 )
                 return False
 

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -1263,6 +1263,30 @@ class BaseStep:
             "[yellow]⚠️  Warning: expected_failure was set but the step succeeded[/yellow]"
         )
 
+    def _is_connectivity_error(self, error_message: str) -> bool:
+        """Return True if an error message looks like a network/connectivity fault.
+
+        Auth steps use this to keep ``expected_failure`` honest: a negative auth
+        test (e.g. "bad credentials are rejected") must assert an *auth* failure,
+        not silently pass because the node was unreachable. ``AuthManager`` wraps
+        transport faults with a "Network error ..." prefix, while a genuine
+        rejection surfaces as "Invalid credentials" / "Access forbidden".
+        """
+        if not error_message:
+            return False
+        lowered = error_message.lower()
+        markers = (
+            "network error",
+            "connection refused",
+            "cannot connect",
+            "connection reset",
+            "timed out",
+            "timeout",
+            "name or service not known",
+            "temporary failure in name resolution",
+        )
+        return any(marker in lowered for marker in markers)
+
     def _check_jsonrpc_error(self, result_data: Any) -> bool:
         """
         Check if the API response contains a JSON-RPC error.

--- a/merobox/commands/bootstrap/steps/execute.py
+++ b/merobox/commands/bootstrap/steps/execute.py
@@ -59,6 +59,12 @@ class ExecuteStep(BaseStep):
                 f"Step '{step_name}': 'expected_failure' must be a boolean"
             )
 
+        # Validate unauthenticated is a boolean if provided
+        if "unauthenticated" in self.config and not isinstance(
+            self.config["unauthenticated"], bool
+        ):
+            raise ValueError(f"Step '{step_name}': 'unauthenticated' must be a boolean")
+
     def _get_exportable_variables(self):
         """
         Define which variables this step can export.
@@ -111,6 +117,15 @@ class ExecuteStep(BaseStep):
         except Exception as e:
             console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
             return False
+
+        # Negative-test support: force a no-token call so a protected endpoint
+        # rejects it. Pair with `expected_failure: true` to assert the 401.
+        if self.config.get("unauthenticated"):
+            client_node_name = None
+            vprint(
+                "[yellow]🔓 Sending unauthenticated request (no token attached)[/yellow]",
+                level=LOG_LEVEL_VERBOSE,
+            )
 
         # Execute based on type
         try:

--- a/merobox/commands/bootstrap/steps/login.py
+++ b/merobox/commands/bootstrap/steps/login.py
@@ -68,21 +68,31 @@ class LoginStep(BaseStep):
             token = await auth_manager.authenticate(rpc_url, username, password)
         except AuthenticationError as e:
             if expected_failure:
+                # A negative test must assert an *auth* rejection, not pass just
+                # because the node was unreachable (AuthManager wraps transport
+                # faults in the same exception type as a 401).
+                if self._is_connectivity_error(str(e)):
+                    console.print(
+                        f"[red]❌ Expected an auth rejection but hit a "
+                        f"connectivity error for {node_name}: {e}[/red]"
+                    )
+                    return False
                 self._report_expected_failure(str(e))
                 return True
             console.print(f"[red]❌ Login failed for {node_name}: {e}[/red]")
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False
         except Exception as e:
-            if expected_failure:
-                self._report_expected_failure(str(e))
-                return True
+            # An unexpected exception is never proof of an auth rejection.
             console.print(f"[red]❌ Login error for {node_name}: {e}[/red]")
             return False
 
         if expected_failure:
             # Login succeeded but the workflow asserted it should be rejected.
+            # Do NOT seed the cache or export tokens — a mis-asserted negative
+            # test must not leave stale credentials behind for later steps/runs.
             self._report_unexpected_success()
+            return False
 
         # Seed the on-disk cache so downstream calls auto-attach this token.
         if not auth_manager.save_token(token, cache_node_name):
@@ -97,7 +107,7 @@ class LoginStep(BaseStep):
         self._export_variables(token.to_dict(), node_name, dynamic_values)
 
         console.print(f"[green]✓ Logged in to {node_name} as {username}[/green]")
-        return not expected_failure
+        return True
 
     def _resolve_login_target(self, node_name: str) -> tuple[str, str]:
         """Return ``(rpc_url, cache_node_name)`` for the login target.

--- a/merobox/commands/bootstrap/steps/login.py
+++ b/merobox/commands/bootstrap/steps/login.py
@@ -1,0 +1,112 @@
+"""
+Login step executor for embedded-auth nodes.
+
+Performs the bootstrap/login against a node's embedded auth router
+(`POST /auth/token`, `auth_method = user_password`) and seeds the on-disk
+token cache so that every downstream `execute`/`call`/`ws_connect` step on the
+same node is authenticated automatically.
+
+On a fresh node the first `POST /auth/token` with `user_password` auto-creates a
+root key with `["admin"]` permission — so the very first login doubles as setup,
+with no chicken-and-egg.
+"""
+
+from typing import Any
+
+from merobox.commands.auth import AuthenticationError, AuthManager
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import console
+
+
+class LoginStep(BaseStep):
+    """Authenticate against a node's embedded auth router and seed the token cache.
+
+    Required fields: ``node``, ``username``, ``password``.
+
+    Set ``expected_failure: true`` to assert that authentication is *rejected*
+    (e.g. bad credentials) — the step then passes only when the login fails.
+
+    Exports (via ``outputs``): the response carries ``access_token`` and
+    ``refresh_token``, so e.g. ``outputs: { token: access_token }`` captures the
+    JWT for later steps.
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "username", "password"]
+
+    def _validate_field_types(self) -> None:
+        self._validate_string_field("node")
+        self._validate_string_field("username")
+        # Password may be any non-empty string (allow symbols/whitespace inside).
+        self._validate_string_field("password", allow_empty=False)
+        self._validate_boolean_field("expected_failure", required=False)
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        username = self._resolve_dynamic_value(
+            self.config["username"], workflow_results, dynamic_values
+        )
+        password = self._resolve_dynamic_value(
+            self.config["password"], workflow_results, dynamic_values
+        )
+        expected_failure = self._is_expected_failure()
+
+        # Resolve the node URL and the stable name used as the token-cache key.
+        # We always seed under a stable name (independent of auth_mode) so that
+        # downstream steps find the token via the same key.
+        try:
+            rpc_url, cache_node_name = self._resolve_login_target(node_name)
+        except Exception as e:
+            console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
+            return False
+
+        auth_manager = AuthManager()
+
+        try:
+            token = await auth_manager.authenticate(rpc_url, username, password)
+        except AuthenticationError as e:
+            if expected_failure:
+                self._report_expected_failure(str(e))
+                return True
+            console.print(f"[red]❌ Login failed for {node_name}: {e}[/red]")
+            self._print_node_logs_on_failure(node_name=node_name, lines=50)
+            return False
+        except Exception as e:
+            if expected_failure:
+                self._report_expected_failure(str(e))
+                return True
+            console.print(f"[red]❌ Login error for {node_name}: {e}[/red]")
+            return False
+
+        if expected_failure:
+            # Login succeeded but the workflow asserted it should be rejected.
+            self._report_unexpected_success()
+
+        # Seed the on-disk cache so downstream calls auto-attach this token.
+        if not auth_manager.save_token(token, cache_node_name):
+            console.print(
+                f"[yellow]⚠️  Authenticated with {node_name} but failed to "
+                f"write the token cache[/yellow]"
+            )
+
+        # Store and export the token material for later steps.
+        step_key = f"login_{node_name}"
+        workflow_results[step_key] = token.to_dict()
+        self._export_variables(token.to_dict(), node_name, dynamic_values)
+
+        console.print(f"[green]✓ Logged in to {node_name} as {username}[/green]")
+        return not expected_failure
+
+    def _resolve_login_target(self, node_name: str) -> tuple[str, str]:
+        """Return ``(rpc_url, cache_node_name)`` for the login target.
+
+        The cache node name is the stable identifier used as the token-cache
+        key. For resolver-backed nodes it comes from the ResolvedNode; otherwise
+        it falls back to the raw node name from the workflow.
+        """
+        resolved = self._resolve_node(node_name)
+        if resolved:
+            return resolved.url, resolved.node_name
+        return self._get_node_rpc_url(node_name), node_name

--- a/merobox/commands/bootstrap/steps/refresh.py
+++ b/merobox/commands/bootstrap/steps/refresh.py
@@ -1,0 +1,96 @@
+"""
+Refresh step executor for embedded-auth nodes.
+
+Exercises ``POST /auth/refresh``: reads the cached token for a node, swaps the
+refresh token for a fresh access token, and re-seeds the cache so downstream
+steps pick up the new token. Useful for testing that the refresh path issues a
+working access token.
+"""
+
+from typing import Any
+
+from merobox.commands.auth import AuthenticationError, AuthManager
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import console
+
+
+class RefreshStep(BaseStep):
+    """Refresh the cached access token for a node via ``POST /auth/refresh``.
+
+    Required fields: ``node``. The node must already have a cached token with a
+    refresh token (typically seeded by a prior ``login`` step).
+
+    Set ``expected_failure: true`` to assert the refresh is *rejected* (e.g. an
+    expired/invalid refresh token) — the step then passes only when refresh
+    fails.
+
+    Exports (via ``outputs``): the new ``access_token`` and ``refresh_token``.
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node"]
+
+    def _validate_field_types(self) -> None:
+        self._validate_string_field("node")
+        self._validate_boolean_field("expected_failure", required=False)
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        expected_failure = self._is_expected_failure()
+
+        try:
+            resolved = self._resolve_node(node_name)
+            if resolved:
+                rpc_url, cache_node_name = resolved.url, resolved.node_name
+            else:
+                rpc_url, cache_node_name = self._get_node_rpc_url(node_name), node_name
+        except Exception as e:
+            console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
+            return False
+
+        auth_manager = AuthManager()
+        cached = auth_manager.get_cached_token(cache_node_name)
+        if cached is None:
+            console.print(
+                f"[red]❌ No cached token for {node_name}; run a 'login' step "
+                f"before 'refresh'[/red]"
+            )
+            return False
+        if not cached.refresh_token:
+            console.print(
+                f"[red]❌ Cached token for {node_name} has no refresh token[/red]"
+            )
+            return False
+
+        try:
+            new_token = await auth_manager.refresh(rpc_url, cached)
+        except AuthenticationError as e:
+            if expected_failure:
+                self._report_expected_failure(str(e))
+                return True
+            console.print(f"[red]❌ Token refresh failed for {node_name}: {e}[/red]")
+            return False
+        except Exception as e:
+            if expected_failure:
+                self._report_expected_failure(str(e))
+                return True
+            console.print(f"[red]❌ Token refresh error for {node_name}: {e}[/red]")
+            return False
+
+        if expected_failure:
+            self._report_unexpected_success()
+
+        if not auth_manager.save_token(new_token, cache_node_name):
+            console.print(
+                f"[yellow]⚠️  Refreshed token for {node_name} but failed to "
+                f"write the token cache[/yellow]"
+            )
+
+        step_key = f"refresh_{node_name}"
+        workflow_results[step_key] = new_token.to_dict()
+        self._export_variables(new_token.to_dict(), node_name, dynamic_values)
+
+        console.print(f"[green]✓ Refreshed token for {node_name}[/green]")
+        return not expected_failure

--- a/merobox/commands/bootstrap/steps/refresh.py
+++ b/merobox/commands/bootstrap/steps/refresh.py
@@ -68,19 +68,28 @@ class RefreshStep(BaseStep):
             new_token = await auth_manager.refresh(rpc_url, cached)
         except AuthenticationError as e:
             if expected_failure:
+                # A negative test must assert an *auth* rejection, not pass just
+                # because the node was unreachable.
+                if self._is_connectivity_error(str(e)):
+                    console.print(
+                        f"[red]❌ Expected a refresh rejection but hit a "
+                        f"connectivity error for {node_name}: {e}[/red]"
+                    )
+                    return False
                 self._report_expected_failure(str(e))
                 return True
             console.print(f"[red]❌ Token refresh failed for {node_name}: {e}[/red]")
             return False
         except Exception as e:
-            if expected_failure:
-                self._report_expected_failure(str(e))
-                return True
+            # An unexpected exception is never proof of a refresh rejection.
             console.print(f"[red]❌ Token refresh error for {node_name}: {e}[/red]")
             return False
 
         if expected_failure:
+            # Refresh succeeded but the workflow asserted it should be rejected.
+            # Do NOT re-seed the cache or export — keep the prior token intact.
             self._report_unexpected_success()
+            return False
 
         if not auth_manager.save_token(new_token, cache_node_name):
             console.print(
@@ -93,4 +102,4 @@ class RefreshStep(BaseStep):
         self._export_variables(new_token.to_dict(), node_name, dynamic_values)
 
         console.print(f"[green]✓ Refreshed token for {node_name}[/green]")
-        return not expected_failure
+        return True

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -1,0 +1,154 @@
+"""
+WebSocket connect step executor for embedded-auth nodes.
+
+Opens a WebSocket subscription against a node's ``/ws`` endpoint and asserts the
+handshake outcome. WebSocket clients cannot set custom headers, so the JWT is
+passed via the ``?token=<jwt>`` query param (mirroring
+``core/scripts/test-websocket-auth.sh``).
+
+Use it two ways:
+- Positive: with a valid cached token (seeded by a prior ``login`` step) the
+  connect must succeed.
+- Negative: ``unauthenticated: true`` forces a no-token connect; combine with
+  ``expected_failure: true`` to assert the server rejects it (HTTP 401 on the
+  upgrade handshake).
+"""
+
+import asyncio
+from typing import Any, Optional
+
+import aiohttp
+
+from merobox.commands.auth import AuthManager
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.constants import DEFAULT_CONNECTION_TIMEOUT
+from merobox.commands.utils import console
+
+WS_ENDPOINT = "/ws"
+
+
+class WebSocketConnectStep(BaseStep):
+    """Open a WebSocket subscription and assert the handshake outcome.
+
+    Required fields: ``node``.
+
+    Optional fields:
+    - ``unauthenticated`` (bool): connect without attaching a token.
+    - ``expected_failure`` (bool): the step passes only if the connect is
+      rejected (use with ``unauthenticated: true`` for the negative case).
+    - ``token`` (str): explicit JWT to attach (supports ``{{placeholders}}``);
+      overrides the cached token.
+    - ``message`` (str): optional text frame to send once connected.
+    - ``timeout`` (number): handshake timeout in seconds.
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node"]
+
+    def _validate_field_types(self) -> None:
+        self._validate_string_field("node")
+        self._validate_boolean_field("unauthenticated", required=False)
+        self._validate_boolean_field("expected_failure", required=False)
+        self._validate_string_field("token", required=False)
+        self._validate_string_field("message", required=False)
+        self._validate_number_field("timeout", required=False, positive=True)
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        unauthenticated = bool(self.config.get("unauthenticated", False))
+        expected_failure = self._is_expected_failure()
+        message = self.config.get("message")
+        timeout = float(self.config.get("timeout", DEFAULT_CONNECTION_TIMEOUT))
+
+        try:
+            resolved = self._resolve_node(node_name)
+            if resolved:
+                rpc_url, cache_node_name = resolved.url, resolved.node_name
+            else:
+                rpc_url, cache_node_name = self._get_node_rpc_url(node_name), node_name
+        except Exception as e:
+            console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
+            return False
+
+        token = None
+        if not unauthenticated:
+            token = self._resolve_token(
+                cache_node_name, workflow_results, dynamic_values
+            )
+            if token is None:
+                console.print(
+                    f"[red]❌ No token available for {node_name}; run a 'login' "
+                    f"step first or set 'unauthenticated: true'[/red]"
+                )
+                return False
+
+        ws_url = self._build_ws_url(rpc_url, token)
+        display_url = self._build_ws_url(rpc_url, "***" if token else None)
+        console.print(f"[cyan]Opening WebSocket to {display_url}[/cyan]")
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                # Bound the upgrade handshake with asyncio.wait_for so the timeout
+                # works across aiohttp versions (ws_connect's timeout kwarg changed
+                # shape in 3.11).
+                ws = await asyncio.wait_for(session.ws_connect(ws_url), timeout)
+                try:
+                    if message is not None:
+                        resolved_message = self._resolve_dynamic_value(
+                            message, workflow_results, dynamic_values
+                        )
+                        await ws.send_str(resolved_message)
+                finally:
+                    await ws.close()
+        except (
+            aiohttp.WSServerHandshakeError,
+            aiohttp.ClientError,
+            asyncio.TimeoutError,
+        ) as e:
+            if expected_failure:
+                self._report_expected_failure(str(e))
+                return True
+            console.print(f"[red]❌ WebSocket connect to {node_name} failed: {e}[/red]")
+            return False
+        except Exception as e:
+            if expected_failure:
+                self._report_expected_failure(str(e))
+                return True
+            console.print(f"[red]❌ WebSocket connect to {node_name} error: {e}[/red]")
+            return False
+
+        if expected_failure:
+            self._report_unexpected_success()
+            return False
+
+        console.print(f"[green]✓ WebSocket connected to {node_name}[/green]")
+        return True
+
+    def _resolve_token(
+        self,
+        cache_node_name: str,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> Optional[str]:
+        """Resolve the JWT to attach: explicit ``token`` field wins, else cache."""
+        explicit = self.config.get("token")
+        if explicit:
+            return self._resolve_dynamic_value(
+                explicit, workflow_results, dynamic_values
+            )
+        cached = AuthManager().get_cached_token(cache_node_name)
+        return cached.access_token if cached else None
+
+    def _build_ws_url(self, rpc_url: str, token: Optional[str]) -> str:
+        """Build the ``ws(s)://host:port/ws[?token=...]`` URL from the RPC URL."""
+        base = rpc_url.rstrip("/")
+        if base.startswith("https://"):
+            base = "wss://" + base[len("https://") :]
+        elif base.startswith("http://"):
+            base = "ws://" + base[len("http://") :]
+        url = f"{base}{WS_ENDPOINT}"
+        if token:
+            url = f"{url}?token={token}"
+        return url

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -60,7 +60,14 @@ class WebSocketConnectStep(BaseStep):
         unauthenticated = bool(self.config.get("unauthenticated", False))
         expected_failure = self._is_expected_failure()
         message = self.config.get("message")
-        timeout = float(self.config.get("timeout", DEFAULT_CONNECTION_TIMEOUT))
+        # `timeout` is optional and may be explicitly null in YAML — fall back to
+        # the default rather than letting float(None) raise.
+        timeout_cfg = self.config.get("timeout")
+        timeout = (
+            float(timeout_cfg)
+            if timeout_cfg is not None
+            else float(DEFAULT_CONNECTION_TIMEOUT)
+        )
 
         try:
             resolved = self._resolve_node(node_name)
@@ -102,20 +109,24 @@ class WebSocketConnectStep(BaseStep):
                         await ws.send_str(resolved_message)
                 finally:
                     await ws.close()
-        except (
-            aiohttp.WSServerHandshakeError,
-            aiohttp.ClientError,
-            asyncio.TimeoutError,
-        ) as e:
+        except aiohttp.WSServerHandshakeError as e:
+            # The server rejected the upgrade handshake — the genuine auth signal.
+            # Only an auth status (401/403) proves a rejected-without-token test;
+            # other statuses are a real failure even under expected_failure.
             if expected_failure:
-                self._report_expected_failure(str(e))
-                return True
+                if e.status in (401, 403):
+                    self._report_expected_failure(str(e))
+                    return True
+                console.print(
+                    f"[red]❌ Expected a 401/403 auth rejection but the "
+                    f"{node_name} handshake returned HTTP {e.status}[/red]"
+                )
+                return False
             console.print(f"[red]❌ WebSocket connect to {node_name} failed: {e}[/red]")
             return False
-        except Exception as e:
-            if expected_failure:
-                self._report_expected_failure(str(e))
-                return True
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            # Connection refused / reset / timeout doesn't prove an auth
+            # rejection, so it never satisfies expected_failure.
             console.print(f"[red]❌ WebSocket connect to {node_name} error: {e}[/red]")
             return False
 

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -1,0 +1,308 @@
+"""
+Unit tests for the embedded-auth workflow steps: login, refresh, ws_connect.
+
+These exercise the step executors with the network layer (AuthManager /
+aiohttp) mocked, so they verify orchestration: token-cache seeding, output
+export, and the positive/negative (expected_failure / unauthenticated)
+branches.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from merobox.commands.auth import AuthenticationError, AuthToken
+from merobox.commands.bootstrap.steps.login import LoginStep
+from merobox.commands.bootstrap.steps.refresh import RefreshStep
+from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _manager():
+    """A manager whose RPC URL resolves to a fixed localhost port."""
+    manager = MagicMock()
+    manager.get_node_rpc_port.return_value = 2528
+    return manager
+
+
+def _token(access="acc.jwt.tok", refresh="ref.jwt.tok"):
+    return AuthToken(
+        access_token=access,
+        node_url="http://localhost:2528",
+        auth_method="user_password",
+        refresh_token=refresh,
+        username="alice",
+    )
+
+
+# =============================================================================
+# login
+# =============================================================================
+
+
+class TestLoginStep:
+    def _step(self, **extra):
+        config = {
+            "type": "login",
+            "name": "login",
+            "node": "calimero-node-1",
+            "username": "alice",
+            "password": "password123",
+            **extra,
+        }
+        return LoginStep(config, manager=_manager())
+
+    def test_login_seeds_cache_and_exports_token(self):
+        step = self._step(outputs={"access_token": "access_token"})
+        fake_auth = MagicMock()
+        fake_auth.authenticate = AsyncMock(return_value=_token())
+        fake_auth.save_token.return_value = True
+
+        dynamic = {}
+        with patch(
+            "merobox.commands.bootstrap.steps.login.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, dynamic))
+
+        assert result is True
+        fake_auth.authenticate.assert_awaited_once()
+        # Token cached under the stable node name.
+        fake_auth.save_token.assert_called_once()
+        assert fake_auth.save_token.call_args[0][1] == "calimero-node-1"
+        # Token material exported for downstream steps.
+        assert dynamic["access_token"] == "acc.jwt.tok"
+
+    def test_login_failure_fails_step(self):
+        step = self._step()
+        fake_auth = MagicMock()
+        fake_auth.authenticate = AsyncMock(side_effect=AuthenticationError("bad creds"))
+
+        with patch(
+            "merobox.commands.bootstrap.steps.login.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is False
+        fake_auth.save_token.assert_not_called()
+
+    def test_login_expected_failure_passes_on_rejection(self):
+        step = self._step(expected_failure=True)
+        fake_auth = MagicMock()
+        fake_auth.authenticate = AsyncMock(side_effect=AuthenticationError("bad creds"))
+
+        with patch(
+            "merobox.commands.bootstrap.steps.login.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is True
+        fake_auth.save_token.assert_not_called()
+
+    def test_login_expected_failure_but_success_fails(self):
+        step = self._step(expected_failure=True)
+        fake_auth = MagicMock()
+        fake_auth.authenticate = AsyncMock(return_value=_token())
+        fake_auth.save_token.return_value = True
+
+        with patch(
+            "merobox.commands.bootstrap.steps.login.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        # Asserted rejection but login succeeded -> step fails.
+        assert result is False
+
+
+# =============================================================================
+# refresh
+# =============================================================================
+
+
+class TestRefreshStep:
+    def _step(self, **extra):
+        config = {
+            "type": "refresh",
+            "name": "refresh",
+            "node": "calimero-node-1",
+            **extra,
+        }
+        return RefreshStep(config, manager=_manager())
+
+    def test_refresh_swaps_and_reseeds_token(self):
+        step = self._step(outputs={"access_token": "access_token"})
+        new = _token(access="new.acc.tok", refresh="new.ref.tok")
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = _token()
+        fake_auth.refresh = AsyncMock(return_value=new)
+        fake_auth.save_token.return_value = True
+
+        dynamic = {}
+        with patch(
+            "merobox.commands.bootstrap.steps.refresh.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, dynamic))
+
+        assert result is True
+        fake_auth.refresh.assert_awaited_once()
+        fake_auth.save_token.assert_called_once()
+        assert dynamic["access_token"] == "new.acc.tok"
+
+    def test_refresh_without_cached_token_fails(self):
+        step = self._step()
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = None
+
+        with patch(
+            "merobox.commands.bootstrap.steps.refresh.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is False
+
+    def test_refresh_expected_failure_passes_on_rejection(self):
+        step = self._step(expected_failure=True)
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = _token()
+        fake_auth.refresh = AsyncMock(
+            side_effect=AuthenticationError("expired refresh token")
+        )
+
+        with patch(
+            "merobox.commands.bootstrap.steps.refresh.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is True
+
+
+# =============================================================================
+# ws_connect
+# =============================================================================
+
+
+class _FakeWS:
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, msg):
+        self.sent.append(msg)
+
+    async def close(self):
+        pass
+
+
+class _FakeSession:
+    """Async-context-manager session whose ws_connect is configurable."""
+
+    def __init__(self, ws_connect):
+        self._ws_connect = ws_connect
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def ws_connect(self, url):
+        return self._ws_connect(url)
+
+
+class TestWebSocketConnectStep:
+    def _step(self, **extra):
+        config = {
+            "type": "ws_connect",
+            "name": "ws",
+            "node": "calimero-node-1",
+            **extra,
+        }
+        return WebSocketConnectStep(config, manager=_manager())
+
+    def test_ws_connects_with_cached_token(self):
+        step = self._step(message="ping")
+        captured = {}
+
+        async def ws_connect(url):
+            captured["url"] = url
+            return _FakeWS()
+
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = _token()
+
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.AuthManager",
+                return_value=fake_auth,
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+                return_value=_FakeSession(ws_connect),
+            ),
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is True
+        # JWT rides on the ?token= query param.
+        assert captured["url"] == "ws://localhost:2528/ws?token=acc.jwt.tok"
+
+    def test_ws_missing_token_fails(self):
+        step = self._step()
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = None
+
+        with patch(
+            "merobox.commands.bootstrap.steps.websocket.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is False
+
+    def test_ws_unauthenticated_rejected_is_expected_failure(self):
+        import aiohttp
+
+        step = self._step(unauthenticated=True, expected_failure=True)
+        captured = {}
+
+        async def ws_connect(url):
+            captured["url"] = url
+            raise aiohttp.WSServerHandshakeError(MagicMock(), MagicMock())
+
+        with patch(
+            "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+            return_value=_FakeSession(ws_connect),
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is True
+        # No token attached on the unauthenticated negative case.
+        assert captured["url"] == "ws://localhost:2528/ws"
+
+    def test_ws_unauthenticated_unexpected_success_fails(self):
+        step = self._step(unauthenticated=True, expected_failure=True)
+
+        async def ws_connect(url):
+            return _FakeWS()
+
+        with patch(
+            "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+            return_value=_FakeSession(ws_connect),
+        ):
+            result = _run(step.execute({}, {}))
+
+        # Asserted rejection but the connection succeeded -> step fails.
+        assert result is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -20,7 +20,21 @@ from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
 
 
 def _run(coro):
-    return asyncio.run(coro)
+    """Run a coroutine on a dedicated loop, leaving a fresh current loop behind.
+
+    `asyncio.run()` closes its loop and unsets the current one, which on
+    Python 3.11 makes a later bare `asyncio.get_event_loop()` raise
+    "no current event loop". Other unit-test modules in this suite still use
+    that legacy pattern, so we restore a usable current loop afterward rather
+    than poison shared state for tests that run after us.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 def _manager():

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -10,6 +10,7 @@ branches.
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from merobox.commands.auth import AuthenticationError, AuthToken
@@ -279,21 +280,25 @@ class _FakeSession:
         return self._ws_connect(url)
 
 
-def _handshake_error(status):
-    """Build an aiohttp.WSServerHandshakeError carrying an HTTP status."""
-    import aiohttp
-    import multidict
-    import yarl
+class _FakeHandshakeError(aiohttp.WSServerHandshakeError):
+    """A WSServerHandshakeError stand-in that carries a status.
 
-    request_info = aiohttp.RequestInfo(
-        yarl.URL("http://localhost:2528/ws"),
-        "GET",
-        multidict.CIMultiDictProxy(multidict.CIMultiDict()),
-        yarl.URL("http://localhost:2528/ws"),
-    )
-    return aiohttp.WSServerHandshakeError(
-        request_info, (), status=status, message="rejected"
-    )
+    The real ``ClientResponseError`` constructor and ``__str__`` reach into
+    ``request_info``/``message`` internals whose shape varies across aiohttp
+    versions. We skip the base ``__init__`` and override ``__str__`` so the
+    fixture is version-proof; it still matches ``except
+    aiohttp.WSServerHandshakeError`` (the step only reads ``.status``).
+    """
+
+    def __init__(self, status):
+        self.status = status
+
+    def __str__(self):
+        return f"handshake rejected with {self.status}"
+
+
+def _handshake_error(status):
+    return _FakeHandshakeError(status)
 
 
 class TestWebSocketConnectStep:

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -111,13 +111,36 @@ class TestLoginStep:
         fake_auth.authenticate = AsyncMock(return_value=_token())
         fake_auth.save_token.return_value = True
 
+        dynamic = {}
+        with patch(
+            "merobox.commands.bootstrap.steps.login.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, dynamic))
+
+        # Asserted rejection but login succeeded -> step fails AND must not
+        # seed the cache or export tokens (no stale credentials left behind).
+        assert result is False
+        fake_auth.save_token.assert_not_called()
+        assert dynamic == {}
+
+    def test_login_expected_failure_ignores_connectivity_error(self):
+        # A negative test must assert an auth rejection, not pass because the
+        # node was unreachable (AuthManager wraps both as AuthenticationError).
+        step = self._step(expected_failure=True)
+        fake_auth = MagicMock()
+        fake_auth.authenticate = AsyncMock(
+            side_effect=AuthenticationError(
+                "Network error during authentication: connection refused"
+            )
+        )
+
         with patch(
             "merobox.commands.bootstrap.steps.login.AuthManager",
             return_value=fake_auth,
         ):
             result = _run(step.execute({}, {}))
 
-        # Asserted rejection but login succeeded -> step fails.
         assert result is False
 
 
@@ -185,6 +208,44 @@ class TestRefreshStep:
 
         assert result is True
 
+    def test_refresh_expected_failure_but_success_does_not_reseed(self):
+        step = self._step(expected_failure=True)
+        new = _token(access="new.acc.tok")
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = _token()
+        fake_auth.refresh = AsyncMock(return_value=new)
+        fake_auth.save_token.return_value = True
+
+        dynamic = {}
+        with patch(
+            "merobox.commands.bootstrap.steps.refresh.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, dynamic))
+
+        # Asserted rejection but refresh succeeded -> fail and keep prior token.
+        assert result is False
+        fake_auth.save_token.assert_not_called()
+        assert dynamic == {}
+
+    def test_refresh_expected_failure_ignores_connectivity_error(self):
+        step = self._step(expected_failure=True)
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = _token()
+        fake_auth.refresh = AsyncMock(
+            side_effect=AuthenticationError(
+                "Network error during token refresh: timed out"
+            )
+        )
+
+        with patch(
+            "merobox.commands.bootstrap.steps.refresh.AuthManager",
+            return_value=fake_auth,
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is False
+
 
 # =============================================================================
 # ws_connect
@@ -216,6 +277,23 @@ class _FakeSession:
 
     def ws_connect(self, url):
         return self._ws_connect(url)
+
+
+def _handshake_error(status):
+    """Build an aiohttp.WSServerHandshakeError carrying an HTTP status."""
+    import aiohttp
+    import multidict
+    import yarl
+
+    request_info = aiohttp.RequestInfo(
+        yarl.URL("http://localhost:2528/ws"),
+        "GET",
+        multidict.CIMultiDictProxy(multidict.CIMultiDict()),
+        yarl.URL("http://localhost:2528/ws"),
+    )
+    return aiohttp.WSServerHandshakeError(
+        request_info, (), status=status, message="rejected"
+    )
 
 
 class TestWebSocketConnectStep:
@@ -269,14 +347,12 @@ class TestWebSocketConnectStep:
         assert result is False
 
     def test_ws_unauthenticated_rejected_is_expected_failure(self):
-        import aiohttp
-
         step = self._step(unauthenticated=True, expected_failure=True)
         captured = {}
 
         async def ws_connect(url):
             captured["url"] = url
-            raise aiohttp.WSServerHandshakeError(MagicMock(), MagicMock())
+            raise _handshake_error(401)
 
         with patch(
             "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
@@ -287,6 +363,52 @@ class TestWebSocketConnectStep:
         assert result is True
         # No token attached on the unauthenticated negative case.
         assert captured["url"] == "ws://localhost:2528/ws"
+
+    def test_ws_non_auth_handshake_status_fails_even_when_expected(self):
+        # A 500 (or any non-401/403) handshake error doesn't prove an auth
+        # rejection, so it must not satisfy expected_failure.
+        step = self._step(unauthenticated=True, expected_failure=True)
+
+        async def ws_connect(url):
+            raise _handshake_error(500)
+
+        with patch(
+            "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+            return_value=_FakeSession(ws_connect),
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is False
+
+    def test_ws_timeout_fails_even_when_expected(self):
+        # A connection timeout doesn't prove an auth rejection.
+        step = self._step(unauthenticated=True, expected_failure=True)
+
+        async def ws_connect(url):
+            raise asyncio.TimeoutError()
+
+        with patch(
+            "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+            return_value=_FakeSession(ws_connect),
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is False
+
+    def test_ws_null_timeout_falls_back_to_default(self):
+        # `timeout: null` in YAML must not blow up on float(None).
+        step = self._step(timeout=None, unauthenticated=True)
+
+        async def ws_connect(url):
+            return _FakeWS()
+
+        with patch(
+            "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+            return_value=_FakeSession(ws_connect),
+        ):
+            result = _run(step.execute({}, {}))
+
+        assert result is True
 
     def test_ws_unauthenticated_unexpected_success_fails(self):
         step = self._step(unauthenticated=True, expected_failure=True)

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -144,6 +144,76 @@ class TestValidateWorkflowStep:
         errors = config_module.validate_workflow_step(step, 0)
         assert len(errors) == 0
 
+    def test_valid_login_step(self, config_module):
+        """Test validation of a valid login step."""
+        step = {
+            "name": "Authenticate",
+            "type": "login",
+            "node": "calimero-node-1",
+            "username": "alice",
+            "password": "password123",
+            "outputs": {"token": "access_token"},
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert len(errors) == 0
+
+    def test_login_step_missing_credentials(self, config_module):
+        """Test that login requires username and password."""
+        step = {
+            "name": "Bad login",
+            "type": "login",
+            "node": "calimero-node-1",
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert any("username" in err.lower() for err in errors)
+        assert any("password" in err.lower() for err in errors)
+
+    def test_valid_refresh_step(self, config_module):
+        """Test validation of a valid refresh step."""
+        step = {"name": "Refresh", "type": "refresh", "node": "calimero-node-1"}
+        errors = config_module.validate_workflow_step(step, 0)
+        assert len(errors) == 0
+
+    def test_valid_ws_connect_step(self, config_module):
+        """Test validation of a valid ws_connect step (both positive and negative)."""
+        positive = {"name": "WS", "type": "ws_connect", "node": "calimero-node-1"}
+        negative = {
+            "name": "WS negative",
+            "type": "ws_subscribe",
+            "node": "calimero-node-1",
+            "unauthenticated": True,
+            "expected_failure": True,
+            "timeout": 5,
+        }
+        assert config_module.validate_workflow_step(positive, 0) == []
+        assert config_module.validate_workflow_step(negative, 0) == []
+
+    def test_ws_connect_rejects_non_positive_timeout(self, config_module):
+        """Test that ws_connect rejects a non-positive timeout."""
+        step = {
+            "name": "WS bad timeout",
+            "type": "ws_connect",
+            "node": "calimero-node-1",
+            "timeout": -1,
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert any("timeout" in err.lower() for err in errors)
+
+    def test_call_step_accepts_unauthenticated_flag(self, config_module):
+        """Test that the call step accepts the negative-auth flags."""
+        step = {
+            "name": "Unauthenticated call",
+            "type": "call",
+            "node": "calimero-node-1",
+            "context_id": "{{context_id}}",
+            "method": "get",
+            "args": {"key": "hello"},
+            "unauthenticated": True,
+            "expected_failure": True,
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert len(errors) == 0
+
     def test_missing_type_field(self, config_module):
         """Test that missing type field is detected."""
         step = {

--- a/workflow-examples/workflow-embedded-auth-example.yml
+++ b/workflow-examples/workflow-embedded-auth-example.yml
@@ -1,0 +1,135 @@
+name: "Embedded Auth Example (binary mode)"
+description: >
+  End-to-end exercise of merobox's embedded-auth support: bootstrap/login,
+  authenticated calls, negative (unauthenticated) asserts, WebSocket auth, and
+  the refresh flow. Runs a single native `merod` node with the auth router
+  mounted inside the node (no separate mero-auth container needed).
+
+# Embedded auth is only supported in binary/native mode (the auth router is
+# mounted inside merod itself). In Docker mode use `auth_service`/`auth_image`.
+no_docker: true
+
+# Enable the embedded auth router on the node (passes --auth-mode embedded to
+# merod). With no --auth-username/--auth-password on the CLI, the workflow drives
+# auth declaratively via the `login` step below.
+auth_mode: embedded
+
+nuke_on_start: true
+
+nodes:
+  count: 1
+  prefix: "calimero-node"
+  # `image` is a Docker-only hint; ignored in --no-docker mode but kept for compatibility.
+  image: "ghcr.io/calimero-network/merod:edge"
+
+steps:
+  - name: "Wait for node startup"
+    type: wait
+    seconds: 5
+    message: "Waiting for the embedded auth router to come up..."
+
+  # --- 1. Bootstrap / login -------------------------------------------------
+  # On a fresh node the FIRST POST /auth/token with user_password auto-creates a
+  # root key with ["admin"] permission — so this first login doubles as setup.
+  # It seeds ~/.merobox/auth_cache/{node}.json so downstream calls just work.
+  - name: "Authenticate as admin"
+    type: login
+    node: calimero-node-1
+    username: alice
+    password: password123
+    outputs:
+      access_token: access_token
+      refresh_token: refresh_token
+
+  # --- 2. Negative login: wrong credentials must be rejected ----------------
+  - name: "Reject bad credentials"
+    type: login
+    node: calimero-node-1
+    username: alice
+    password: wrong-password
+    expected_failure: true
+
+  # --- 3. Authenticated call (token auto-attached from the cache) -----------
+  - name: "Install application (authenticated)"
+    type: install_application
+    node: calimero-node-1
+    path: workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: "Create namespace (authenticated)"
+    type: create_namespace
+    node: calimero-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: "Create context (authenticated)"
+    type: create_context
+    node: calimero-node-1
+    application_id: "{{app_id}}"
+    group_id: "{{namespace_id}}"
+    outputs:
+      context_id: contextId
+
+  - name: "Set a value (authenticated)"
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: set
+    args:
+      key: hello
+      value: world
+
+  # --- 4. Negative call: no token must be rejected (401) --------------------
+  # `unauthenticated: true` forces a no-token request; `expected_failure: true`
+  # asserts the protected endpoint rejects it.
+  - name: "Unauthenticated call is rejected"
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: hello
+    unauthenticated: true
+    expected_failure: true
+
+  # --- 5. WebSocket auth ----------------------------------------------------
+  # Valid token (from the cache) -> connect succeeds. WS clients can't set
+  # headers, so the JWT rides on ?token=<jwt>.
+  - name: "WebSocket connects with a valid token"
+    type: ws_connect
+    node: calimero-node-1
+
+  # No token -> the upgrade handshake must be rejected.
+  - name: "WebSocket without a token is rejected"
+    type: ws_connect
+    node: calimero-node-1
+    unauthenticated: true
+    expected_failure: true
+
+  # --- 6. Refresh flow ------------------------------------------------------
+  # Swap the refresh token for a fresh access token and re-seed the cache.
+  - name: "Refresh the access token"
+    type: refresh
+    node: calimero-node-1
+    outputs:
+      access_token: access_token
+
+  # The refreshed token still authorizes calls.
+  - name: "Authenticated call after refresh"
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: hello
+
+stop_all_nodes: true
+nuke_on_end: true
+
+# How to run:
+#   merobox bootstrap run workflow-examples/workflow-embedded-auth-example.yml --no-docker
+#
+# (Requires a `merod` binary on PATH or via --binary-path.)

--- a/workflow-examples/workflow-websocket-auth-example.yml
+++ b/workflow-examples/workflow-websocket-auth-example.yml
@@ -1,0 +1,63 @@
+name: "WebSocket Auth Example (binary mode)"
+description: >
+  Focused exercise of WebSocket authentication against a node's embedded auth
+  router. A WS client cannot set custom headers, so the JWT is passed on the
+  `?token=<jwt>` query param. Mirrors core/scripts/test-websocket-auth.sh:
+  a valid token connects, no token is rejected on the upgrade handshake.
+
+# Embedded auth is only supported in binary/native mode (the auth router is
+# mounted inside merod itself).
+no_docker: true
+auth_mode: embedded
+
+nuke_on_start: true
+
+nodes:
+  count: 1
+  prefix: "calimero-node"
+  # `image` is a Docker-only hint; ignored in --no-docker mode but kept for compatibility.
+  image: "ghcr.io/calimero-network/merod:edge"
+
+steps:
+  - name: "Wait for node startup"
+    type: wait
+    seconds: 5
+    message: "Waiting for the embedded auth router to come up..."
+
+  # Bootstrap/login seeds ~/.merobox/auth_cache/{node}.json. On a fresh node the
+  # first POST /auth/token auto-creates a root key with ["admin"].
+  - name: "Authenticate as admin"
+    type: login
+    node: calimero-node-1
+    username: alice
+    password: password123
+
+  # Positive: a valid cached token (from the login above) -> connect succeeds.
+  # The token rides on ?token=<jwt> behind the scenes.
+  - name: "WebSocket connects with a valid token"
+    type: ws_connect
+    node: calimero-node-1
+    message: "ping"
+
+  # Negative: no token -> the server must reject the upgrade handshake.
+  - name: "WebSocket without a token is rejected"
+    type: ws_connect
+    node: calimero-node-1
+    unauthenticated: true
+    expected_failure: true
+
+  # You can also pass an explicit token instead of relying on the cache, e.g.
+  # to test a deliberately bad/expired token is rejected:
+  - name: "WebSocket with a bad token is rejected"
+    type: ws_subscribe
+    node: calimero-node-1
+    token: "not-a-real-jwt"
+    expected_failure: true
+
+stop_all_nodes: true
+nuke_on_end: true
+
+# How to run:
+#   merobox bootstrap run workflow-examples/workflow-websocket-auth-example.yml --no-docker
+#
+# (Requires a `merod` binary on PATH or via --binary-path.)


### PR DESCRIPTION
Closes #273.

Adds first-class **embedded-auth** support to merobox workflows so core can write declarative authenticated (and negative) e2e tests against `merod`'s embedded auth router (`--auth-mode embedded`, no separate `mero-auth` container). Companion: calimero-network/core#2641.

Most plumbing already existed (`AuthManager`, token cache, `auth_mode: embedded` wiring, `expected_failure` on `call`); what was missing was a way to *seed* the cache from a workflow and a WebSocket / negative-auth surface.

## New step types
- **`login`** — `POST /auth/token` (user_password), seeds `~/.merobox/auth_cache/{node}.json` so every downstream `call`/`execute`/`ws_connect` on that node is authenticated automatically. On a fresh node the first login auto-creates a root key with `["admin"]` (login == setup). Exports `access_token`/`refresh_token`. `expected_failure: true` asserts bad credentials are rejected.
- **`refresh`** — `POST /auth/refresh`, swaps the cached refresh token for a fresh access token and re-seeds the cache.
- **`ws_connect`** / **`ws_subscribe`** — opens a WebSocket against `/ws` with the JWT on the `?token=<jwt>` query param (WS clients can't set headers). Valid token connects; `unauthenticated: true` + `expected_failure: true` asserts the upgrade handshake is rejected. Mirrors `core/scripts/test-websocket-auth.sh`.

## Other changes
- `call`/`execute` gains **`unauthenticated: true`** to force a no-token request; pair with `expected_failure: true` to assert the 401.
- `auth_mode: embedded` no longer **requires** `--auth-username`/`--auth-password`. Omit them to drive auth declaratively via `login` steps; provide both to keep the legacy "auth every node up front" behavior. Supplying only one of the pair is now a validation error.
- Example workflow `workflow-examples/workflow-embedded-auth-example.yml` exercising bootstrap/login, authenticated calls, the unauthenticated negative assert, WebSocket auth (positive + negative), and refresh.
- `LLM.md` step-type docs, CHANGELOG, version bump `0.6.30 → 0.6.31`.

## Acceptance criteria
- [x] Workflow can start a node with embedded auth (binary `--auth-mode embedded`; Docker via existing `auth_service`/`auth_image`)
- [x] `login` step bootstraps/authenticates and seeds the token cache; downstream `execute` steps succeed authenticated
- [x] A step can assert an unauthenticated/bad-token call is rejected (401)
- [x] WS connect can be driven authenticated (valid token connects) and negatively (no token → rejected)
- [x] Example workflow demonstrating all of the above
- [ ] Released so core's `setup-merobox` action can pull the version with these step types — *follow-up on merge (tag/publish)*

## Tests
`merobox/tests/unit/test_auth_steps.py` (11 behavioral tests, network layer mocked) + 6 new schema-validation tests. All 124 in those modules pass; `black --check` and `ruff check` clean.

> Note: the pre-existing `test_expected_failure.py` failures seen locally are a Python 3.14 artifact (`asyncio.get_event_loop()` removed); CI targets py39–311 and the new tests use `asyncio.run()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication flows, token caching, and workflow execution paths used in e2e tests; changes are well-covered by unit tests but incorrect negative-test semantics could mask real failures.
> 
> **Overview**
> Merobox **0.6.33** adds declarative **embedded auth** for binary workflows (`auth_mode: embedded`): new steps **`login`**, **`refresh`**, and **`ws_connect`** / **`ws_subscribe`** authenticate against `merod`'s built-in router, write tokens to `~/.merobox/auth_cache/{node}.json`, and let later **`call`** steps attach JWTs automatically (WebSockets use `?token=`). **`call`** also gains **`unauthenticated: true`** for negative 401 tests alongside **`expected_failure`**.
> 
> CLI validation changes: **`--auth-username` / `--auth-password`** are optional when both omitted (workflows drive auth via **`login`**); supplying only one credential pair is now an error. Auth-step **`expected_failure`** is tightened so only real auth rejections pass—connectivity errors and non-401/403 WS handshakes fail the step, and a mistaken negative **`login`**/**`refresh`** does not pollute the cache.
> 
> Schema, executor wiring, **`LLM.md`**, **CHANGELOG**, example workflows under **`workflow-examples/`**, and unit tests in **`test_auth_steps.py`** accompany the bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ee49b33fc884068b6f275e6e878f19ab7e66d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->