### PR TITLE
fix(examples): align blob-upload + group-upgrade workflows with current merod

### DIFF
--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1075,9 +1075,10 @@ class UpdateGroupSettingsStepConfig(BaseStepConfig):
     type: Literal["update_group_settings"] = "update_group_settings"
     node: str = Field(..., description="Target node")
     group_id: str = Field(..., description="Group ID")
+    # The server accepts only 'automatic' or 'lazy-on-access'; the former
+    # 'coordinated' policy was removed and is now rejected on deserialize.
     upgrade_policy: Literal[
         "automatic",
-        "coordinated",
         "lazy",
         "lazy-on-access",
         "lazy_on_access",

--- a/merobox/commands/bootstrap/steps/group_governance.py
+++ b/merobox/commands/bootstrap/steps/group_governance.py
@@ -20,7 +20,7 @@ class UpdateGroupSettingsStep(BaseStep):
 
     def _validate_field_types(self) -> None:
         step_name = self.config.get(
-            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+            "name", f"Unnamed {self.config.get('type', 'Unknown')} step"
         )
         for field in ("node", "group_id", "upgrade_policy"):
             if not isinstance(self.config.get(field), str):
@@ -44,7 +44,7 @@ class UpdateGroupSettingsStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("update_group_settings failed", error=e)
+            result = fail(f"update_group_settings failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -80,7 +80,7 @@ class DetachContextFromGroupStep(BaseStep):
 
     def _validate_field_types(self) -> None:
         step_name = self.config.get(
-            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+            "name", f"Unnamed {self.config.get('type', 'Unknown')} step"
         )
         for field in ("node", "group_id", "context_id"):
             if not isinstance(self.config.get(field), str):
@@ -104,7 +104,7 @@ class DetachContextFromGroupStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("detach_context_from_group failed", error=e)
+            result = fail(f"detach_context_from_group failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -140,7 +140,7 @@ class SyncGroupStep(BaseStep):
 
     def _validate_field_types(self) -> None:
         step_name = self.config.get(
-            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+            "name", f"Unnamed {self.config.get('type', 'Unknown')} step"
         )
         for field in ("node", "group_id"):
             if not isinstance(self.config.get(field), str):
@@ -159,7 +159,7 @@ class SyncGroupStep(BaseStep):
             api_result = client.sync_group(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("sync_group failed", error=e)
+            result = fail(f"sync_group failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -1041,7 +1041,7 @@ class TestGroupGovernanceStepSchemas:
             "type": "update_group_settings",
             "node": "calimero-node-1",
             "group_id": "{{group_id}}",
-            "upgrade_policy": "coordinated",
+            "upgrade_policy": "automatic",
         }
         assert config_module.validate_workflow_step(step, 0) == []
 
@@ -1056,14 +1056,17 @@ class TestGroupGovernanceStepSchemas:
             assert config_module.validate_workflow_step(step, 0) == [], policy
 
     def test_invalid_update_group_settings_bad_policy(self, config_module):
-        step = {
-            "type": "update_group_settings",
-            "node": "calimero-node-1",
-            "group_id": "{{group_id}}",
-            "upgrade_policy": "eager",
-        }
-        errors = config_module.validate_workflow_step(step, 0)
-        assert any("upgrade_policy" in e.lower() for e in errors)
+        # 'coordinated' was removed from the server and must now be rejected at
+        # schema time alongside any other unknown policy.
+        for policy in ("eager", "coordinated"):
+            step = {
+                "type": "update_group_settings",
+                "node": "calimero-node-1",
+                "group_id": "{{group_id}}",
+                "upgrade_policy": policy,
+            }
+            errors = config_module.validate_workflow_step(step, 0)
+            assert any("upgrade_policy" in e.lower() for e in errors), policy
 
     def test_valid_detach_context_from_group(self, config_module):
         step = {

--- a/workflow-examples/workflow-blob-upload-example.yml
+++ b/workflow-examples/workflow-blob-upload-example.yml
@@ -91,7 +91,7 @@ steps:
     method: upload_file
     args:
       name: project-proposal.pdf
-      blob_id_str: "{{pdf_blob_id}}"
+      blob_id: "{{pdf_blob_id}}"
       size: "{{pdf_blob_size}}"
       mime_type: application/pdf
     outputs:
@@ -125,7 +125,7 @@ steps:
     method: upload_file
     args:
       name: screenshot.png
-      blob_id_str: "{{png_blob_id}}"
+      blob_id: "{{png_blob_id}}"
       size: "{{png_blob_size}}"
       mime_type: image/png
     outputs:
@@ -149,7 +149,7 @@ steps:
     method: upload_file
     args:
       name: readme.txt
-      blob_id_str: "{{txt_blob_id}}"
+      blob_id: "{{txt_blob_id}}"
       size: "{{txt_blob_size}}"
       mime_type: text/plain
     outputs:

--- a/workflow-examples/workflow-group-upgrade-example.yml
+++ b/workflow-examples/workflow-group-upgrade-example.yml
@@ -76,12 +76,14 @@ steps:
     type: wait
     seconds: 5
 
-  # Phase 3: Set upgrade policy to coordinated (synchronous upgrade)
-  - name: Set Upgrade Policy to Coordinated
+  # Phase 3: Set upgrade policy to automatic (upgrade all contexts immediately
+  # when the group target changes). The former 'coordinated' policy was removed
+  # from the server, which now accepts only 'automatic' or 'lazy-on-access'.
+  - name: Set Upgrade Policy to Automatic
     type: update_group_settings
     node: calimero-node-1
     group_id: '{{group_id}}'
-    upgrade_policy: coordinated
+    upgrade_policy: automatic
 
   # Phase 4: Initiate upgrade v1 -> v2
   - name: Upgrade Subgroup Application to v2


### PR DESCRIPTION
## Why

The `Docker (*-example)` matrix runs the example workflows against `merod:edge`, which drifted forward and broke two of them on the latest master run ([26880567597](https://github.com/calimero-network/merobox/actions/runs/26880567597)). These are informational jobs (the merge gate `test-merobox-integration` still passes), but the examples were genuinely broken against current core.

## Root causes

**`blob-upload-example`** — core renamed `upload_file`'s argument `blob_id_str` → `blob_id` (BlobId newtypes, core #2564) and now rejects unknown JSON-RPC method arguments (core #1646/#2598). The stale `blob_id_str` field hard-panicked on deserialize:
```
unknown field `blob_id_str`, expected one of `name`, `blob_id`, `size`, `mime_type`
```

**`group-upgrade-example`** — core removed the `Coordinated` upgrade policy (core #2585); the server now accepts only `Automatic`/`LazyOnAccess`. `calimero-client-py` still maps `coordinated` → the removed `Coordinated` wire value, so the server's `ValidatedJson` rejected it *before* the handler ran:
```
upgradePolicy: unknown variant `Coordinated`, expected `Automatic` or `LazyOnAccess`
```
The real error was also masked by the group-governance steps discarding the client exception.

## Changes

- `workflow-blob-upload-example.yml` — `blob_id_str:` → `blob_id:` (×3).
- `workflow-group-upgrade-example.yml` — `upgrade_policy: coordinated` → `automatic`, step renamed + comment.
- `bootstrap/config.py` — drop `coordinated` from the `upgrade_policy` schema so stale workflows fail fast at validation.
- `steps/group_governance.py` — surface the underlying client exception in `update_group_settings` / `detach_context_from_group` / `sync_group` (previously discarded, which masked the real error).
- `test_workflow_schema_validation.py` — valid test uses `automatic`; regression assert that `coordinated` is now rejected.

## Verification

- Both workflows run green end-to-end against a freshly pulled `merod:edge` (with `blobs.wasm`/`kv-store` built from current core).
- `113/113` schema unit tests pass; `ruff format`/`ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example YAML, workflow schema, and error-message tweaks only; no auth, security, or production runtime behavior changes beyond clearer failures.
> 
> **Overview**
> Updates **example workflows** and **bootstrap validation** so Docker example jobs pass against current `merod:edge`.
> 
> The blob-upload example now passes **`blob_id`** (not the removed **`blob_id_str`**) into `upload_file` on all three register steps. The group-upgrade example switches **`upgrade_policy`** from removed **`coordinated`** to **`automatic`**, with comments reflecting server-supported policies.
> 
> **`UpdateGroupSettingsStepConfig`** drops **`coordinated`** from the allowed `upgrade_policy` literals so invalid YAML fails at **`merobox validate`**. Group-governance steps (**`update_group_settings`**, **`detach_context_from_group`**, **`sync_group`**) include the underlying client exception in failure messages. Unit tests expect **`automatic`** as valid and reject **`coordinated`** alongside unknown policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfaef711753b20d59852f19aa8968a01459d5759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->