### PR TITLE
feat(bootstrap): partition_peers/heal_peers — surgical libp2p partition keeping RPC (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DOCKER-USER` iptables chain matched on the containers' bridge IPs; a CI /
   Linux primitive (needs iptables + passwordless sudo). `heal_peers` removes
   the rules (same args; idempotent). Closes calimero-network/merobox#278.
+  Behavioral coverage in `workflow-fault-injection-partition-peers-example.yml`
+  (Docker matrix): proves RPC stays up on the isolated node, the partition
+  actually blocks delivery, and heal restores it.
 
 ## [0.6.34] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.35] - 2026-06-04
+
 ### Added
 
 - New `partition_peers` / `heal_peers` workflow steps: a **surgical peer-pair

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `partition_peers` / `heal_peers` workflow steps: a **surgical peer-pair
+  network partition** that drops only container-to-container (libp2p) traffic
+  between a node and the listed peers, while leaving the node's published-port
+  RPC reachable. Unlike `disconnect_node` (which detaches the container from
+  its bridge and so also severs its RPC), this lets a workflow issue `call`s to
+  a node *while* it is partitioned from its peers — required for tests that
+  must drive both sides of a split (e.g. two nodes concurrently rotating a
+  SharedStorage writer set). Implemented as symmetric DROP rules in the host's
+  `DOCKER-USER` iptables chain matched on the containers' bridge IPs; a CI /
+  Linux primitive (needs iptables + passwordless sudo). `heal_peers` removes
+  the rules (same args; idempotent). Closes calimero-network/merobox#278.
+
 ## [0.6.34] - 2026-06-03
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.34"
+__version__ = "0.6.35"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -94,6 +94,8 @@ VALID_STEP_TYPES = frozenset(
         "restart_container",
         "disconnect_node",
         "connect_node",
+        "partition_peers",
+        "heal_peers",
         "inject_network_fault",
         "assert",
         "json_assert",
@@ -522,6 +524,35 @@ class ConnectNodeStepConfig(BaseStepConfig):
             "(the modern multi-node default); set explicitly for legacy / "
             "single-node setups that use Docker's default bridge."
         ),
+    )
+
+
+class PartitionPeersStepConfig(BaseStepConfig):
+    """Configuration for partition_peers step.
+
+    Cuts libp2p between ``node`` and each container in ``peers`` while keeping
+    every node RPC-reachable (unlike disconnect_node, which also severs the
+    node's published-port RPC). Linux + iptables + passwordless sudo only.
+    """
+
+    type: Literal["partition_peers"] = "partition_peers"
+    node: str = Field(..., description="Container to isolate from its peers")
+    peers: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Peer container(s) to cut this node's libp2p traffic to/from",
+    )
+
+
+class HealPeersStepConfig(BaseStepConfig):
+    """Configuration for heal_peers step — undoes a partition_peers (same args)."""
+
+    type: Literal["heal_peers"] = "heal_peers"
+    node: str = Field(..., description="Container to reconnect to its peers")
+    peers: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Peer container(s) whose libp2p partition to lift",
     )
 
 
@@ -1346,6 +1377,8 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "restart_container": RestartContainerStepConfig,
     "disconnect_node": DisconnectNodeStepConfig,
     "connect_node": ConnectNodeStepConfig,
+    "partition_peers": PartitionPeersStepConfig,
+    "heal_peers": HealPeersStepConfig,
     "inject_network_fault": InjectNetworkFaultStepConfig,
     "assert": AssertStep,
     "json_assert": JsonAssertStep,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -90,6 +90,8 @@ from merobox.commands.bootstrap.steps.mesh import CreateMeshStep
 from merobox.commands.bootstrap.steps.network import (
     ConnectNodeStep,
     DisconnectNodeStep,
+    HealPeersStep,
+    PartitionPeersStep,
 )
 from merobox.commands.bootstrap.steps.pause import (
     PauseContainerStep,
@@ -2124,6 +2126,10 @@ class WorkflowExecutor:
             return DisconnectNodeStep(step_config, **common_kwargs)
         elif step_type == "connect_node":
             return ConnectNodeStep(step_config, **common_kwargs)
+        elif step_type == "partition_peers":
+            return PartitionPeersStep(step_config, **common_kwargs)
+        elif step_type == "heal_peers":
+            return HealPeersStep(step_config, **common_kwargs)
         elif step_type == "inject_network_fault":
             return InjectNetworkFaultStep(step_config, **common_kwargs)
         elif step_type == "assert":

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -88,6 +88,8 @@ from merobox.commands.bootstrap.steps.namespace import (
 from merobox.commands.bootstrap.steps.network import (
     ConnectNodeStep,
     DisconnectNodeStep,
+    HealPeersStep,
+    PartitionPeersStep,
 )
 from merobox.commands.bootstrap.steps.parallel import ParallelStep
 from merobox.commands.bootstrap.steps.pause import (
@@ -147,6 +149,8 @@ __all__ = [
     "RestartContainerStep",
     "DisconnectNodeStep",
     "ConnectNodeStep",
+    "PartitionPeersStep",
+    "HealPeersStep",
     "InjectNetworkFaultStep",
     "AssertStep",
     "AssertLogAbsentStep",

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -238,8 +238,13 @@ def _ip_on_network(container: Any, network_name: str) -> str | None:
     if not ip:
         return None
     try:
-        ipaddress.ip_address(ip)
+        addr = ipaddress.ip_address(ip)
     except ValueError:
+        return None
+    # IPv4 only: these steps shell out to `iptables`, not `ip6tables`. A
+    # dual-stack/IPv6 endpoint would need the v6 chain, so refuse rather than
+    # hand iptables an address it will reject.
+    if not isinstance(addr, ipaddress.IPv4Address):
         return None
     return ip
 
@@ -389,8 +394,22 @@ class PartitionPeersStep(_PeerPartitionBase):
         inserted: list[tuple[str, str]] = []
 
         def rollback():
+            # Best-effort, but a rollback delete that fails for a non-benign
+            # reason (sudo revoked mid-run, iptables state changed) leaves a
+            # rule behind — surface which one so an operator can clean up.
             for s, d in inserted:
-                _iptables("-D", s, d)  # best-effort
+                res = _iptables("-D", s, d)
+                err = _iptables_err(res).lower()
+                if res.returncode != 0 and not any(
+                    benign in err for benign in _BENIGN_DELETE_ERRORS
+                ):
+                    safe_console_error(
+                        "⚠ partition_peers: rollback of {s} -> {d} failed; "
+                        "rule may persist: {out}",
+                        s=s,
+                        d=d,
+                        out=_iptables_err(res),
+                    )
 
         for peer_name, peer_ip in peers:
             console.print(
@@ -466,6 +485,19 @@ class HealPeersStep(_PeerPartitionBase):
                     )
                     ok = False
                     break
+                else:
+                    # Loop ran the full cap with every delete succeeding and
+                    # never hit "does not exist" — there are more duplicates
+                    # than the cap, or the rule is being re-added underneath us.
+                    # Don't claim a clean heal.
+                    safe_console_error(
+                        "✗ heal_peers: {src} -> {dst} still present after "
+                        "{n} deletes — rule may be re-added externally",
+                        src=src,
+                        dst=dst,
+                        n=str(_MAX_DUP_DELETES),
+                    )
+                    ok = False
 
         if ok:
             console.print(

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -20,6 +20,7 @@ Reconnect typically needs a few seconds for libp2p mesh reformation
 explicit `wait_for_sync` or short `wait` before asserting state propagation.
 """
 
+import ipaddress
 import subprocess
 from typing import Any
 
@@ -215,49 +216,84 @@ class ConnectNodeStep(BaseStep):
 # Docker-network fault steps — it is a CI / Linux primitive.
 
 _DOCKER_USER_CHAIN = "DOCKER-USER"
+# Bound on a wedged sudo/iptables call so the workflow can't hang.
+_IPTABLES_TIMEOUT_S = 30
+# Upper bound on delete-until-gone, so a stuck rule can't loop forever.
+_MAX_DUP_DELETES = 16
+# iptables stderr substrings that mean "the rule/chain isn't there" — i.e. the
+# benign already-healed case, as opposed to a real failure (sudo denied, etc.).
+_BENIGN_DELETE_ERRORS = ("does not exist", "no chain/target/match")
 
 
-def _container_bridge_ip(container: Any) -> str | None:
-    """First non-empty IPv4 across the container's attached networks.
+def _libp2p_ip(container: Any) -> str | None:
+    """The container's IPv4 on the network it uses for inter-node libp2p.
 
-    Works regardless of the network's name (merobox may use a custom bridge).
+    Resolves the IP on the network ``detect_node_network`` would partition
+    (merobox-cluster / calimero_web / the single attached bridge) rather than
+    whichever network Docker happened to list first — so on a multi-attached
+    (e.g. auth-mode) node the DROP rules target the subnet libp2p actually flows
+    on. Falls back to any attached IPv4 if the chosen network has none, and
+    validates the result. Returns None if no well-formed IPv4 is found.
     """
-    try:
-        container.reload()
-    except docker.errors.DockerException:
-        pass
+    # detect_node_network reloads the container and applies the priority rule.
+    network_name = detect_node_network(container)
     networks = container.attrs.get("NetworkSettings", {}).get("Networks", {}) or {}
-    for net in networks.values():
-        ip = net.get("IPAddress")
-        if ip:
-            return ip
-    return None
+    ip = (networks.get(network_name) or {}).get("IPAddress") or ""
+    if not ip:
+        for net in networks.values():
+            if net.get("IPAddress"):
+                ip = net["IPAddress"]
+                break
+    if not ip:
+        return None
+    try:
+        ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    return ip
 
 
-def _iptables_drop(action: str, src: str, dst: str) -> subprocess.CompletedProcess:
-    """Run one `iptables <action> DOCKER-USER -s src -d dst -j DROP` on the host.
+def _iptables(action: str, src: str, dst: str) -> subprocess.CompletedProcess:
+    """Run `iptables <action> DOCKER-USER -s src -d dst -j DROP` on the host.
 
-    `sudo -n` fails fast instead of prompting when sudo needs a password (so a
-    misconfigured host errors clearly rather than hanging the workflow).
+    `sudo -n` fails fast instead of prompting; `timeout` bounds a wedged
+    sudo/iptables; stdout and stderr are kept SEPARATE so a sudo auth error is
+    distinguishable from a "rule not found". A timeout surfaces as a synthetic
+    non-zero result rather than raising, so callers handle it uniformly.
     """
-    return subprocess.run(
-        [
-            "sudo",
-            "-n",
-            "iptables",
-            action,
-            _DOCKER_USER_CHAIN,
-            "-s",
-            src,
-            "-d",
-            dst,
-            "-j",
-            "DROP",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
+    argv = [
+        "sudo",
+        "-n",
+        "iptables",
+        action,
+        _DOCKER_USER_CHAIN,
+        "-s",
+        src,
+        "-d",
+        dst,
+        "-j",
+        "DROP",
+    ]
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_IPTABLES_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            argv,
+            returncode=124,
+            stdout="",
+            stderr=f"timed out after {_IPTABLES_TIMEOUT_S}s",
+        )
+
+
+def _iptables_err(result: subprocess.CompletedProcess) -> str:
+    """Combined, trimmed stdout+stderr from an iptables run (for diagnostics)."""
+    parts = [p.strip() for p in (result.stdout, result.stderr) if p and p.strip()]
+    return " ".join(parts)
 
 
 class _PeerPartitionBase(BaseStep):
@@ -275,10 +311,11 @@ class _PeerPartitionBase(BaseStep):
     def _resolve_ips(self, workflow_results, dynamic_values):
         """Resolve (node_name, node_ip, [(peer_name, peer_ip), ...]).
 
-        Returns None (after printing a diagnostic) if a container is missing or
-        has no bridge IP.
+        Returns None (after a diagnostic naming the step) if a container is
+        missing or has no usable libp2p IPv4.
         """
         client = get_docker_client(self.manager)
+        step_type = self.config.get("type", "partition_peers")
 
         def lookup(raw_name):
             name = self._resolve_dynamic_value(
@@ -287,11 +324,14 @@ class _PeerPartitionBase(BaseStep):
             try:
                 container = client.containers.get(name)
             except docker.errors.NotFound:
-                console.print(f"[red]✗ Container '{name}' not found[/red]")
+                console.print(f"[red]✗ {step_type}: container '{name}' not found[/red]")
                 return None, None
-            ip = _container_bridge_ip(container)
+            ip = _libp2p_ip(container)
             if not ip:
-                console.print(f"[red]✗ Could not resolve bridge IP for {name}[/red]")
+                console.print(
+                    f"[red]✗ {step_type}: could not resolve a libp2p IP "
+                    f"for {name}[/red]"
+                )
                 return name, None
             return name, ip
 
@@ -312,7 +352,11 @@ class PartitionPeersStep(_PeerPartitionBase):
     """Cut libp2p between ``node`` and each of ``peers`` while keeping RPC up.
 
     Inserts symmetric DROP rules into the host's DOCKER-USER chain on the
-    containers' bridge IPs. Heal with heal_peers (same args).
+    containers' libp2p IPs. **Idempotent**: a rule already present (checked with
+    ``iptables -C``) is not re-inserted, so re-runs don't accumulate duplicates.
+    On a partial failure the rules inserted by THIS call are rolled back before
+    returning, so the step never leaves a half-applied partition. Heal with
+    heal_peers (same args).
     """
 
     async def execute(
@@ -330,21 +374,33 @@ class PartitionPeersStep(_PeerPartitionBase):
             return False
         node_name, node_ip, peers = resolved
 
+        inserted: list[tuple[str, str]] = []
+
+        def rollback():
+            for s, d in inserted:
+                _iptables("-D", s, d)  # best-effort
+
         for peer_name, peer_ip in peers:
             console.print(
                 f"[yellow]Partitioning {node_name} ({node_ip}) <-x-> "
                 f"{peer_name} ({peer_ip}) — libp2p only, RPC stays up[/yellow]"
             )
             for src, dst in ((node_ip, peer_ip), (peer_ip, node_ip)):
-                result = _iptables_drop("-I", src, dst)
+                # Idempotent: skip if the DROP rule is already present.
+                if _iptables("-C", src, dst).returncode == 0:
+                    continue
+                result = _iptables("-I", src, dst)
                 if result.returncode != 0:
                     safe_console_error(
-                        "✗ iptables insert failed ({src} -> {dst}): {out}",
+                        "✗ partition_peers: iptables insert failed "
+                        "({src} -> {dst}): {out}",
                         src=src,
                         dst=dst,
-                        out=result.stdout.strip(),
+                        out=_iptables_err(result),
                     )
+                    rollback()
                     return False
+                inserted.append((src, dst))
 
         console.print(
             f"[green]✓ Partitioned {node_name} from {len(peers)} peer(s) "
@@ -356,8 +412,11 @@ class PartitionPeersStep(_PeerPartitionBase):
 class HealPeersStep(_PeerPartitionBase):
     """Remove the DROP rules a prior partition_peers added (same args).
 
-    Deleting a rule that is already gone is not an error, so the step is
-    idempotent and safe even after a partial partition.
+    For each direction the rule is deleted until iptables reports it is gone
+    (clearing any duplicates an interrupted/re-run workflow may have left). A
+    "rule does not exist" is the benign already-healed case; any OTHER iptables
+    failure (sudo denied, missing binary) fails the step, so a partition is
+    never silently reported as healed.
     """
 
     async def execute(
@@ -375,15 +434,29 @@ class HealPeersStep(_PeerPartitionBase):
             return False
         node_name, node_ip, peers = resolved
 
+        ok = True
         for peer_name, peer_ip in peers:
             console.print(f"[yellow]Healing {node_name} <--> {peer_name}[/yellow]")
             for src, dst in ((node_ip, peer_ip), (peer_ip, node_ip)):
-                result = _iptables_drop("-D", src, dst)
-                if result.returncode != 0:
-                    # A missing rule is the common, benign case (already healed).
-                    console.print(
-                        f"[dim]  no rule {src} -> {dst} to remove (already healed)[/dim]"
+                for _ in range(_MAX_DUP_DELETES):
+                    result = _iptables("-D", src, dst)
+                    if result.returncode == 0:
+                        continue  # removed one; retry in case of duplicates
+                    err = _iptables_err(result).lower()
+                    if any(benign in err for benign in _BENIGN_DELETE_ERRORS):
+                        break  # nothing (more) to remove — already healed
+                    safe_console_error(
+                        "✗ heal_peers: iptables delete failed "
+                        "({src} -> {dst}): {out}",
+                        src=src,
+                        dst=dst,
+                        out=_iptables_err(result),
                     )
+                    ok = False
+                    break
 
-        console.print(f"[green]✓ Healed {node_name} from {len(peers)} peer(s)[/green]")
-        return True
+        if ok:
+            console.print(
+                f"[green]✓ Healed {node_name} from {len(peers)} peer(s)[/green]"
+            )
+        return ok

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -249,6 +249,33 @@ def _ip_on_network(container: Any, network_name: str) -> str | None:
     return ip
 
 
+def _ensure_bridge_netfilter() -> None:
+    """Best-effort: make iptables actually filter bridged traffic.
+
+    Two containers on the SAME docker bridge (e.g. the default `docker0`, the
+    common merobox case) talk at L2 — their packets only traverse the iptables
+    FORWARD chain, where DOCKER-USER lives, when the kernel's `br_netfilter`
+    hook is active (`net.bridge.bridge-nf-call-iptables=1`). Docker normally
+    enables it, but it can be off on minimal/CI hosts, in which case our DROP
+    rules silently never see same-bridge libp2p traffic and the "partition"
+    is a no-op. Turn it on before inserting rules.
+
+    Failures are non-fatal: if sudo/modprobe/sysctl is unavailable the partition
+    attempt (and any behavioral assertions downstream) will surface a partition
+    that didn't bite, rather than this masking it.
+    """
+    for argv in (
+        ["sudo", "-n", "modprobe", "br_netfilter"],
+        ["sudo", "-n", "sysctl", "-w", "net.bridge.bridge-nf-call-iptables=1"],
+    ):
+        try:
+            subprocess.run(
+                argv, capture_output=True, text=True, timeout=_IPTABLES_TIMEOUT_S
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+
 def _iptables(action: str, src: str, dst: str) -> subprocess.CompletedProcess:
     """Run `iptables <action> DOCKER-USER -s src -d dst -j DROP` on the host.
 
@@ -385,6 +412,10 @@ class PartitionPeersStep(_PeerPartitionBase):
                 "container network to partition[/yellow]"
             )
             return True
+
+        # Without this, DROP rules don't bite same-bridge container pairs (the
+        # default docker0 case) because that traffic is L2-bridged.
+        _ensure_bridge_netfilter()
 
         resolved = self._resolve_ips(workflow_results, dynamic_values)
         if resolved is None:

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -225,25 +225,16 @@ _MAX_DUP_DELETES = 16
 _BENIGN_DELETE_ERRORS = ("does not exist", "no chain/target/match")
 
 
-def _libp2p_ip(container: Any) -> str | None:
-    """The container's IPv4 on the network it uses for inter-node libp2p.
+def _ip_on_network(container: Any, network_name: str) -> str | None:
+    """The container's validated IPv4 on a SPECIFIC Docker network.
 
-    Resolves the IP on the network ``detect_node_network`` would partition
-    (merobox-cluster / calimero_web / the single attached bridge) rather than
-    whichever network Docker happened to list first — so on a multi-attached
-    (e.g. auth-mode) node the DROP rules target the subnet libp2p actually flows
-    on. Falls back to any attached IPv4 if the chosen network has none, and
-    validates the result. Returns None if no well-formed IPv4 is found.
+    Reads `NetworkSettings.Networks[network_name].IPAddress` (caller is
+    responsible for a fresh `reload()`), so partition rules can be pinned to one
+    network that every endpoint shares — see `_resolve_ips`. Returns None if the
+    container isn't on that network or the IP is malformed.
     """
-    # detect_node_network reloads the container and applies the priority rule.
-    network_name = detect_node_network(container)
     networks = container.attrs.get("NetworkSettings", {}).get("Networks", {}) or {}
     ip = (networks.get(network_name) or {}).get("IPAddress") or ""
-    if not ip:
-        for net in networks.values():
-            if net.get("IPAddress"):
-                ip = net["IPAddress"]
-                break
     if not ip:
         return None
     try:
@@ -311,38 +302,59 @@ class _PeerPartitionBase(BaseStep):
     def _resolve_ips(self, workflow_results, dynamic_values):
         """Resolve (node_name, node_ip, [(peer_name, peer_ip), ...]).
 
-        Returns None (after a diagnostic naming the step) if a container is
-        missing or has no usable libp2p IPv4.
+        Picks the libp2p network ONCE from the node (via `detect_node_network`,
+        which applies the merobox-cluster / calimero_web / bridge priority) and
+        pins the node AND every peer to that same network. Resolving each
+        container independently could otherwise land the node and a peer on
+        different networks/subnets — DROP rules between IPs that don't share a
+        network are meaningless, so libp2p wouldn't actually be cut. A peer that
+        isn't on the node's network is a real misconfiguration and is rejected.
+
+        Returns None (after a diagnostic naming the step) on any miss.
         """
         client = get_docker_client(self.manager)
         step_type = self.config.get("type", "partition_peers")
 
-        def lookup(raw_name):
+        def get_container(raw_name):
             name = self._resolve_dynamic_value(
                 raw_name, workflow_results, dynamic_values
             )
             try:
-                container = client.containers.get(name)
+                return name, client.containers.get(name)
             except docker.errors.NotFound:
                 console.print(f"[red]✗ {step_type}: container '{name}' not found[/red]")
-                return None, None
-            ip = _libp2p_ip(container)
-            if not ip:
-                console.print(
-                    f"[red]✗ {step_type}: could not resolve a libp2p IP "
-                    f"for {name}[/red]"
-                )
                 return name, None
-            return name, ip
 
-        node_name, node_ip = lookup(self.config["node"])
-        if node_ip is None:
+        node_name, node_container = get_container(self.config["node"])
+        if node_container is None:
+            return None
+
+        # detect_node_network reloads the node and returns the network all
+        # endpoints must share for the partition to bite.
+        network = detect_node_network(node_container)
+        node_ip = _ip_on_network(node_container, network)
+        if not node_ip:
+            console.print(
+                f"[red]✗ {step_type}: {node_name} has no IPv4 on "
+                f"network '{network}'[/red]"
+            )
             return None
 
         peers = []
         for raw_peer in self.config["peers"]:
-            peer_name, peer_ip = lookup(raw_peer)
-            if peer_ip is None:
+            peer_name, peer_container = get_container(raw_peer)
+            if peer_container is None:
+                return None
+            try:
+                peer_container.reload()
+            except docker.errors.DockerException:
+                pass
+            peer_ip = _ip_on_network(peer_container, network)
+            if not peer_ip:
+                console.print(
+                    f"[red]✗ {step_type}: {peer_name} is not on {node_name}'s "
+                    f"network '{network}' — can't partition them[/red]"
+                )
                 return None
             peers.append((peer_name, peer_ip))
         return node_name, node_ip, peers

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -222,7 +222,17 @@ _IPTABLES_TIMEOUT_S = 30
 _MAX_DUP_DELETES = 16
 # iptables stderr substrings that mean "the rule/chain isn't there" — i.e. the
 # benign already-healed case, as opposed to a real failure (sudo denied, etc.).
-_BENIGN_DELETE_ERRORS = ("does not exist", "no chain/target/match")
+# `-D` on a missing rule is phrased differently across iptables versions/
+# backends, e.g. "Bad rule (does not exist that you attempted to delete)" and
+# "Bad rule (does a matching rule exist in that chain?)" — match both, plus the
+# missing-chain case. (A genuinely malformed spec yields a different message,
+# e.g. "Bad argument"/"unknown option".)
+_BENIGN_DELETE_ERRORS = (
+    "does not exist",
+    "matching rule",
+    "bad rule",
+    "no chain/target/match",
+)
 
 
 def _ip_on_network(container: Any, network_name: str) -> str | None:

--- a/merobox/commands/bootstrap/steps/network.py
+++ b/merobox/commands/bootstrap/steps/network.py
@@ -20,6 +20,7 @@ Reconnect typically needs a few seconds for libp2p mesh reformation
 explicit `wait_for_sync` or short `wait` before asserting state propagation.
 """
 
+import subprocess
 from typing import Any
 
 import docker.errors
@@ -190,4 +191,199 @@ class ConnectNodeStep(BaseStep):
         # out, and the partition never actually "heals" for libp2p. No-op
         # outside a NAT topology.
         reinject_nat_default_route(self.manager, node_name, context="post-reconnect")
+        return True
+
+
+# ── Surgical peer-pair partition (calimero-network/merobox#278) ──────────────
+#
+# disconnect_node detaches a container from its bridge, which also tears down
+# its published-port DNAT — so the partitioned node can't be `call`ed. That is
+# fine when a test only reads a partitioned node *after* reconnecting, but it
+# can't drive a node that must execute a call WHILE partitioned (e.g. two nodes
+# concurrently rotating a SharedStorage writer set).
+#
+# partition_peers instead drops only *container-to-container* (libp2p) traffic
+# between specific peers, via symmetric DROP rules in the host's DOCKER-USER
+# iptables chain matched on the containers' bridge IPs. DOCKER-USER is consulted
+# for forwarded traffic, so the peers' libp2p packets are dropped both ways;
+# host→container traffic for the published RPC port arrives via DNAT with a
+# non-container source IP, so it does not match these rules and RPC stays up.
+# The container keeps its interface, IP, and routing table intact.
+#
+# Requires a Linux host with iptables + passwordless sudo (GitHub-hosted runners
+# qualify); it is incompatible with Docker Desktop's VM, so — like the other
+# Docker-network fault steps — it is a CI / Linux primitive.
+
+_DOCKER_USER_CHAIN = "DOCKER-USER"
+
+
+def _container_bridge_ip(container: Any) -> str | None:
+    """First non-empty IPv4 across the container's attached networks.
+
+    Works regardless of the network's name (merobox may use a custom bridge).
+    """
+    try:
+        container.reload()
+    except docker.errors.DockerException:
+        pass
+    networks = container.attrs.get("NetworkSettings", {}).get("Networks", {}) or {}
+    for net in networks.values():
+        ip = net.get("IPAddress")
+        if ip:
+            return ip
+    return None
+
+
+def _iptables_drop(action: str, src: str, dst: str) -> subprocess.CompletedProcess:
+    """Run one `iptables <action> DOCKER-USER -s src -d dst -j DROP` on the host.
+
+    `sudo -n` fails fast instead of prompting when sudo needs a password (so a
+    misconfigured host errors clearly rather than hanging the workflow).
+    """
+    return subprocess.run(
+        [
+            "sudo",
+            "-n",
+            "iptables",
+            action,
+            _DOCKER_USER_CHAIN,
+            "-s",
+            src,
+            "-d",
+            dst,
+            "-j",
+            "DROP",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+class _PeerPartitionBase(BaseStep):
+    """Shared field validation + IP resolution for partition_peers / heal_peers."""
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "peers"]
+
+    def _validate_field_types(self) -> None:
+        self._validate_string_field("node")
+        self._validate_list_field(
+            "peers", required=True, allow_empty=False, element_type=str
+        )
+
+    def _resolve_ips(self, workflow_results, dynamic_values):
+        """Resolve (node_name, node_ip, [(peer_name, peer_ip), ...]).
+
+        Returns None (after printing a diagnostic) if a container is missing or
+        has no bridge IP.
+        """
+        client = get_docker_client(self.manager)
+
+        def lookup(raw_name):
+            name = self._resolve_dynamic_value(
+                raw_name, workflow_results, dynamic_values
+            )
+            try:
+                container = client.containers.get(name)
+            except docker.errors.NotFound:
+                console.print(f"[red]✗ Container '{name}' not found[/red]")
+                return None, None
+            ip = _container_bridge_ip(container)
+            if not ip:
+                console.print(f"[red]✗ Could not resolve bridge IP for {name}[/red]")
+                return name, None
+            return name, ip
+
+        node_name, node_ip = lookup(self.config["node"])
+        if node_ip is None:
+            return None
+
+        peers = []
+        for raw_peer in self.config["peers"]:
+            peer_name, peer_ip = lookup(raw_peer)
+            if peer_ip is None:
+                return None
+            peers.append((peer_name, peer_ip))
+        return node_name, node_ip, peers
+
+
+class PartitionPeersStep(_PeerPartitionBase):
+    """Cut libp2p between ``node`` and each of ``peers`` while keeping RPC up.
+
+    Inserts symmetric DROP rules into the host's DOCKER-USER chain on the
+    containers' bridge IPs. Heal with heal_peers (same args).
+    """
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        if is_binary_mode(self.manager):
+            console.print(
+                "[yellow]Skipping partition_peers: --no-docker mode has no "
+                "container network to partition[/yellow]"
+            )
+            return True
+
+        resolved = self._resolve_ips(workflow_results, dynamic_values)
+        if resolved is None:
+            return False
+        node_name, node_ip, peers = resolved
+
+        for peer_name, peer_ip in peers:
+            console.print(
+                f"[yellow]Partitioning {node_name} ({node_ip}) <-x-> "
+                f"{peer_name} ({peer_ip}) — libp2p only, RPC stays up[/yellow]"
+            )
+            for src, dst in ((node_ip, peer_ip), (peer_ip, node_ip)):
+                result = _iptables_drop("-I", src, dst)
+                if result.returncode != 0:
+                    safe_console_error(
+                        "✗ iptables insert failed ({src} -> {dst}): {out}",
+                        src=src,
+                        dst=dst,
+                        out=result.stdout.strip(),
+                    )
+                    return False
+
+        console.print(
+            f"[green]✓ Partitioned {node_name} from {len(peers)} peer(s) "
+            f"(libp2p dropped; RPC reachable)[/green]"
+        )
+        return True
+
+
+class HealPeersStep(_PeerPartitionBase):
+    """Remove the DROP rules a prior partition_peers added (same args).
+
+    Deleting a rule that is already gone is not an error, so the step is
+    idempotent and safe even after a partial partition.
+    """
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        if is_binary_mode(self.manager):
+            console.print(
+                "[yellow]Skipping heal_peers: --no-docker mode has no "
+                "container network to heal[/yellow]"
+            )
+            return True
+
+        resolved = self._resolve_ips(workflow_results, dynamic_values)
+        if resolved is None:
+            return False
+        node_name, node_ip, peers = resolved
+
+        for peer_name, peer_ip in peers:
+            console.print(f"[yellow]Healing {node_name} <--> {peer_name}[/yellow]")
+            for src, dst in ((node_ip, peer_ip), (peer_ip, node_ip)):
+                result = _iptables_drop("-D", src, dst)
+                if result.returncode != 0:
+                    # A missing rule is the common, benign case (already healed).
+                    console.print(
+                        f"[dim]  no rule {src} -> {dst} to remove (already healed)[/dim]"
+                    )
+
+        console.print(f"[green]✓ Healed {node_name} from {len(peers)} peer(s)[/green]")
         return True

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -77,6 +77,8 @@ from merobox.commands.bootstrap.steps.namespace import (
 from merobox.commands.bootstrap.steps.network import (
     ConnectNodeStep,
     DisconnectNodeStep,
+    HealPeersStep,
+    PartitionPeersStep,
 )
 from merobox.commands.bootstrap.steps.parallel import ParallelStep
 from merobox.commands.bootstrap.steps.pause import (
@@ -334,6 +336,10 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = DisconnectNodeStep
         elif step_type == "connect_node":
             step_class = ConnectNodeStep
+        elif step_type == "partition_peers":
+            step_class = PartitionPeersStep
+        elif step_type == "heal_peers":
+            step_class = HealPeersStep
         elif step_type == "inject_network_fault":
             step_class = InjectNetworkFaultStep
         else:

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -16,6 +16,8 @@ from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.network import (
     ConnectNodeStep,
     DisconnectNodeStep,
+    HealPeersStep,
+    PartitionPeersStep,
 )
 from merobox.commands.bootstrap.steps.pause import (
     PauseContainerStep,
@@ -820,3 +822,140 @@ class TestConnectNodeReinjectsRoute:
         assert ok is True
         # The reconnected node, tagged with the post-reconnect context.
         assert reinjected == [("sync-resil-node-2", "post-reconnect")], reinjected
+
+
+class TestPartitionPeersValidation:
+    def test_partition_minimal(self):
+        PartitionPeersStep(
+            {"type": "partition_peers", "node": "node-2", "peers": ["node-1"]}
+        )
+
+    def test_heal_minimal(self):
+        HealPeersStep(
+            {"type": "heal_peers", "node": "node-2", "peers": ["node-1", "node-3"]}
+        )
+
+    def test_missing_node_rejected(self):
+        with pytest.raises(ValueError, match="node"):
+            PartitionPeersStep({"type": "partition_peers", "peers": ["node-1"]})
+
+    def test_missing_peers_rejected(self):
+        with pytest.raises(ValueError, match="peers"):
+            PartitionPeersStep({"type": "partition_peers", "node": "node-2"})
+
+    def test_empty_peers_rejected(self):
+        with pytest.raises(ValueError, match="peers"):
+            PartitionPeersStep(
+                {"type": "partition_peers", "node": "node-2", "peers": []}
+            )
+
+
+class _FakeContainer:
+    def __init__(self, ip):
+        self.attrs = {
+            "NetworkSettings": {"Networks": {"merobox-cluster": {"IPAddress": ip}}}
+        }
+
+    def reload(self):
+        return None
+
+
+def _fake_client(ips: dict):
+    """Docker client stub whose containers.get(name) yields a container at ips[name]."""
+
+    class _Client:
+        class containers:
+            @staticmethod
+            def get(name):
+                return _FakeContainer(ips[name])
+
+    return _Client()
+
+
+def _capture_iptables(monkeypatch):
+    """Patch network_mod.subprocess.run, returning the captured argv lists."""
+    calls: list[list[str]] = []
+
+    class _Completed:
+        returncode = 0
+        stdout = ""
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(argv)
+        return _Completed()
+
+    monkeypatch.setattr(network_mod.subprocess, "run", _fake_run)
+    return calls
+
+
+class TestPartitionPeersExecute:
+    @pytest.mark.asyncio
+    async def test_partition_inserts_symmetric_drops_keeps_rpc(self, monkeypatch):
+        monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
+        monkeypatch.setattr(
+            network_mod,
+            "get_docker_client",
+            lambda _m: _fake_client(
+                {"node-2": "10.0.0.2", "node-1": "10.0.0.1", "node-3": "10.0.0.3"}
+            ),
+        )
+        calls = _capture_iptables(monkeypatch)
+
+        step = PartitionPeersStep(
+            {"type": "partition_peers", "node": "node-2", "peers": ["node-1", "node-3"]}
+        )
+        step.manager = object()
+        ok = await step.execute({}, {})
+        assert ok is True
+
+        # Symmetric DROP into DOCKER-USER for each peer, both directions.
+        drops = {
+            (a[a.index("-s") + 1], a[a.index("-d") + 1])
+            for a in calls
+            if "DOCKER-USER" in a and "-I" in a
+        }
+        assert drops == {
+            ("10.0.0.2", "10.0.0.1"),
+            ("10.0.0.1", "10.0.0.2"),
+            ("10.0.0.2", "10.0.0.3"),
+            ("10.0.0.3", "10.0.0.2"),
+        }
+        # Inserts, not deletes (partition adds rules).
+        assert all("-I" in a and "-D" not in a for a in calls)
+        # No rule ever matches a non-container source (RPC path is untouched).
+        assert all(a.index("-j") and a[-1] == "DROP" for a in calls)
+
+    @pytest.mark.asyncio
+    async def test_heal_deletes_the_same_rules(self, monkeypatch):
+        monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
+        monkeypatch.setattr(
+            network_mod,
+            "get_docker_client",
+            lambda _m: _fake_client({"node-2": "10.0.0.2", "node-1": "10.0.0.1"}),
+        )
+        calls = _capture_iptables(monkeypatch)
+
+        step = HealPeersStep(
+            {"type": "heal_peers", "node": "node-2", "peers": ["node-1"]}
+        )
+        step.manager = object()
+        ok = await step.execute({}, {})
+        assert ok is True
+
+        # Two deletes (both directions), mirroring the partition inserts.
+        assert all("-D" in a and "-I" not in a for a in calls)
+        deletes = {(a[a.index("-s") + 1], a[a.index("-d") + 1]) for a in calls}
+        assert deletes == {("10.0.0.2", "10.0.0.1"), ("10.0.0.1", "10.0.0.2")}
+
+    @pytest.mark.asyncio
+    async def test_binary_mode_is_a_no_op(self, monkeypatch):
+        monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: True)
+        calls = _capture_iptables(monkeypatch)
+
+        step = PartitionPeersStep(
+            {"type": "partition_peers", "node": "node-2", "peers": ["node-1"]}
+        )
+        step.manager = object()
+        ok = await step.execute({}, {})
+        assert ok is True
+        assert calls == []  # no iptables touched without Docker

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -880,21 +880,29 @@ class _IptablesResult:
 
 
 def _capture_iptables(
-    monkeypatch, *, check_returncode=1, fail_action=None, fail_on=1, fail_stderr="boom"
+    monkeypatch,
+    *,
+    check_returncode=1,
+    fail_action=None,
+    fail_on=1,
+    fail_stderr="boom",
+    delete_succeeds=1,
 ):
     """Patch network_mod._iptables and record (action, src, dst) per call.
 
     Simulates iptables without touching the host:
     - ``-C`` returns ``check_returncode`` (default 1 = "rule not present", so a
       partition proceeds to ``-I``; pass 0 to simulate an existing rule).
-    - ``-D`` returns 0 the first time a given (src,dst) is deleted, then a benign
-      "does not exist" — so heal's delete-until-gone removes one copy and stops.
+    - ``-D`` returns 0 for the first ``delete_succeeds`` calls per (src,dst),
+      then a benign "does not exist" — so heal's delete-until-gone removes that
+      many copies and stops. ``delete_succeeds=None`` makes ``-D`` ALWAYS succeed
+      (to exercise the _MAX_DUP_DELETES cap).
     - ``-I`` (and anything else) returns 0.
     - If ``fail_action`` is set, the ``fail_on``-th call of that action returns a
       non-zero result carrying ``fail_stderr`` (to exercise failure paths).
     """
     calls: list[tuple[str, str, str]] = []
-    deleted: set = set()
+    delete_counts: dict = {}
     counts: dict = {}
 
     def _fake_iptables(action, src, dst):
@@ -905,13 +913,14 @@ def _capture_iptables(
         if action == "-C":
             return _IptablesResult(check_returncode)
         if action == "-D":
-            if (src, dst) in deleted:
-                return _IptablesResult(
-                    1,
-                    "iptables: Bad rule (does not exist that you attempted to delete)",
-                )
-            deleted.add((src, dst))
-            return _IptablesResult(0)
+            n = delete_counts.get((src, dst), 0)
+            delete_counts[(src, dst)] = n + 1
+            if delete_succeeds is None or n < delete_succeeds:
+                return _IptablesResult(0)
+            return _IptablesResult(
+                1,
+                "iptables: Bad rule (does not exist that you attempted to delete)",
+            )
         return _IptablesResult(0)  # -I
 
     monkeypatch.setattr(network_mod, "_iptables", _fake_iptables)
@@ -1006,6 +1015,35 @@ class TestPartitionPeersExecute:
         ok = await _step(HealPeersStep, ["node-1"]).execute({}, {})
         assert ok is False
         assert any(a == "-D" for (a, _s, _d) in calls)
+
+    @pytest.mark.asyncio
+    async def test_heal_clears_duplicate_rules(self, monkeypatch):
+        _patch_docker(monkeypatch, {"node-2": "10.0.0.2", "node-1": "10.0.0.1"})
+        # Two duplicate rules per direction (e.g. left by crashed re-runs): heal
+        # must delete BOTH copies, then stop on the benign "does not exist".
+        calls = _capture_iptables(monkeypatch, delete_succeeds=2)
+
+        ok = await _step(HealPeersStep, ["node-1"]).execute({}, {})
+        assert ok is True
+        # Per direction: 2 successful deletes + 1 benign-stop = 3 calls.
+        per_dir = {}
+        for _a, s, d in calls:
+            per_dir[(s, d)] = per_dir.get((s, d), 0) + 1
+        assert per_dir == {("10.0.0.2", "10.0.0.1"): 3, ("10.0.0.1", "10.0.0.2"): 3}
+
+    @pytest.mark.asyncio
+    async def test_heal_fails_if_rule_never_clears(self, monkeypatch):
+        _patch_docker(monkeypatch, {"node-2": "10.0.0.2", "node-1": "10.0.0.1"})
+        # -D always reports success (rule keeps reappearing / buggy iptables):
+        # the delete-until-gone loop hits its cap and must NOT claim a clean heal.
+        calls = _capture_iptables(monkeypatch, delete_succeeds=None)
+
+        ok = await _step(HealPeersStep, ["node-1"]).execute({}, {})
+        assert ok is False
+        # Bounded by _MAX_DUP_DELETES per direction (no infinite loop).
+        from merobox.commands.bootstrap.steps.network import _MAX_DUP_DELETES
+
+        assert sum(1 for (a, _s, _d) in calls if a == "-D") == 2 * _MAX_DUP_DELETES
 
     @pytest.mark.asyncio
     async def test_binary_mode_is_a_no_op(self, monkeypatch):

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -930,6 +930,8 @@ def _capture_iptables(
 def _patch_docker(monkeypatch, ips):
     monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
     monkeypatch.setattr(network_mod, "get_docker_client", lambda _m: _fake_client(ips))
+    # Don't run real `sudo modprobe/sysctl` from unit tests.
+    monkeypatch.setattr(network_mod, "_ensure_bridge_netfilter", lambda: None)
 
 
 def _step(cls, peers):

--- a/merobox/tests/unit/test_fault_injection_steps.py
+++ b/merobox/tests/unit/test_fault_injection_steps.py
@@ -872,90 +872,146 @@ def _fake_client(ips: dict):
     return _Client()
 
 
-def _capture_iptables(monkeypatch):
-    """Patch network_mod.subprocess.run, returning the captured argv lists."""
-    calls: list[list[str]] = []
+class _IptablesResult:
+    def __init__(self, returncode, stderr=""):
+        self.returncode = returncode
+        self.stdout = ""
+        self.stderr = stderr
 
-    class _Completed:
-        returncode = 0
-        stdout = ""
 
-    def _fake_run(argv, **_kwargs):
-        calls.append(argv)
-        return _Completed()
+def _capture_iptables(
+    monkeypatch, *, check_returncode=1, fail_action=None, fail_on=1, fail_stderr="boom"
+):
+    """Patch network_mod._iptables and record (action, src, dst) per call.
 
-    monkeypatch.setattr(network_mod.subprocess, "run", _fake_run)
+    Simulates iptables without touching the host:
+    - ``-C`` returns ``check_returncode`` (default 1 = "rule not present", so a
+      partition proceeds to ``-I``; pass 0 to simulate an existing rule).
+    - ``-D`` returns 0 the first time a given (src,dst) is deleted, then a benign
+      "does not exist" — so heal's delete-until-gone removes one copy and stops.
+    - ``-I`` (and anything else) returns 0.
+    - If ``fail_action`` is set, the ``fail_on``-th call of that action returns a
+      non-zero result carrying ``fail_stderr`` (to exercise failure paths).
+    """
+    calls: list[tuple[str, str, str]] = []
+    deleted: set = set()
+    counts: dict = {}
+
+    def _fake_iptables(action, src, dst):
+        calls.append((action, src, dst))
+        counts[action] = counts.get(action, 0) + 1
+        if action == fail_action and counts[action] == fail_on:
+            return _IptablesResult(1, fail_stderr)
+        if action == "-C":
+            return _IptablesResult(check_returncode)
+        if action == "-D":
+            if (src, dst) in deleted:
+                return _IptablesResult(
+                    1,
+                    "iptables: Bad rule (does not exist that you attempted to delete)",
+                )
+            deleted.add((src, dst))
+            return _IptablesResult(0)
+        return _IptablesResult(0)  # -I
+
+    monkeypatch.setattr(network_mod, "_iptables", _fake_iptables)
     return calls
+
+
+def _patch_docker(monkeypatch, ips):
+    monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
+    monkeypatch.setattr(network_mod, "get_docker_client", lambda _m: _fake_client(ips))
+
+
+def _step(cls, peers):
+    step = cls({"type": cls.__name__, "node": "node-2", "peers": peers})
+    step.manager = object()
+    return step
 
 
 class TestPartitionPeersExecute:
     @pytest.mark.asyncio
     async def test_partition_inserts_symmetric_drops_keeps_rpc(self, monkeypatch):
-        monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
-        monkeypatch.setattr(
-            network_mod,
-            "get_docker_client",
-            lambda _m: _fake_client(
-                {"node-2": "10.0.0.2", "node-1": "10.0.0.1", "node-3": "10.0.0.3"}
-            ),
+        _patch_docker(
+            monkeypatch,
+            {"node-2": "10.0.0.2", "node-1": "10.0.0.1", "node-3": "10.0.0.3"},
         )
         calls = _capture_iptables(monkeypatch)
 
-        step = PartitionPeersStep(
-            {"type": "partition_peers", "node": "node-2", "peers": ["node-1", "node-3"]}
-        )
-        step.manager = object()
-        ok = await step.execute({}, {})
+        ok = await _step(PartitionPeersStep, ["node-1", "node-3"]).execute({}, {})
         assert ok is True
 
-        # Symmetric DROP into DOCKER-USER for each peer, both directions.
-        drops = {
-            (a[a.index("-s") + 1], a[a.index("-d") + 1])
-            for a in calls
-            if "DOCKER-USER" in a and "-I" in a
-        }
-        assert drops == {
+        # Symmetric DROP inserted for each peer, both directions.
+        inserts = {(s, d) for (a, s, d) in calls if a == "-I"}
+        assert inserts == {
             ("10.0.0.2", "10.0.0.1"),
             ("10.0.0.1", "10.0.0.2"),
             ("10.0.0.2", "10.0.0.3"),
             ("10.0.0.3", "10.0.0.2"),
         }
-        # Inserts, not deletes (partition adds rules).
-        assert all("-I" in a and "-D" not in a for a in calls)
-        # No rule ever matches a non-container source (RPC path is untouched).
-        assert all(a.index("-j") and a[-1] == "DROP" for a in calls)
+        # Each insert is preceded by an existence check (idempotency probe).
+        assert sum(1 for (a, _s, _d) in calls if a == "-C") == 4
+        # A successful partition never deletes (no rollback).
+        assert all(a != "-D" for (a, _s, _d) in calls)
 
     @pytest.mark.asyncio
-    async def test_heal_deletes_the_same_rules(self, monkeypatch):
-        monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: False)
-        monkeypatch.setattr(
-            network_mod,
-            "get_docker_client",
-            lambda _m: _fake_client({"node-2": "10.0.0.2", "node-1": "10.0.0.1"}),
+    async def test_partition_idempotent_skips_existing_rules(self, monkeypatch):
+        _patch_docker(monkeypatch, {"node-2": "10.0.0.2", "node-1": "10.0.0.1"})
+        # -C reports the rule already present → nothing should be inserted.
+        calls = _capture_iptables(monkeypatch, check_returncode=0)
+
+        ok = await _step(PartitionPeersStep, ["node-1"]).execute({}, {})
+        assert ok is True
+        assert all(a == "-C" for (a, _s, _d) in calls)  # only checks, no -I
+
+    @pytest.mark.asyncio
+    async def test_partition_rolls_back_on_partial_failure(self, monkeypatch):
+        _patch_docker(monkeypatch, {"node-2": "10.0.0.2", "node-1": "10.0.0.1"})
+        # First insert succeeds; the second fails → the first must be rolled back.
+        calls = _capture_iptables(
+            monkeypatch, fail_action="-I", fail_on=2, fail_stderr="iptables: failure"
         )
+
+        ok = await _step(PartitionPeersStep, ["node-1"]).execute({}, {})
+        assert ok is False
+        # The one rule that did get inserted is deleted again (rollback).
+        assert ("-D", "10.0.0.2", "10.0.0.1") in calls
+
+    @pytest.mark.asyncio
+    async def test_heal_deletes_until_gone(self, monkeypatch):
+        _patch_docker(monkeypatch, {"node-2": "10.0.0.2", "node-1": "10.0.0.1"})
         calls = _capture_iptables(monkeypatch)
 
-        step = HealPeersStep(
-            {"type": "heal_peers", "node": "node-2", "peers": ["node-1"]}
-        )
-        step.manager = object()
-        ok = await step.execute({}, {})
+        ok = await _step(HealPeersStep, ["node-1"]).execute({}, {})
         assert ok is True
+        # Heal only deletes, both directions.
+        assert all(a == "-D" for (a, _s, _d) in calls)
+        assert {(s, d) for (a, s, d) in calls if a == "-D"} == {
+            ("10.0.0.2", "10.0.0.1"),
+            ("10.0.0.1", "10.0.0.2"),
+        }
 
-        # Two deletes (both directions), mirroring the partition inserts.
-        assert all("-D" in a and "-I" not in a for a in calls)
-        deletes = {(a[a.index("-s") + 1], a[a.index("-d") + 1]) for a in calls}
-        assert deletes == {("10.0.0.2", "10.0.0.1"), ("10.0.0.1", "10.0.0.2")}
+    @pytest.mark.asyncio
+    async def test_heal_fails_on_non_benign_iptables_error(self, monkeypatch):
+        _patch_docker(monkeypatch, {"node-2": "10.0.0.2", "node-1": "10.0.0.1"})
+        # A sudo/permission error is NOT "rule does not exist" → heal must fail
+        # rather than falsely report the partition healed.
+        calls = _capture_iptables(
+            monkeypatch,
+            fail_action="-D",
+            fail_on=1,
+            fail_stderr="sudo: a password is required",
+        )
+
+        ok = await _step(HealPeersStep, ["node-1"]).execute({}, {})
+        assert ok is False
+        assert any(a == "-D" for (a, _s, _d) in calls)
 
     @pytest.mark.asyncio
     async def test_binary_mode_is_a_no_op(self, monkeypatch):
         monkeypatch.setattr(network_mod, "is_binary_mode", lambda _m: True)
         calls = _capture_iptables(monkeypatch)
 
-        step = PartitionPeersStep(
-            {"type": "partition_peers", "node": "node-2", "peers": ["node-1"]}
-        )
-        step.manager = object()
-        ok = await step.execute({}, {})
+        ok = await _step(PartitionPeersStep, ["node-1"]).execute({}, {})
         assert ok is True
         assert calls == []  # no iptables touched without Docker

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -1308,3 +1308,40 @@ class TestFaultInjectionStepSchemas:
         dumped = cfg.model_dump(exclude_none=True)
         assert dumped["mdns"] is False
         assert dumped["network_admin"] is False
+
+    def test_valid_partition_peers_step(self, config_module):
+        """A partition_peers step with node + non-empty peers validates."""
+        step = {
+            "name": "Partition node-2 from peers",
+            "type": "partition_peers",
+            "node": "node-2",
+            "peers": ["node-1", "node-3"],
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    def test_valid_heal_peers_step(self, config_module):
+        """A heal_peers step validates with the same shape as partition_peers."""
+        step = {
+            "name": "Heal node-2",
+            "type": "heal_peers",
+            "node": "node-2",
+            "peers": ["node-1"],
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    def test_partition_peers_missing_peers_rejected(self, config_module):
+        """partition_peers requires a non-empty peers list."""
+        step = {"name": "bad", "type": "partition_peers", "node": "node-2"}
+        errors = config_module.validate_workflow_step(step, 0)
+        assert len(errors) > 0
+
+    def test_partition_peers_empty_peers_rejected(self, config_module):
+        """An empty peers list is rejected (min_length=1)."""
+        step = {
+            "name": "bad",
+            "type": "partition_peers",
+            "node": "node-2",
+            "peers": [],
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert len(errors) > 0

--- a/workflow-examples/workflow-fault-injection-partition-peers-example.yml
+++ b/workflow-examples/workflow-fault-injection-partition-peers-example.yml
@@ -1,0 +1,227 @@
+description: |
+  Behavioral verification for the partition_peers / heal_peers steps — the
+  surgical libp2p partition that keeps RPC reachable (merobox#278).
+
+  Unlike disconnect_node (which detaches the container from its bridge and so
+  also kills its published-port RPC), partition_peers drops ONLY container-to-
+  container libp2p traffic via the host's DOCKER-USER iptables chain, leaving
+  every node callable. This workflow proves all three properties on a real
+  3-node mesh running kv_store:
+
+    1. RPC stays up under partition (the headline, vs disconnect_node):
+       partition node-1 from {node-2, node-3}, then `set` AND `get` on the
+       isolated node-1 — both calls succeed. node-2 (the other side) is
+       likewise driven while partitioned.
+    2. The partition actually bites (catches a silent no-op): node-1's
+       during-partition write does NOT reach node-3, and node-2's write does
+       NOT reach the isolated node-1 — asserted with not_contains while still
+       partitioned (only possible because RPC is up).
+    3. heal_peers restores delivery: after heal + wait_for_sync, both
+       during-partition writes converge on every node.
+
+  Docker-only (the steps short-circuit under --no-docker, and the iptables
+  rules need a real bridge); the `fault-injection` name keeps it out of the
+  binary-mode matrix and in the Docker matrix. Slower (~3-5 min) because of a
+  real app install + context join + sync cycles.
+name: Fault Injection — partition_peers (RPC-preserving libp2p cut)
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: calimero-node
+  # mDNS left ENABLED: count-mode-no-restart starts nodes individually without
+  # auto-wiring bootstrap peers, so mDNS over the bridge is how they form the
+  # initial mesh. partition_peers severs the bridge path between the named
+  # peers cleanly, so the partition is still real.
+
+steps:
+  # --- Setup: 3-node mesh on kv_store ---
+  - name: Install kv_store on node 1
+    type: install_application
+    node: calimero-node-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create mesh context across all 3 nodes
+    type: create_mesh
+    context_node: calimero-node-1
+    application_id: "{{app_id}}"
+    path: ./workflow-examples/res/kv_store.wasm
+    nodes:
+      - calimero-node-2
+      - calimero-node-3
+    capability: member
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+
+  - name: Set baseline key from node 1
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: set
+    args:
+      key: baseline
+      value: ok
+
+  - name: Wait for baseline to reach all 3 nodes
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+
+  - name: Read baseline on node 3 (sanity — mesh works before we break it)
+    type: call
+    node: calimero-node-3
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: baseline
+    outputs:
+      baseline_node3: result
+  - name: Assert baseline replicated to node 3
+    type: assert
+    statements:
+      - "contains({{baseline_node3}}, 'ok')"
+
+  # ====================================================================
+  # Partition node-1 from BOTH peers (so node-3 can't relay node-2 to it)
+  # ====================================================================
+  - name: Partition node-1 from node-2 and node-3 (libp2p only; RPC stays up)
+    type: partition_peers
+    node: calimero-node-1
+    peers:
+      - calimero-node-2
+      - calimero-node-3
+
+  - name: Settle after the partition takes effect
+    type: wait
+    seconds: 8
+
+  # --- Property 1: RPC works on the isolated node (the headline) ---
+  - name: Write a key on the PARTITIONED node-1
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: set
+    args:
+      key: from_n1
+      value: n1_while_partitioned
+  - name: Read it back on node-1 — proves RPC is reachable under partition
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: from_n1
+    outputs:
+      n1_self_read: result
+  - name: Assert node-1 is callable + functional while partitioned
+    type: assert
+    statements:
+      - "contains({{n1_self_read}}, 'n1_while_partitioned')"
+
+  # node-2 (the other side) is also driven while partitioned.
+  - name: Write a different key on node-2
+    type: call
+    node: calimero-node-2
+    context_id: "{{context_id}}"
+    method: set
+    args:
+      key: from_n2
+      value: n2_while_partitioned
+
+  - name: node-2 and node-3 still converge with each other
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 30
+
+  - name: Grace window — gossip WOULD cross here if the partition were a no-op
+    type: wait
+    seconds: 10
+
+  # --- Property 2: the partition actually bites (assertable because RPC is up) ---
+  - name: Read node-1's key on node-3 (across the partition)
+    type: call
+    node: calimero-node-3
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: from_n1
+    outputs:
+      n1_key_on_node3: result
+  - name: Assert node-1's write did NOT cross the partition to node-3
+    type: assert
+    statements:
+      - "not_contains({{n1_key_on_node3}}, 'n1_while_partitioned')"
+
+  - name: Read node-2's key on the isolated node-1
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: from_n2
+    outputs:
+      n2_key_on_node1: result
+  - name: Assert node-1 did NOT receive node-2's write either (fully isolated)
+    type: assert
+    statements:
+      - "not_contains({{n2_key_on_node1}}, 'n2_while_partitioned')"
+
+  # ====================================================================
+  # Heal and prove delivery resumes both ways
+  # ====================================================================
+  - name: Heal the partition
+    type: heal_peers
+    node: calimero-node-1
+    peers:
+      - calimero-node-2
+      - calimero-node-3
+
+  - name: Wait for the mesh to reconverge after heal
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Read node-1's key on node-3 after heal
+    type: call
+    node: calimero-node-3
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: from_n1
+    outputs:
+      n1_key_on_node3_after_heal: result
+  - name: Assert node-1's write reached node-3 after heal
+    type: assert
+    statements:
+      - "contains({{n1_key_on_node3_after_heal}}, 'n1_while_partitioned')"
+
+  - name: Read node-2's key on node-1 after heal
+    type: call
+    node: calimero-node-1
+    context_id: "{{context_id}}"
+    method: get
+    args:
+      key: from_n2
+    outputs:
+      n2_key_on_node1_after_heal: result
+  - name: Assert node-2's write reached node-1 after heal
+    type: assert
+    statements:
+      - "contains({{n2_key_on_node1_after_heal}}, 'n2_while_partitioned')"


### PR DESCRIPTION
Closes #278.

## Problem

`disconnect_node` detaches a container from its bridge — which also tears down its published-port DNAT, so a partitioned node can't be `call`ed. That's fine for tests that read a partitioned node *after* reconnecting, but it can't drive a node that must execute a call **while** partitioned. At least three core workflows want exactly that:
- `shared-storage-concurrent-rotation-converge` (two nodes concurrently rotating a SharedStorage writer set),
- `member-removed-partition-window-reconcile` (admin signs against a stale view during a partition),
- `sync-resilience-lossy-link` (#2468).

`pause_container` doesn't help (the kernel buffers gossip and drains it on unpause), and `inject_network_fault` needs `tc` inside the merod image (which lacks `iproute2`).

## What

Two new workflow steps that cut only **container-to-container (libp2p)** traffic between a node and the listed peers, leaving the node fully **RPC-reachable**:

```yaml
- type: partition_peers
  node: e2e-node-2
  peers: [e2e-node-1, e2e-node-3]
# ... the workflow can still `call` ALL of node-1/2/3 while partitioned ...
- type: heal_peers
  node: e2e-node-2
  peers: [e2e-node-1, e2e-node-3]
```

### How

Symmetric `DROP` rules in the host's `DOCKER-USER` iptables chain, matched on the containers' bridge IPs (both directions, per peer). `DOCKER-USER` is consulted for *forwarded* traffic, so the peers' libp2p packets are dropped both ways; host→container traffic for the published RPC port arrives via DNAT with a **non-container source IP**, so it doesn't match the rules and RPC stays up. The container keeps its interface, IP, and routing table intact (unlike `disconnect_node`). `heal_peers` deletes the rules (idempotent — a missing rule is benign).

`sudo -n` fails fast rather than prompting. Like the other Docker-network fault steps, it's a **CI / Linux primitive** (needs iptables + passwordless sudo; no-op skip under `--no-docker`).

## Wiring + tests

Registered in `config.py` (step type + `PartitionPeersStepConfig`/`HealPeersStepConfig` + map), `run/executor.py` dispatch, `validate/validator.py`, and `steps/__init__.py`. Unit tests in `test_fault_injection_steps.py` (field validation; mocked-docker execute asserting the exact `iptables -I/-D DOCKER-USER -s … -d … -j DROP` argv both directions; binary-mode no-op) and `test_workflow_schema_validation.py` (valid + missing/empty-peers rejection). Targeted suites green; `black --check` + `ruff check` clean.

## Follow-up

Once released, bump `MIN_MEROBOX` in core's `setup-merobox` action so core workflows can adopt `partition_peers` and drop their disconnect/pause choreography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New host-level iptables/sudo dependency on Linux CI; misconfigured rules or failed rollback could affect container networking, though scope is limited to explicit peer pairs and Docker mode only.
> 
> **Overview**
> Adds **`partition_peers`** and **`heal_peers`** bootstrap steps so workflows can isolate a node from specific peers on **libp2p only** while **RPC stays callable**—unlike `disconnect_node`, which also breaks published-port access.
> 
> Implementation drops symmetric **`DOCKER-USER` iptables** rules between containers’ bridge IPv4s (with idempotent insert, rollback on partial failure, `br_netfilter` best-effort, and `--no-docker` no-op). **`heal_peers`** removes rules until gone, treating missing rules as success but failing on real iptables/sudo errors.
> 
> Wiring covers Pydantic configs, executor/validator dispatch, and exports; **0.6.35** changelog/version bump. Unit tests mock Docker/iptables; a new **Docker-matrix** example workflow asserts RPC under partition, gossip blocked, and recovery after heal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77c355b859436208de8bf0d717793f23251c119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->