### PR TITLE
feat(bootstrap): persist container logs when nodes are left running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.34] - 2026-06-03
+
+### Added
+
+- Container logs are now persisted to `data/container-logs/<name>.log` on every
+  `bootstrap run`, regardless of the `stop_all_nodes` setting. Previously logs
+  were only captured on the stop path, so workflows that leave nodes running
+  (`stop_all_nodes: false`, the default) — including Calimero core's parallel
+  e2e jobs — produced no collectable log artifacts, and failures had to be
+  diagnosed via an external bash docker-logs workaround. A one-shot dump now
+  runs in both the leave-running success branch and the failure-exit path
+  (before any stop/teardown), so success and failure runs both yield artifacts.
+  Closes calimero-network/merobox#207.
+
 ## [0.6.33] - 2026-06-03
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.33"
+__version__ = "0.6.34"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -408,6 +408,10 @@ class WorkflowExecutor:
                     console.print(
                         "[cyan]Nodes will continue running for future workflows[/cyan]"
                     )
+                    # Nodes are left running, so the stop path never captures
+                    # their logs. Dump them now so CI still collects
+                    # data/container-logs/*.log artifacts.
+                    self._export_node_logs()
                 # Tear down NAT-topology infra (boot-node, gateway,
                 # bridges) on success too. `stop_all_nodes` covers
                 # the client merods that the normal manager knows
@@ -720,9 +724,31 @@ class WorkflowExecutor:
         `_stop_nodes_on_failure` and silently skipped NAT teardown
         when `stop_all_nodes: false` was set.
         """
+        # Capture logs of whatever is still running BEFORE any stop, so
+        # failure artifacts survive even when `stop_all_nodes: false` leaves
+        # the cluster up (the stop path's own log capture never fires then).
+        self._export_node_logs()
         if stop_all_nodes:
             self._stop_nodes_on_failure()
         self._teardown_nat_topology_if_present()
+
+    def _export_node_logs(self) -> None:
+        """Persist logs of all running nodes to ``data/container-logs/``.
+
+        Best-effort and manager-agnostic: remote-only / dry-run paths reach
+        here with no Docker manager, in which case there is nothing to dump.
+        """
+        if self.manager is None or getattr(self.manager, "client", None) is None:
+            return
+        try:
+            count = self.manager.export_node_logs()
+            if count:
+                console.print(
+                    f"[cyan]📝 Exported logs for {count} node(s) to "
+                    f"data/container-logs/[/cyan]"
+                )
+        except Exception as e:
+            console.print(f"[yellow]⚠️  Failed to export node logs: {str(e)}[/yellow]")
 
     def _stop_nodes_on_failure(self) -> None:
         """

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -107,6 +107,30 @@ def _get_node_hostname(node_name: str) -> str:
     return node_name.replace("calimero-", "").replace("-", "")
 
 
+# Directory, relative to the workflow's working directory, where per-container
+# logs are persisted. Kept stable so CI can collect ``data/container-logs/*.log``
+# as build artifacts regardless of the ``stop_all_nodes`` setting.
+CONTAINER_LOG_DIR = os.path.join("data", "container-logs")
+
+
+def _dump_container_log(container, container_name: str, log_dir: str) -> bool:
+    """Write a single container's full log to ``<log_dir>/<name>.log``.
+
+    Best-effort: any Docker/IO error is swallowed and reported via the return
+    value so callers in shutdown paths never fail just because a log could not
+    be captured. ``timestamps=True`` matches the format used elsewhere so the
+    files are consistent whether written on stop or on a still-running dump.
+    """
+    try:
+        log_content = container.logs(timestamps=True).decode("utf-8", errors="replace")
+        log_file = os.path.join(log_dir, f"{container_name}.log")
+        with open(log_file, "w") as f:
+            f.write(log_content)
+        return True
+    except Exception:
+        return False
+
+
 class DockerManager(CleanupMixin):
     """Manages Calimero nodes in Docker containers."""
 
@@ -1768,20 +1792,12 @@ class DockerManager(CleanupMixin):
         # Phase 3: Capture logs, then stop and remove all containers in parallel
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
-        log_dir = os.path.join("data", "container-logs")
+        log_dir = CONTAINER_LOG_DIR
         os.makedirs(log_dir, exist_ok=True)
 
         def stop_one(container_name, container):
             # Capture logs before stopping
-            try:
-                log_content = container.logs(timestamps=True).decode(
-                    "utf-8", errors="replace"
-                )
-                log_file = os.path.join(log_dir, f"{container_name}.log")
-                with open(log_file, "w") as f:
-                    f.write(log_content)
-            except Exception:
-                pass
+            _dump_container_log(container, container_name, log_dir)
 
             try:
                 container.stop(timeout=stop_timeout)
@@ -1959,6 +1975,40 @@ class DockerManager(CleanupMixin):
             return [c.name for c in containers]
         except Exception:
             return []
+
+    def export_node_logs(self, node_names: Optional[list[str]] = None) -> int:
+        """Persist logs for the given (or all running) Calimero nodes.
+
+        Writes ``data/container-logs/<name>.log`` for each node without
+        stopping it, so workflows that leave nodes running
+        (``stop_all_nodes: false``) still produce collectable log artifacts.
+        The stop path captures logs of its own when nodes are torn down; this
+        method covers the cases where they are not.
+
+        Args:
+            node_names: Explicit container names to dump. When ``None``, all
+                currently running Calimero nodes are used.
+
+        Returns:
+            The number of node logs successfully written.
+        """
+        if node_names is None:
+            node_names = self.get_running_nodes()
+        if not node_names:
+            return 0
+
+        os.makedirs(CONTAINER_LOG_DIR, exist_ok=True)
+        written = 0
+        for name in node_names:
+            container = self.nodes.get(name)
+            if container is None:
+                try:
+                    container = self.client.containers.get(name)
+                except Exception:
+                    continue
+            if _dump_container_log(container, name, CONTAINER_LOG_DIR):
+                written += 1
+        return written
 
     def list_nodes(self) -> None:
         """List all running Calimero nodes and infrastructure."""

--- a/merobox/tests/unit/test_docker_manager.py
+++ b/merobox/tests/unit/test_docker_manager.py
@@ -1301,3 +1301,102 @@ def test_drain_timeout_zero_skips_drain_phase(mock_docker):
         manager.stop_all_nodes(stop_timeout=10)
 
     mock_sleep.assert_not_called()
+
+
+# --- export_node_logs (merobox#207): persist logs without stopping nodes -----
+
+
+def _logging_container(name, log_text):
+    """A MagicMock container whose `.logs()` returns `log_text` as bytes."""
+    c = MagicMock()
+    c.name = name
+    c.logs.return_value = log_text.encode("utf-8")
+    return c
+
+
+@patch("docker.from_env")
+def test_export_node_logs_writes_running_nodes(mock_docker, tmp_path, monkeypatch):
+    """With no explicit names, all running nodes are dumped to data/container-logs/."""
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    node = _logging_container("calimero-node-1", "hello from node-1")
+    # get_running_nodes() lists running calimero nodes; export then re-fetches
+    # each by name via containers.get().
+    client.containers.list.return_value = [node]
+    client.containers.get.return_value = node
+
+    monkeypatch.chdir(tmp_path)
+    written = manager.export_node_logs()
+
+    assert written == 1
+    log_file = tmp_path / "data" / "container-logs" / "calimero-node-1.log"
+    assert log_file.read_text() == "hello from node-1"
+    # Logs are captured with timestamps, matching the stop-path format.
+    node.logs.assert_called_once_with(timestamps=True)
+    # Node was never stopped — it is left running.
+    node.stop.assert_not_called()
+
+
+@patch("docker.from_env")
+def test_export_node_logs_explicit_names(mock_docker, tmp_path, monkeypatch):
+    """Explicit names bypass get_running_nodes and are fetched directly."""
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    node = _logging_container("calimero-node-2", "node-2 logs")
+    client.containers.get.return_value = node
+
+    monkeypatch.chdir(tmp_path)
+    written = manager.export_node_logs(["calimero-node-2"])
+
+    assert written == 1
+    assert (
+        tmp_path / "data" / "container-logs" / "calimero-node-2.log"
+    ).read_text() == "node-2 logs"
+    # No running-node discovery when names are supplied.
+    client.containers.list.assert_not_called()
+
+
+@patch("docker.from_env")
+def test_export_node_logs_no_running_nodes_returns_zero(
+    mock_docker, tmp_path, monkeypatch
+):
+    """No running nodes -> nothing written, returns 0, no directory churn."""
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    client.containers.list.return_value = []
+
+    monkeypatch.chdir(tmp_path)
+    assert manager.export_node_logs() == 0
+    assert not (tmp_path / "data" / "container-logs").exists()
+
+
+@patch("docker.from_env")
+def test_export_node_logs_skips_missing_container(mock_docker, tmp_path, monkeypatch):
+    """A name that can't be fetched is skipped without aborting the rest."""
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    good = _logging_container("calimero-node-1", "ok")
+
+    def get(name):
+        if name == "calimero-node-1":
+            return good
+        raise docker.errors.NotFound("gone")
+
+    client.containers.get.side_effect = get
+
+    monkeypatch.chdir(tmp_path)
+    written = manager.export_node_logs(["calimero-node-1", "calimero-node-missing"])
+
+    assert written == 1
+    assert (tmp_path / "data" / "container-logs" / "calimero-node-1.log").exists()
+    assert not (
+        tmp_path / "data" / "container-logs" / "calimero-node-missing.log"
+    ).exists()

--- a/merobox/tests/unit/test_executor_lifecycle.py
+++ b/merobox/tests/unit/test_executor_lifecycle.py
@@ -115,3 +115,36 @@ async def test_remote_only_workflow_has_no_manager_to_keep():
 
     with _stub_node_io(executor, has_local_nodes=False):
         assert await executor.execute_workflow() is True
+
+
+# --- merobox#207: logs persisted even when nodes are left running ------------
+
+
+@pytest.mark.asyncio
+async def test_logs_exported_when_nodes_left_running():
+    # stop_all_nodes:false -> stop path never runs, so Step 5 must dump logs
+    # itself (otherwise data/container-logs/ stays empty on success).
+    executor, manager = _make_executor(
+        {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": False}
+    )
+
+    with _stub_node_io(executor):
+        assert await executor.execute_workflow() is True
+
+    manager.export_node_logs.assert_called_once()
+    manager.stop_all_nodes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_logs_exported_on_failure_before_cleanup():
+    # On failure with stop_all_nodes:false the nodes are left up, so logs must
+    # still be captured for post-mortem before NAT teardown.
+    executor, manager = _make_executor(
+        {"name": "wf", "nodes": {"count": 1}, "stop_all_nodes": False}
+    )
+
+    with _stub_node_io(executor, steps_ok=False):
+        assert await executor.execute_workflow() is False
+
+    manager.export_node_logs.assert_called_once()
+    manager.stop_all_nodes.assert_not_called()


### PR DESCRIPTION
## Summary

Closes calimero-network/merobox#207. Unblocks calimero-network/core#2179.

merobox only wrote `data/container-logs/<name>.log` on the **stop** path. Workflows using `stop_all_nodes: false` (the default, and what core CI uses across its parallel e2e jobs) never persisted logs — the nodes are left running, so the stop path's log capture never fires. On failure there were no collectable log artifacts, which is why core#2177 added an external bash docker-logs watcher as a workaround.

This implements **Option A** from the issue: a one-shot log dump that writes per-container logs **without** stopping the nodes, regardless of `stop_all_nodes`.

## Changes

- **`manager.py`**
  - Extracted the inline log-write block out of `stop_one` into a shared module-level `_dump_container_log()` helper + a `CONTAINER_LOG_DIR` constant (single source of truth).
  - Added `DockerManager.export_node_logs(node_names=None)` — dumps logs for all running (or named) Calimero nodes without stopping them; returns the count written. Uses the same `timestamps=True` format as the stop path.
- **`bootstrap/run/executor.py`**
  - New `_export_node_logs()` wrapper (no-ops for remote-only / dry-run paths with no Docker manager).
  - Wired into Step 5's `stop_all_nodes: false` branch (success) and into `_handle_failure_exit` (before any stop/teardown), so both success and failure runs produce artifacts.

Best-effort throughout: missing/unfetchable containers and IO errors are skipped, not fatal.

## Follow-up (separate, in core)

Once this ships in a merobox release, core#2179 can bump the merobox dep in `setup-merobox/action.yml`, remove the bash docker-logs watcher from `e2e-rust-apps.yml`, and repoint the log artifact paths to `data/container-logs/`.

## Tests

- 4 new `export_node_logs` unit tests in `test_docker_manager.py` (running-node dump, explicit names, no-nodes→0, missing-container skip).
- 2 new executor tests in `test_executor_lifecycle.py` (logs exported on success-leave-running and on failure).
- Full affected suite green (61 passed); `ruff format --check` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort Docker log export for CI artifacts; no changes to auth, APIs, or node lifecycle beyond when logs are written.
> 
> **Overview**
> **Every `bootstrap run` now writes Docker node logs to `data/container-logs/<name>.log` even when nodes are left running** (`stop_all_nodes: false`, the default). Log capture used to happen only inside `stop_all_nodes`, so parallel e2e workflows often had nothing to upload on failure.
> 
> `DockerManager` gains **`export_node_logs()`** (dump running Calimero nodes without stopping) and a shared **`_dump_container_log` / `CONTAINER_LOG_DIR`** used by the existing stop path. **`WorkflowExecutor`** calls **`_export_node_logs()`** on the Step 5 leave-running success branch and at the start of **`_handle_failure_exit`** (before stop/teardown). Remote-only / no-Docker paths no-op; errors are best-effort.
> 
> Release **0.6.34** with changelog and unit tests for the manager and executor lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194cb67c3da3139e6537394f3a29df1acbe29605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->