### PR TITLE
feat(steps): strand-e2e enablers — delete_blob_on_disk + get_application (0.6.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.38] - 2026-06-16
+
+### Added
+
+- New `delete_blob_on_disk` workflow step: removes a single content-addressed
+  bytecode blob file from a node's on-disk blob store via `docker exec rm -f`
+  (`<data_dir>/<node>/blobs/<blob_id>`, default `data_dir=/app/data`). A
+  fault-injection primitive for the migrations-v2 stranded-context e2e —
+  `uninstall_application` does not remove the content-addressed blob and a
+  behind node pre-stages an upgrade-ladder rung over BlobShare, so `stop_node`
+  alone can't make a rung's bytecode unobtainable; deleting the intermediate
+  blob on every holder strands a behind context (`NoMigrationPath`), which
+  `resync_context` then recovers. The `blob_id` is the base58 id surfaced by
+  `list_application_versions` (matches the on-disk filename). Verifies the blob
+  is actually gone after `rm` (fails on a silent survivor) and confirms it was
+  present unless `missing_ok` (default true). Docker-only (pairs with the
+  `partition_peers` fault steps); stores `{blob_id, path, existed, removed}`.
+
 ## [0.6.37] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is actually gone after `rm` (fails on a silent survivor) and confirms it was
   present unless `missing_ok` (default true). Docker-only (pairs with the
   `partition_peers` fault steps); stores `{blob_id, path, existed, removed}`.
+- New `get_application` workflow step: reads an application's current row
+  (`id`, `version`, `blob.bytecode`/`blob.compiled`) via
+  `GET admin-api/applications/{id}`. Same-package bundles share one
+  `applicationId`, so this is how a workflow distinguishes versions — the row
+  points at the latest install, so reading it right after an install captures
+  that version's base58 `blob.bytecode` (the id `delete_blob_on_disk` and the
+  on-disk blob store use). `outputs:` paths start at `application` (e.g.
+  `application.blob.bytecode`).
 
 ## [0.6.37] - 2026-06-15
 

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.37"
+__version__ = "0.6.38"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -110,6 +110,7 @@ VALID_STEP_TYPES = frozenset(
         "list_proposals",
         "get_proposal_approvers",
         "upload_blob",
+        "delete_blob_on_disk",
         "create_mesh",
         "fuzzy_test",
         "stop_node",
@@ -702,6 +703,29 @@ class UploadBlobStep(BaseStepConfig):
     node: str = Field(..., description="Target node")
     file_path: str = Field(..., description="Path to the blob file")
     context_id: Optional[str] = Field(None, description="Context ID (optional)")
+
+
+class DeleteBlobOnDiskStepConfig(BaseStepConfig):
+    """Configuration for delete_blob_on_disk step."""
+
+    type: Literal["delete_blob_on_disk"] = "delete_blob_on_disk"
+    node: str = Field(..., description="Target node (== container name)")
+    blob_id: str = Field(
+        ...,
+        description="Base58 blob id to delete (e.g. from list_application_versions)",
+    )
+    data_dir: Optional[str] = Field(
+        None,
+        description="CALIMERO_HOME inside the container (default /app/data)",
+    )
+    blobs_subdir: Optional[str] = Field(
+        None,
+        description="Blob-store subdir under <data_dir>/<node> (default 'blobs')",
+    )
+    missing_ok: Optional[bool] = Field(
+        True,
+        description="Treat a node that never held the blob as success (default true)",
+    )
 
 
 class CreateNamespaceStepConfig(BaseStepConfig):
@@ -1481,6 +1505,7 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "list_proposals": ListProposalsStep,
     "get_proposal_approvers": GetProposalApproversStep,
     "upload_blob": UploadBlobStep,
+    "delete_blob_on_disk": DeleteBlobOnDiskStepConfig,
     "create_mesh": CreateMeshStep,
     "fuzzy_test": FuzzyTestStep,
 }

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -111,6 +111,7 @@ VALID_STEP_TYPES = frozenset(
         "get_proposal_approvers",
         "upload_blob",
         "delete_blob_on_disk",
+        "get_application",
         "create_mesh",
         "fuzzy_test",
         "stop_node",
@@ -726,6 +727,14 @@ class DeleteBlobOnDiskStepConfig(BaseStepConfig):
         True,
         description="Treat a node that never held the blob as success (default true)",
     )
+
+
+class GetApplicationStepConfig(BaseStepConfig):
+    """Configuration for get_application step."""
+
+    type: Literal["get_application"] = "get_application"
+    node: str = Field(..., description="Target node")
+    application_id: str = Field(..., description="Application ID to read")
 
 
 class CreateNamespaceStepConfig(BaseStepConfig):
@@ -1506,6 +1515,7 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "get_proposal_approvers": GetProposalApproversStep,
     "upload_blob": UploadBlobStep,
     "delete_blob_on_disk": DeleteBlobOnDiskStepConfig,
+    "get_application": GetApplicationStepConfig,
     "create_mesh": CreateMeshStep,
     "fuzzy_test": FuzzyTestStep,
 }

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -30,6 +30,7 @@ from merobox.commands.bootstrap.steps import (
     CreateIdentityStep,
     CreateNamespaceInvitationStep,
     CreateNamespaceStep,
+    DeleteBlobOnDiskStep,
     DeleteContextStep,
     DeleteGroupStep,
     DeleteNamespaceStep,
@@ -2153,6 +2154,8 @@ class WorkflowExecutor:
             return GetProposalApproversStep(step_config, **common_kwargs)
         elif step_type == "upload_blob":
             return UploadBlobStep(step_config, **common_kwargs)
+        elif step_type == "delete_blob_on_disk":
+            return DeleteBlobOnDiskStep(step_config, **common_kwargs)
         elif step_type == "create_mesh":
             return CreateMeshStep(step_config, **common_kwargs)
         elif step_type == "fuzzy_test":

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -36,6 +36,7 @@ from merobox.commands.bootstrap.steps import (
     DeleteNamespaceStep,
     DetachContextFromGroupStep,
     ExecuteStep,
+    GetApplicationStep,
     GetCascadeStatusStep,
     GetContextMetadataStep,
     GetGroupInfoStep,
@@ -2156,6 +2157,8 @@ class WorkflowExecutor:
             return UploadBlobStep(step_config, **common_kwargs)
         elif step_type == "delete_blob_on_disk":
             return DeleteBlobOnDiskStep(step_config, **common_kwargs)
+        elif step_type == "get_application":
+            return GetApplicationStep(step_config, **common_kwargs)
         elif step_type == "create_mesh":
             return CreateMeshStep(step_config, **common_kwargs)
         elif step_type == "fuzzy_test":

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -10,6 +10,7 @@ from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.bootstrap.steps.blob import UploadBlobStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
+from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
@@ -162,6 +163,7 @@ __all__ = [
     "AssertLogPresentStep",
     "JsonAssertStep",
     "UploadBlobStep",
+    "DeleteBlobOnDiskStep",
     "CreateMeshStep",
     "FuzzyTestStep",
     "RemoveGroupMembersStep",

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -14,6 +14,7 @@ from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
+from merobox.commands.bootstrap.steps.get_application import GetApplicationStep
 from merobox.commands.bootstrap.steps.group_create import (
     CreateGroupStep,
     CreateNamespaceStep,
@@ -164,6 +165,7 @@ __all__ = [
     "JsonAssertStep",
     "UploadBlobStep",
     "DeleteBlobOnDiskStep",
+    "GetApplicationStep",
     "CreateMeshStep",
     "FuzzyTestStep",
     "RemoveGroupMembersStep",

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -1,0 +1,185 @@
+"""
+delete_blob_on_disk workflow step — remove a content-addressed bytecode blob
+from a node's on-disk blob store via `docker exec`.
+
+This is a fault-injection primitive for the migrations-v2 stranded-context e2e:
+`uninstall_application` removes the extracted dir + app row but NOT the
+content-addressed blob, and a behind node pre-stages an upgrade-ladder rung's
+blob over BlobShare during the sync gate — so `stop_node` alone can't make a
+rung's bytecode unobtainable. Deleting the intermediate blob file on every node
+that holds it strands a behind context: its lazy ladder replay can no longer
+fetch that rung and hits `NoMigrationPath`. `resync_context` then recovers it.
+
+The merod blob store is a flat directory of one file per blob, named by the
+blob id's base58 string (calimero core `crates/store/blobs`,
+`FileSystem::path` = `<root>/<blob_id>`). That base58 id is exactly what the
+`list_application_versions` step surfaces as `blob_id`, so it can be threaded
+straight in. In a merobox container `CALIMERO_HOME` is `/app/data` and the
+per-node store is `/app/data/<node>/blobs/`.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from merobox.commands.bootstrap.steps._docker_utils import (
+    is_binary_mode,
+    resolve_container,
+)
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.utils import console
+
+# merod's per-node data root inside a merobox container (CALIMERO_HOME), and the
+# blob-store subdir under it (core's BlobStoreConfig default is `blobs`).
+_DEFAULT_DATA_DIR = "/app/data"
+_DEFAULT_BLOBS_SUBDIR = "blobs"
+
+# Node/container names: same restriction merobox's manager applies, so an
+# interpolated value can't path-traverse out of the data dir in the exec path.
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+# A blob id is a base58-encoded 32-byte hash (bitcoin alphabet — no 0 O I l).
+# Validated so the id can't smuggle a path separator / shell metachar into the
+# exec target even though we already pass argv as a list (defence in depth).
+_BASE58_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]+$")
+
+
+class DeleteBlobOnDiskStep(BaseStep):
+    """Delete a single blob file from a node's on-disk blob store (docker exec).
+
+    Fields:
+      node:       target node (== container name).
+      blob_id:    base58 blob id to delete (e.g. from list_application_versions).
+      data_dir:   optional CALIMERO_HOME inside the container (default /app/data).
+      blobs_subdir: optional blob-store subdir under <data_dir>/<node>
+                  (default `blobs`).
+      missing_ok: optional (default true) — a node that never held the blob is
+                  still a success (the goal is "absent here", reached either way).
+
+    Stores `{blob_id, path, existed, removed}` under
+    `delete_blob_on_disk_{node}` and exposes it to `outputs:`.
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "blob_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "blob_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+        for field in ("data_dir", "blobs_subdir"):
+            value = self.config.get(field)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(
+                    f"Step '{step_name}': '{field}' must be a string if provided"
+                )
+        missing_ok = self.config.get("missing_ok")
+        if missing_ok is not None and not isinstance(missing_ok, bool):
+            raise ValueError(
+                f"Step '{step_name}': 'missing_ok' must be a boolean if provided"
+            )
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self._resolve_dynamic_value(
+            self.config["node"], workflow_results, dynamic_values
+        )
+        blob_id = self._resolve_dynamic_value(
+            self.config["blob_id"], workflow_results, dynamic_values
+        )
+        data_dir = self.config.get("data_dir") or _DEFAULT_DATA_DIR
+        blobs_subdir = self.config.get("blobs_subdir") or _DEFAULT_BLOBS_SUBDIR
+        missing_ok = bool(self.config.get("missing_ok", True))
+        expected_failure = self._is_expected_failure()
+
+        # Defence in depth: every component lands in an exec path, so reject a
+        # crafted node name / blob id before building it (argv is a list, so
+        # this is belt-and-suspenders against traversal, not shell injection).
+        if not _SAFE_NAME_RE.match(str(node_name)):
+            return self._fail(f"unsafe node name {node_name!r}", expected_failure)
+        if not _BASE58_RE.match(str(blob_id)):
+            return self._fail(
+                f"blob_id {blob_id!r} is not a base58 blob id", expected_failure
+            )
+
+        # docker-exec only: in binary mode the blob is on the host filesystem and
+        # this primitive does not apply (the stranded-resync workflow is
+        # docker-only, like the partition_peers fault steps it pairs with).
+        if is_binary_mode(self.manager):
+            return self._fail(
+                "delete_blob_on_disk is only supported in Docker mode "
+                "(no container to exec into in binary mode)",
+                expected_failure,
+            )
+        if not self.manager:
+            return self._fail(
+                "no manager available (remote-only mode)", expected_failure
+            )
+
+        container = resolve_container(self.manager, node_name)
+        if container is None:
+            return self._fail(f"container '{node_name}' not found", expected_failure)
+
+        path = f"{data_dir}/{node_name}/{blobs_subdir}/{blob_id}"
+
+        try:
+            existed = container.exec_run(["test", "-e", path]).exit_code == 0
+            rm = container.exec_run(["rm", "-f", path])
+            if rm.exit_code != 0:
+                detail = _decode(rm.output)
+                return self._fail(
+                    f"rm -f {path} exited {rm.exit_code}: {detail}", expected_failure
+                )
+            # Confirm the file is actually gone — a silently-surviving blob would
+            # make the strand a no-op and the workflow false-pass.
+            still_present = container.exec_run(["test", "-e", path]).exit_code == 0
+        except Exception as e:
+            return self._fail(f"exec failed on {node_name}: {e}", expected_failure)
+
+        if still_present:
+            return self._fail(
+                f"blob {blob_id} still present at {path} after rm", expected_failure
+            )
+
+        if not existed and not missing_ok:
+            return self._fail(
+                f"blob {blob_id} was not present at {path} (missing_ok=false)",
+                expected_failure,
+            )
+
+        result = {
+            "blob_id": blob_id,
+            "path": path,
+            "existed": existed,
+            "removed": existed,
+        }
+        workflow_results[f"delete_blob_on_disk_{node_name}"] = result
+        if "outputs" in self.config:
+            self._export_variables(result, node_name, dynamic_values)
+
+        verb = "removed" if existed else "already absent"
+        console.print(
+            f"[green]✓ delete_blob_on_disk on {node_name}: blob {blob_id} "
+            f"{verb} ({path})[/green]"
+        )
+        if expected_failure:
+            self._report_unexpected_success()
+        return True
+
+    def _fail(self, message: str, expected_failure: bool) -> bool:
+        if expected_failure:
+            self._report_expected_failure(message)
+            return True
+        console.print(f"[red]delete_blob_on_disk failed: {message}[/red]")
+        return False
+
+
+def _decode(output: Any) -> str:
+    """Best-effort decode of exec_run output bytes for an error message."""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace").strip()
+    return str(output).strip() if output is not None else ""

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -151,23 +151,36 @@ class DeleteBlobOnDiskStep(BaseStep):
 
         # exec_run blocks indefinitely on a paused container (the process is
         # SIGSTOP'd and never drains the exec stream — same hazard documented
-        # for the fault steps). Check state first so a paused node fails fast.
+        # for the fault steps). Require a confirmed "running" state first: an
+        # unknown state (reload raised) is treated as unsafe rather than risking
+        # the hang the whole check exists to prevent.
         try:
             container.reload()
             state = container.attrs.get("State", {}).get("Status")
         except Exception:
             state = None
-        if state is not None and state != "running":
+        if state != "running":
             return self._fail(
-                f"container '{node_name}' is '{state}', not running "
-                f"(exec would hang)",
+                f"container '{node_name}' is '{state}', not confirmed running "
+                f"(exec would risk hanging)",
                 expected_failure,
             )
 
         path = f"{data_dir}/{node_name}/{blobs_subdir}/{blob_id}"
 
+        # `op` labels the in-flight exec so a daemon error names which call failed.
+        op = "test -e (pre)"
         try:
             existed = container.exec_run(["test", "-e", path]).exit_code == 0
+            # Fail before issuing rm when a required blob is absent — don't run a
+            # no-op rm just to reject it afterward (clearer + avoids touching a
+            # never-present path).
+            if not existed and not missing_ok:
+                return self._fail(
+                    f"blob {blob_id} was not present at {path} (missing_ok=false)",
+                    expected_failure,
+                )
+            op = "rm -f"
             rm = container.exec_run(["rm", "-f", path])
             if rm.exit_code != 0:
                 detail = _decode(rm.output)
@@ -176,19 +189,16 @@ class DeleteBlobOnDiskStep(BaseStep):
                 )
             # Confirm the file is actually gone — a silently-surviving blob would
             # make the strand a no-op and the workflow false-pass.
+            op = "test -e (post)"
             still_present = container.exec_run(["test", "-e", path]).exit_code == 0
         except Exception as e:
-            return self._fail(f"exec failed on {node_name}: {e}", expected_failure)
+            return self._fail(
+                f"exec ({op}) failed on {node_name}: {e}", expected_failure
+            )
 
         if still_present:
             return self._fail(
                 f"blob {blob_id} still present at {path} after rm", expected_failure
-            )
-
-        if not existed and not missing_ok:
-            return self._fail(
-                f"blob {blob_id} was not present at {path} (missing_ok=false)",
-                expected_failure,
             )
 
         result = {

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -72,10 +72,30 @@ class DeleteBlobOnDiskStep(BaseStep):
                 raise ValueError(f"Step '{step_name}': '{field}' must be a string")
         for field in ("data_dir", "blobs_subdir"):
             value = self.config.get(field)
-            if value is not None and not isinstance(value, str):
+            if value is None:
+                continue
+            if not isinstance(value, str):
                 raise ValueError(
                     f"Step '{step_name}': '{field}' must be a string if provided"
                 )
+            # These land in the exec path verbatim, so reject `..` traversal
+            # components outright (node_name/blob_id are validated in execute).
+            if ".." in value.split("/"):
+                raise ValueError(
+                    f"Step '{step_name}': '{field}' must not contain '..' path components"
+                )
+        # `data_dir` is an absolute CALIMERO_HOME inside the container; a
+        # relative value would resolve against the exec cwd, not the data root.
+        data_dir = self.config.get("data_dir")
+        if isinstance(data_dir, str) and not data_dir.startswith("/"):
+            raise ValueError(f"Step '{step_name}': 'data_dir' must be an absolute path")
+        # `blobs_subdir` is a subdir under <data_dir>/<node>; an absolute value
+        # would escape that prefix entirely.
+        blobs_subdir = self.config.get("blobs_subdir")
+        if isinstance(blobs_subdir, str) and blobs_subdir.startswith("/"):
+            raise ValueError(
+                f"Step '{step_name}': 'blobs_subdir' must be a relative subdir"
+            )
         missing_ok = self.config.get("missing_ok")
         if missing_ok is not None and not isinstance(missing_ok, bool):
             raise ValueError(
@@ -93,12 +113,17 @@ class DeleteBlobOnDiskStep(BaseStep):
         )
         data_dir = self.config.get("data_dir") or _DEFAULT_DATA_DIR
         blobs_subdir = self.config.get("blobs_subdir") or _DEFAULT_BLOBS_SUBDIR
-        missing_ok = bool(self.config.get("missing_ok", True))
+        # `.get(..., True)` returns None (not the default) for an explicit
+        # `missing_ok: null`, and `bool(None)` is False — so collapse None to
+        # the documented default here.
+        missing_ok_raw = self.config.get("missing_ok")
+        missing_ok = True if missing_ok_raw is None else bool(missing_ok_raw)
         expected_failure = self._is_expected_failure()
 
-        # Defence in depth: every component lands in an exec path, so reject a
-        # crafted node name / blob id before building it (argv is a list, so
-        # this is belt-and-suspenders against traversal, not shell injection).
+        # Defence in depth: node_name + blob_id land in the exec path, so reject
+        # a crafted value before building it. With data_dir/blobs_subdir also
+        # `..`-validated (see _validate_field_types) the whole path is traversal-
+        # free; argv is a list so there's no shell-injection surface either.
         if not _SAFE_NAME_RE.match(str(node_name)):
             return self._fail(f"unsafe node name {node_name!r}", expected_failure)
         if not _BASE58_RE.match(str(blob_id)):
@@ -106,6 +131,10 @@ class DeleteBlobOnDiskStep(BaseStep):
                 f"blob_id {blob_id!r} is not a base58 blob id", expected_failure
             )
 
+        if not self.manager:
+            return self._fail(
+                "no manager available (remote-only mode)", expected_failure
+            )
         # docker-exec only: in binary mode the blob is on the host filesystem and
         # this primitive does not apply (the stranded-resync workflow is
         # docker-only, like the partition_peers fault steps it pairs with).
@@ -115,14 +144,25 @@ class DeleteBlobOnDiskStep(BaseStep):
                 "(no container to exec into in binary mode)",
                 expected_failure,
             )
-        if not self.manager:
-            return self._fail(
-                "no manager available (remote-only mode)", expected_failure
-            )
 
         container = resolve_container(self.manager, node_name)
         if container is None:
             return self._fail(f"container '{node_name}' not found", expected_failure)
+
+        # exec_run blocks indefinitely on a paused container (the process is
+        # SIGSTOP'd and never drains the exec stream — same hazard documented
+        # for the fault steps). Check state first so a paused node fails fast.
+        try:
+            container.reload()
+            state = container.attrs.get("State", {}).get("Status")
+        except Exception:
+            state = None
+        if state is not None and state != "running":
+            return self._fail(
+                f"container '{node_name}' is '{state}', not running "
+                f"(exec would hang)",
+                expected_failure,
+            )
 
         path = f"{data_dir}/{node_name}/{blobs_subdir}/{blob_id}"
 

--- a/merobox/commands/bootstrap/steps/get_application.py
+++ b/merobox/commands/bootstrap/steps/get_application.py
@@ -1,0 +1,103 @@
+"""
+get_application workflow step — read an application's current row (id, version,
+and blob ids) over the admin API.
+
+Wraps `GET admin-api/applications/{application_id}` (calimero-client-py
+`get_application`). The app row points at the LATEST installed bytecode, so
+calling this right after an install captures that version's `blob.bytecode`
+(base58) — the same id the on-disk blob store and `delete_blob_on_disk` use.
+Same-package bundles share one `applicationId`, so this is how a workflow
+distinguishes versions: read the row's `version` + `blob.bytecode` while a
+given version is current.
+
+Response shape `{data: {application: {id, version, blob: {bytecode, compiled},
+...}}}`; the export machinery unwraps the top-level `data`, so `outputs:` paths
+start at `application` (e.g. `application.blob.bytecode`, `application.version`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.client import get_client_for_rpc_url
+from merobox.commands.result import fail, ok
+from merobox.commands.utils import console
+
+
+class GetApplicationStep(BaseStep):
+    """Read an application's current row (id / version / blob ids).
+
+    Fields:
+      node:           target node.
+      application_id: the application id to read.
+
+    Stores the response under `get_application_{node}`; `outputs:` paths start
+    at `application` (e.g. `application.blob.bytecode`).
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "application_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "application_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        application_id = self._resolve_dynamic_value(
+            self.config["application_id"], workflow_results, dynamic_values
+        )
+
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.get_application(application_id)
+            result = ok(api_result)
+        except Exception as e:
+            result = fail("get_application failed", error=e)
+
+        expected_failure = self._is_expected_failure()
+
+        if not result["success"]:
+            if expected_failure:
+                self._report_expected_failure(str(result.get("error", "Unknown error")))
+                return True
+            console.print(
+                f"[red]get_application failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+
+        if self._check_jsonrpc_error(result["data"]):
+            if expected_failure:
+                self._report_expected_failure("JSON-RPC error returned")
+                return True
+            return False
+
+        data = result["data"]
+        workflow_results[f"get_application_{node_name}"] = data
+        if "outputs" in self.config:
+            self._export_variables(data, node_name, dynamic_values)
+
+        # Pull a compact summary for the run log (best-effort; the body is the
+        # `{data: {application: {...}}}` envelope).
+        app = {}
+        if isinstance(data, dict):
+            inner = data.get("data") if isinstance(data.get("data"), dict) else data
+            app = inner.get("application") or {} if isinstance(inner, dict) else {}
+        version = app.get("version") if isinstance(app, dict) else None
+        blob = app.get("blob") if isinstance(app, dict) else None
+        bytecode = blob.get("bytecode") if isinstance(blob, dict) else None
+        console.print(
+            f"[green]✓ get_application {application_id} on {node_name}: "
+            f"version={version} bytecode={bytecode}[/green]"
+        )
+        if expected_failure:
+            self._report_unexpected_success()
+        return True

--- a/merobox/commands/bootstrap/steps/get_application.py
+++ b/merobox/commands/bootstrap/steps/get_application.py
@@ -50,7 +50,9 @@ class GetApplicationStep(BaseStep):
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
     ) -> bool:
-        node_name = self.config["node"]
+        node_name = self._resolve_dynamic_value(
+            self.config["node"], workflow_results, dynamic_values
+        )
         application_id = self._resolve_dynamic_value(
             self.config["application_id"], workflow_results, dynamic_values
         )

--- a/merobox/commands/bootstrap/steps/get_application.py
+++ b/merobox/commands/bootstrap/steps/get_application.py
@@ -83,16 +83,19 @@ class GetApplicationStep(BaseStep):
             return False
 
         data = result["data"]
-        workflow_results[f"get_application_{node_name}"] = data
+        # Unwrap the `{data: {application: {...}}}` envelope explicitly so the
+        # `outputs:` contract (paths rooted at `application`) holds regardless of
+        # whether the base-class export machinery also unwraps a top-level
+        # `data` key. The unwrapped object is what we store AND export, so a
+        # direct workflow_results read and an `outputs:` path agree.
+        inner = data.get("data") if isinstance(data, dict) else None
+        inner = inner if isinstance(inner, dict) else data
+        workflow_results[f"get_application_{node_name}"] = inner
         if "outputs" in self.config:
-            self._export_variables(data, node_name, dynamic_values)
+            self._export_variables(inner, node_name, dynamic_values)
 
-        # Pull a compact summary for the run log (best-effort; the body is the
-        # `{data: {application: {...}}}` envelope).
-        app = {}
-        if isinstance(data, dict):
-            inner = data.get("data") if isinstance(data.get("data"), dict) else data
-            app = inner.get("application") or {} if isinstance(inner, dict) else {}
+        # Pull a compact summary for the run log (best-effort).
+        app = inner.get("application") or {} if isinstance(inner, dict) else {}
         version = app.get("version") if isinstance(app, dict) else None
         blob = app.get("blob") if isinstance(app, dict) else None
         bytecode = blob.get("bytecode") if isinstance(blob, dict) else None

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -15,6 +15,7 @@ from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
+from merobox.commands.bootstrap.steps.get_application import GetApplicationStep
 from merobox.commands.bootstrap.steps.group_create import CreateNamespaceStep
 from merobox.commands.bootstrap.steps.group_governance import (
     DetachContextFromGroupStep,
@@ -360,6 +361,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = InjectNetworkFaultStep
         elif step_type == "delete_blob_on_disk":
             step_class = DeleteBlobOnDiskStep
+        elif step_type == "get_application":
+            step_class = GetApplicationStep
         else:
             errors.append(f"Step '{step_name}' has unknown type: {step_type}")
             return errors

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -11,6 +11,7 @@ from merobox.commands.bootstrap.steps.assert_log import (
 )
 from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
+from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
@@ -357,6 +358,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = HealPeersStep
         elif step_type == "inject_network_fault":
             step_class = InjectNetworkFaultStep
+        elif step_type == "delete_blob_on_disk":
+            step_class = DeleteBlobOnDiskStep
         else:
             errors.append(f"Step '{step_name}' has unknown type: {step_type}")
             return errors

--- a/merobox/tests/unit/test_delete_blob_step.py
+++ b/merobox/tests/unit/test_delete_blob_step.py
@@ -38,8 +38,9 @@ class _Exec:
         self.output = output
 
 
-def _container(*exec_results):
+def _container(*exec_results, state="running"):
     c = MagicMock()
+    c.attrs = {"State": {"Status": state}}
     c.exec_run.side_effect = list(exec_results)
     return c
 
@@ -94,6 +95,31 @@ class TestDeleteBlobValidation:
                     "missing_ok": "yes",
                 },
                 manager=MagicMock(),
+            )
+
+    def _cfg(self, **extra):
+        cfg = {"type": "delete_blob_on_disk", "node": "node-1", "blob_id": _BLOB}
+        cfg.update(extra)
+        return cfg
+
+    def test_data_dir_with_dotdot_raises(self):
+        with pytest.raises(ValueError, match="data_dir"):
+            DeleteBlobOnDiskStep(self._cfg(data_dir="/app/../etc"), manager=MagicMock())
+
+    def test_relative_data_dir_raises(self):
+        with pytest.raises(ValueError, match="data_dir"):
+            DeleteBlobOnDiskStep(self._cfg(data_dir="app/data"), manager=MagicMock())
+
+    def test_blobs_subdir_with_dotdot_raises(self):
+        with pytest.raises(ValueError, match="blobs_subdir"):
+            DeleteBlobOnDiskStep(
+                self._cfg(blobs_subdir="../../etc"), manager=MagicMock()
+            )
+
+    def test_absolute_blobs_subdir_raises(self):
+        with pytest.raises(ValueError, match="blobs_subdir"):
+            DeleteBlobOnDiskStep(
+                self._cfg(blobs_subdir="/etc/passwd"), manager=MagicMock()
             )
 
 
@@ -198,12 +224,33 @@ class TestDeleteBlobExecute:
 
     def test_exec_exception_fails(self):
         step = _step()
-        container = MagicMock()
+        container = _container()  # running; exec_run overridden to raise
         container.exec_run.side_effect = RuntimeError("docker down")
         p1, p2 = self._patched(container)
         with p1, p2:
             result = _run(step.execute({}, {}))
         assert result is False
+
+    def test_paused_container_fails_fast(self):
+        # exec_run hangs on a paused container, so a non-running state must
+        # fail fast rather than block until timeout.
+        step = _step()
+        container = _container(_Exec(0), _Exec(0), _Exec(1), state="paused")
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is False
+        container.exec_run.assert_not_called()
+
+    def test_missing_ok_null_defaults_true(self):
+        # Explicit `missing_ok: null` must keep the permissive default (an
+        # absent blob is still a success), not flip to False.
+        step = _step(missing_ok=None)
+        container = _container(_Exec(1), _Exec(0), _Exec(1))  # absent
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is True
 
     def test_outputs_export_removed_flag(self):
         cfg_step = _step(outputs={"was_removed": "removed"})

--- a/merobox/tests/unit/test_delete_blob_step.py
+++ b/merobox/tests/unit/test_delete_blob_step.py
@@ -242,6 +242,18 @@ class TestDeleteBlobExecute:
         assert result is False
         container.exec_run.assert_not_called()
 
+    def test_unknown_state_on_reload_error_fails_fast(self):
+        # If reload() raises, the state is unknown — treat it as unsafe (don't
+        # risk the exec hang the check exists to prevent).
+        step = _step()
+        container = _container(_Exec(0), _Exec(0), _Exec(1))
+        container.reload.side_effect = RuntimeError("daemon hiccup")
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is False
+        container.exec_run.assert_not_called()
+
     def test_missing_ok_null_defaults_true(self):
         # Explicit `missing_ok: null` must keep the permissive default (an
         # absent blob is still a success), not flip to False.

--- a/merobox/tests/unit/test_delete_blob_step.py
+++ b/merobox/tests/unit/test_delete_blob_step.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for the `delete_blob_on_disk` workflow step.
+
+Covers `DeleteBlobOnDiskStep` validation + execute (present/absent/missing_ok,
+rm failure, survive-after-rm guard, container-not-found, binary-mode rejection,
+unsafe-name / non-base58 guards, expected_failure, outputs export). The Docker
+container is a MagicMock whose `exec_run` is scripted per call; the module's
+`is_binary_mode` / `resolve_container` helpers are patched.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
+
+_MODULE = "merobox.commands.bootstrap.steps.delete_blob"
+
+# Valid base58 (no 0 O I l) and a deterministic expected on-disk path.
+_BLOB = "Bk8aZ2x9Qm"
+_PATH = f"/app/data/node-1/blobs/{_BLOB}"
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _Exec:
+    """Stand-in for docker's ExecResult (exit_code, output)."""
+
+    def __init__(self, exit_code: int, output: bytes = b""):
+        self.exit_code = exit_code
+        self.output = output
+
+
+def _container(*exec_results):
+    c = MagicMock()
+    c.exec_run.side_effect = list(exec_results)
+    return c
+
+
+def _step(**overrides):
+    cfg = {"type": "delete_blob_on_disk", "node": "node-1", "blob_id": _BLOB}
+    cfg.update(overrides)
+    step = DeleteBlobOnDiskStep(cfg, manager=MagicMock())
+    # Identity dynamic-value resolution, like the other step tests.
+    step._resolve_dynamic_value = lambda v, *_a, **_k: v
+    return step
+
+
+# =============================================================================
+# Validation (construction time)
+# =============================================================================
+
+
+class TestDeleteBlobValidation:
+    def test_valid_config_passes(self):
+        DeleteBlobOnDiskStep(
+            {"type": "delete_blob_on_disk", "node": "node-1", "blob_id": _BLOB},
+            manager=MagicMock(),
+        )
+
+    def test_missing_node_raises(self):
+        with pytest.raises(ValueError, match="node"):
+            DeleteBlobOnDiskStep(
+                {"type": "delete_blob_on_disk", "blob_id": _BLOB}, manager=MagicMock()
+            )
+
+    def test_missing_blob_id_raises(self):
+        with pytest.raises(ValueError, match="blob_id"):
+            DeleteBlobOnDiskStep(
+                {"type": "delete_blob_on_disk", "node": "node-1"}, manager=MagicMock()
+            )
+
+    def test_blob_id_not_string_raises(self):
+        with pytest.raises(ValueError, match="'blob_id' must be a string"):
+            DeleteBlobOnDiskStep(
+                {"type": "delete_blob_on_disk", "node": "node-1", "blob_id": 5},
+                manager=MagicMock(),
+            )
+
+    def test_missing_ok_not_bool_raises(self):
+        with pytest.raises(ValueError, match="missing_ok"):
+            DeleteBlobOnDiskStep(
+                {
+                    "type": "delete_blob_on_disk",
+                    "node": "node-1",
+                    "blob_id": _BLOB,
+                    "missing_ok": "yes",
+                },
+                manager=MagicMock(),
+            )
+
+
+# =============================================================================
+# Execute
+# =============================================================================
+
+
+class TestDeleteBlobExecute:
+    def _patched(self, container):
+        return (
+            patch(f"{_MODULE}.is_binary_mode", return_value=False),
+            patch(f"{_MODULE}.resolve_container", return_value=container),
+        )
+
+    def test_present_blob_removed(self):
+        step = _step()
+        # exists(0) -> rm(0) -> gone(1)
+        container = _container(_Exec(0), _Exec(0), _Exec(1))
+        workflow_results = {}
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute(workflow_results, {}))
+        assert result is True
+        # rm targeted the exact base58 path
+        container.exec_run.assert_any_call(["rm", "-f", _PATH])
+        stored = workflow_results["delete_blob_on_disk_node-1"]
+        assert stored["removed"] is True
+        assert stored["existed"] is True
+        assert stored["path"] == _PATH
+
+    def test_absent_blob_missing_ok_default_passes(self):
+        step = _step()
+        # exists(1 -> absent) -> rm(0) -> gone(1)
+        container = _container(_Exec(1), _Exec(0), _Exec(1))
+        workflow_results = {}
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute(workflow_results, {}))
+        assert result is True
+        assert workflow_results["delete_blob_on_disk_node-1"]["removed"] is False
+
+    def test_absent_blob_missing_ok_false_fails(self):
+        step = _step(missing_ok=False)
+        container = _container(_Exec(1), _Exec(0), _Exec(1))
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_rm_nonzero_fails(self):
+        step = _step()
+        container = _container(_Exec(0), _Exec(1, b"permission denied"))
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_survives_after_rm_fails(self):
+        # rm reports success but the file is still there → must fail, else the
+        # strand would be a silent no-op.
+        step = _step()
+        container = _container(_Exec(0), _Exec(0), _Exec(0))
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_container_not_found_fails(self):
+        step = _step()
+        with (
+            patch(f"{_MODULE}.is_binary_mode", return_value=False),
+            patch(f"{_MODULE}.resolve_container", return_value=None),
+        ):
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_binary_mode_fails(self):
+        step = _step()
+        with patch(f"{_MODULE}.is_binary_mode", return_value=True):
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_unsafe_node_name_fails(self):
+        step = _step(node="../etc")
+        # Guard runs before any container work, so no patches needed.
+        result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_non_base58_blob_id_fails(self):
+        step = _step(blob_id="blob_0/x")  # '_', '0', '/' are not base58
+        result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_rm_failure_with_expected_failure_passes(self):
+        step = _step(expected_failure=True)
+        container = _container(_Exec(0), _Exec(1, b"boom"))
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is True
+
+    def test_exec_exception_fails(self):
+        step = _step()
+        container = MagicMock()
+        container.exec_run.side_effect = RuntimeError("docker down")
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_outputs_export_removed_flag(self):
+        cfg_step = _step(outputs={"was_removed": "removed"})
+        container = _container(_Exec(0), _Exec(0), _Exec(1))
+        dynamic_values = {}
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(cfg_step.execute({}, dynamic_values))
+        assert result is True
+        assert dynamic_values.get("was_removed") is True
+
+    def test_custom_data_dir_and_subdir(self):
+        step = _step(data_dir="/data", blobs_subdir="store")
+        container = _container(_Exec(0), _Exec(0), _Exec(1))
+        p1, p2 = self._patched(container)
+        with p1, p2:
+            result = _run(step.execute({}, {}))
+        assert result is True
+        container.exec_run.assert_any_call(["rm", "-f", f"/data/node-1/store/{_BLOB}"])

--- a/merobox/tests/unit/test_get_application_step.py
+++ b/merobox/tests/unit/test_get_application_step.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for the `get_application` workflow step.
+
+Covers `GetApplicationStep` validation + execute (success / outputs path to the
+nested blob bytecode / client error / expected_failure / JSON-RPC error). The
+client is a MagicMock patched in via `get_client_for_rpc_url`.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.get_application import GetApplicationStep
+
+_MODULE = "merobox.commands.bootstrap.steps.get_application"
+
+# get_application returns the {data: {application: {...}}} envelope.
+_RESPONSE = {
+    "data": {
+        "application": {
+            "id": "app123",
+            "version": "2.0.0",
+            "blob": {"bytecode": "Bk8aZ2x9Qm", "compiled": "Cp9bY3w0Rn"},
+        }
+    }
+}
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class TestGetApplicationValidation:
+    def setup_method(self):
+        self.base = {
+            "type": "get_application",
+            "node": "node-1",
+            "application_id": "app123",
+        }
+
+    def test_valid_config_passes(self):
+        GetApplicationStep(self.base)
+
+    def test_missing_application_id_raises(self):
+        cfg = {**self.base}
+        del cfg["application_id"]
+        with pytest.raises(ValueError, match="application_id"):
+            GetApplicationStep(cfg)
+
+    def test_application_id_not_string_raises(self):
+        with pytest.raises(ValueError, match="'application_id' must be a string"):
+            GetApplicationStep({**self.base, "application_id": 5})
+
+
+class TestGetApplicationExecute:
+    def setup_method(self):
+        self.config = {
+            "type": "get_application",
+            "node": "node-1",
+            "application_id": "app123",
+        }
+
+    def _patched(self, step, client):
+        return (
+            patch.object(
+                step,
+                "_resolve_node_for_client",
+                return_value=("http://localhost:1234", "node-1"),
+            ),
+            patch(f"{_MODULE}.get_client_for_rpc_url", return_value=client),
+            patch.object(step, "_resolve_dynamic_value", side_effect=lambda v, *_: v),
+        )
+
+    def test_success_stores_response(self):
+        step = GetApplicationStep(self.config)
+        client = MagicMock()
+        client.get_application.return_value = _RESPONSE
+        workflow_results = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute(workflow_results, {}))
+        assert result is True
+        client.get_application.assert_called_once_with("app123")
+        assert workflow_results["get_application_node-1"] == _RESPONSE
+
+    def test_outputs_export_nested_bytecode(self):
+        # The export unwrap strips the top-level `data`, so the blob id is
+        # reachable at `application.blob.bytecode` — this is how the strand
+        # workflow captures a version's blob id while it is the row's latest.
+        cfg = {**self.config, "outputs": {"v2_blob": "application.blob.bytecode"}}
+        step = GetApplicationStep(cfg)
+        client = MagicMock()
+        client.get_application.return_value = _RESPONSE
+        dynamic_values = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, dynamic_values))
+        assert result is True
+        assert dynamic_values.get("v2_blob") == "Bk8aZ2x9Qm"
+
+    def test_outputs_export_version(self):
+        cfg = {**self.config, "outputs": {"ver": "application.version"}}
+        step = GetApplicationStep(cfg)
+        client = MagicMock()
+        client.get_application.return_value = _RESPONSE
+        dynamic_values = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, dynamic_values))
+        assert result is True
+        assert dynamic_values.get("ver") == "2.0.0"
+
+    def test_client_error_fails_step(self):
+        step = GetApplicationStep(self.config)
+        client = MagicMock()
+        client.get_application.side_effect = RuntimeError("boom")
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_client_error_with_expected_failure_passes(self):
+        cfg = {**self.config, "expected_failure": True}
+        step = GetApplicationStep(cfg)
+        client = MagicMock()
+        client.get_application.side_effect = RuntimeError("boom")
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, {}))
+        assert result is True
+
+    def test_jsonrpc_error_body_fails_step(self):
+        step = GetApplicationStep(self.config)
+        client = MagicMock()
+        client.get_application.return_value = {"error": {"code": -1}}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3, patch.object(step, "_check_jsonrpc_error", return_value=True):
+            result = _run(step.execute({}, {}))
+        assert result is False

--- a/merobox/tests/unit/test_get_application_step.py
+++ b/merobox/tests/unit/test_get_application_step.py
@@ -86,7 +86,15 @@ class TestGetApplicationExecute:
             result = _run(step.execute(workflow_results, {}))
         assert result is True
         client.get_application.assert_called_once_with("app123")
-        assert workflow_results["get_application_node-1"] == _RESPONSE
+        # The `{data: ...}` envelope is unwrapped before storing, so a direct
+        # read and an `outputs:` path both root at `application`.
+        assert workflow_results["get_application_node-1"] == _RESPONSE["data"]
+        assert (
+            workflow_results["get_application_node-1"]["application"]["blob"][
+                "bytecode"
+            ]
+            == "Bk8aZ2x9Qm"
+        )
 
     def test_outputs_export_nested_bytecode(self):
         # The export unwrap strips the top-level `data`, so the blob id is

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -1236,6 +1236,33 @@ class TestGroupUpgradeStepSchemas:
         errors = config_module.validate_workflow_step(step, 0)
         assert any("application_id" in e for e in errors)
 
+    def test_valid_delete_blob_on_disk(self, config_module):
+        step = {
+            "type": "delete_blob_on_disk",
+            "node": "calimero-node-1",
+            "blob_id": "{{v2_blob_id}}",
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    def test_valid_delete_blob_on_disk_with_overrides(self, config_module):
+        step = {
+            "type": "delete_blob_on_disk",
+            "node": "calimero-node-1",
+            "blob_id": "{{v2_blob_id}}",
+            "data_dir": "/data",
+            "blobs_subdir": "store",
+            "missing_ok": False,
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    def test_invalid_delete_blob_on_disk_missing_blob_id(self, config_module):
+        step = {
+            "type": "delete_blob_on_disk",
+            "node": "calimero-node-1",
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert any("blob_id" in e for e in errors)
+
     def test_invalid_upgrade_group_missing_target(self, config_module):
         step = {
             "type": "upgrade_group",

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -1263,6 +1263,22 @@ class TestGroupUpgradeStepSchemas:
         errors = config_module.validate_workflow_step(step, 0)
         assert any("blob_id" in e for e in errors)
 
+    def test_valid_get_application(self, config_module):
+        step = {
+            "type": "get_application",
+            "node": "calimero-node-1",
+            "application_id": "{{app_id}}",
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    def test_invalid_get_application_missing_app_id(self, config_module):
+        step = {
+            "type": "get_application",
+            "node": "calimero-node-1",
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert any("application_id" in e for e in errors)
+
     def test_invalid_upgrade_group_missing_target(self, config_module):
         step = {
             "type": "upgrade_group",


### PR DESCRIPTION
Adds the two merobox steps the migrations-v2 `stranded → resync → recovers` e2e is blocked on. A follow-up **core** PR pins this release (`MIN_MEROBOX=0.6.38`) and adds the `37-stranded-resync.yml` workflow to the app-migration matrix.

## 1. `delete_blob_on_disk` — the strand primitive

`docker exec rm -f <data_dir>/<node>/blobs/<blob_id>` (default `data_dir=/app/data`).

`uninstall_application` does not remove the content-addressed blob, and a behind node **pre-stages** an upgrade-ladder rung over BlobShare during the sync gate — so `stop_node` alone can't make a rung's bytecode unobtainable (exactly why the earlier `stop_node`-only "stranded" workflow false-passed and was pulled from core). Deleting the intermediate blob on every holder strands a behind context (`NoMigrationPath`); `resync_context` then recovers it from a peer that advanced past the gap.

- The blob store is a flat dir of one file per blob named by the base58 blob id (core `crates/store/blobs` `FileSystem::path`), matching what `get_application`/`list_application_versions` surface.
- Confirms the file is **actually gone** after `rm` (fails on a silent survivor, so a no-op strand can't false-pass); confirms it **was present** unless `missing_ok` (default true).
- Docker-only (pairs with `partition_peers`); validates node-name + base58 blob-id before building the exec path (argv is a list). Stores `{blob_id, path, existed, removed}`.

## 2. `get_application` — version capture

Reads an application's current row (`id`, `version`, `blob.bytecode`, `blob.compiled`) via `GET admin-api/applications/{id}`.

The strand must delete a **specific** version's intermediate blob, but same-package bundles share one `applicationId` and core's `list_application_versions` returns blobs ordered by content hash (a `BTreeSet` over the raw 32-byte hash — version order is effectively random), so a version can't be picked from that list by index or value with workflow templating. The app row points at the latest install, so calling `get_application` right after installing `vN` captures `vN`'s base58 `blob.bytecode` — the exact id `delete_blob_on_disk` keys on.

`outputs:` paths start at `application` (the export unwrap strips the top-level `data`), e.g. `application.blob.bytecode` / `application.version`.

## Wiring & verification

Both steps registered across `executor.py` / `validate/validator.py` / `config.py` (`VALID_STEP_TYPES` + typed `*StepConfig` in `STEP_TYPE_MODELS`) / `steps/__init__.py`, like the existing fault/read steps.

- **27 unit tests** (`test_delete_blob_step.py` 18 + `test_get_application_step.py` 9) + **5 schema-validation tests**.
- 850 unit tests collect with no import errors; `black --check` + `ruff check` clean (`make format-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional workflow primitives for test/fault injection; `delete_blob_on_disk` only mutates files inside Docker test containers with input validation, not production paths or auth.
> 
> **Overview**
> Release **0.6.38** adds two bootstrap workflow steps aimed at migrations-v2 **stranded context → `resync_context` recovery** e2e tests.
> 
> **`get_application`** calls `GET admin-api/applications/{id}` and stores the current app row (version, `blob.bytecode`, etc.), with `outputs:` rooted at `application` so a workflow can capture the base58 bytecode id right after installing a specific version (same `applicationId` across bundle versions).
> 
> **`delete_blob_on_disk`** is a Docker-only fault injector: `docker exec rm -f` on `<data_dir>/<node>/blobs/<blob_id>` (defaults `/app/data`, subdir `blobs`). It validates node name and base58 blob id, requires a running container, fails if `rm` leaves the file behind, and treats a never-present blob as OK unless `missing_ok: false`. Results are exposed as `{blob_id, path, existed, removed}`.
> 
> Both types are registered in schema validation, the executor, and the validator; changelog and version bump are included, with **27 unit tests** and **5 schema tests** for the new steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c610271fbe74e107d97c370d2cbc90c768c9317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->