### PR TITLE
feat(steps): add delete_blob step (admin API, cascades chunked blobs) [0.6.39]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.39] - 2026-06-17
+
+### Added
+
+- New `delete_blob` workflow step: deletes a blob via the admin API
+  (`DELETE admin-api/blobs/{id}`, calimero-client-py `delete_blob`), which
+  cascades the parent metadata + every chunk file + chunk metadata. This is the
+  primitive the stranded-context resync e2e actually needs: `delete_blob_on_disk`
+  `rm`s the base58 PARENT id off disk and is a **no-op for any real (chunked)
+  blob** (the parent id is RocksDB-only metadata; the bytes live in chunk files
+  named by an unexposed chunk hash), so it can't make a rung's bytecode
+  unobtainable. Fields: `node`, `blob_id` (base58 parent id from
+  `list_application_versions` `blobId` / `get_application`
+  `application.blob.bytecode`), optional `missing_ok` (default `true` — a blob
+  already absent on the node is success). Works in docker and binary mode.
+
 ## [0.6.38] - 2026-06-16
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.38"
+__version__ = "0.6.39"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -111,6 +111,7 @@ VALID_STEP_TYPES = frozenset(
         "get_proposal_approvers",
         "upload_blob",
         "delete_blob_on_disk",
+        "delete_blob",
         "get_application",
         "create_mesh",
         "fuzzy_test",
@@ -726,6 +727,24 @@ class DeleteBlobOnDiskStepConfig(BaseStepConfig):
     missing_ok: Optional[bool] = Field(
         True,
         description="Treat a node that never held the blob as success (default true)",
+    )
+
+
+class DeleteBlobStepConfig(BaseStepConfig):
+    """Configuration for delete_blob step (admin API, cascades chunked blobs)."""
+
+    type: Literal["delete_blob"] = "delete_blob"
+    node: str = Field(..., description="Target node")
+    blob_id: str = Field(
+        ...,
+        description=(
+            "Base58 (parent) blob id to delete (e.g. list_application_versions "
+            "`blobId` or get_application `application.blob.bytecode`)"
+        ),
+    )
+    missing_ok: Optional[bool] = Field(
+        True,
+        description="Treat a blob already absent on this node as success (default true)",
     )
 
 
@@ -1515,6 +1534,7 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "get_proposal_approvers": GetProposalApproversStep,
     "upload_blob": UploadBlobStep,
     "delete_blob_on_disk": DeleteBlobOnDiskStepConfig,
+    "delete_blob": DeleteBlobStepConfig,
     "get_application": GetApplicationStepConfig,
     "create_mesh": CreateMeshStep,
     "fuzzy_test": FuzzyTestStep,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -31,6 +31,7 @@ from merobox.commands.bootstrap.steps import (
     CreateNamespaceInvitationStep,
     CreateNamespaceStep,
     DeleteBlobOnDiskStep,
+    DeleteBlobStep,
     DeleteContextStep,
     DeleteGroupStep,
     DeleteNamespaceStep,
@@ -2157,6 +2158,8 @@ class WorkflowExecutor:
             return UploadBlobStep(step_config, **common_kwargs)
         elif step_type == "delete_blob_on_disk":
             return DeleteBlobOnDiskStep(step_config, **common_kwargs)
+        elif step_type == "delete_blob":
+            return DeleteBlobStep(step_config, **common_kwargs)
         elif step_type == "get_application":
             return GetApplicationStep(step_config, **common_kwargs)
         elif step_type == "create_mesh":

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -10,7 +10,10 @@ from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.bootstrap.steps.blob import UploadBlobStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
-from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
+from merobox.commands.bootstrap.steps.delete_blob import (
+    DeleteBlobOnDiskStep,
+    DeleteBlobStep,
+)
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
@@ -165,6 +168,7 @@ __all__ = [
     "JsonAssertStep",
     "UploadBlobStep",
     "DeleteBlobOnDiskStep",
+    "DeleteBlobStep",
     "GetApplicationStep",
     "CreateMeshStep",
     "FuzzyTestStep",

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -297,10 +297,14 @@ class DeleteBlobStep(BaseStep):
             api_result = client.delete_blob(blob_id)
             result = ok(api_result)
         except Exception as e:
-            # The admin API errors ("Blob not found") when the blob's metadata is
-            # already absent on this node; under missing_ok that IS the desired
-            # end state, reached either way — report success without deleting.
-            if missing_ok and "not found" in str(e).lower():
+            # The admin API errors with "Blob not found" (core's
+            # `node_client.delete_blob` bails when the blob metadata is absent —
+            # crates/node/primitives/src/client/blob.rs) when the blob is already
+            # gone on this node; under missing_ok that IS the desired end state,
+            # reached either way — report success without deleting. Match the
+            # anchored "blob not found" (not a bare "not found") so unrelated
+            # failures like "host not found" / "connection refused" still fail.
+            if missing_ok and "blob not found" in str(e).lower():
                 stored = {"blob_id": blob_id, "deleted": False}
                 workflow_results[f"delete_blob_{node_name}"] = stored
                 if "outputs" in self.config:
@@ -330,12 +334,25 @@ class DeleteBlobStep(BaseStep):
             return False
 
         # client-py returns the flat `BlobDeleteResponse` (`{blob_id, deleted}`).
+        # Guard the shape before storing so a non-dict can't slip through and
+        # surface later as a confusing `outputs:` export error.
         data = result["data"]
+        if not isinstance(data, dict):
+            if expected_failure:
+                self._report_expected_failure(
+                    f"unexpected delete_blob response type {type(data).__name__}"
+                )
+                return True
+            console.print(
+                f"[red]delete_blob on {node_name}: unexpected response type "
+                f"{type(data).__name__}[/red]"
+            )
+            return False
         workflow_results[f"delete_blob_{node_name}"] = data
         if "outputs" in self.config:
             self._export_variables(data, node_name, dynamic_values)
 
-        deleted = data.get("deleted") if isinstance(data, dict) else None
+        deleted = data.get("deleted")
         console.print(
             f"[green]✓ delete_blob {blob_id} on {node_name}: deleted={deleted}[/green]"
         )

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -28,6 +28,8 @@ from merobox.commands.bootstrap.steps._docker_utils import (
     resolve_container,
 )
 from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.client import get_client_for_rpc_url
+from merobox.commands.result import fail, ok
 from merobox.commands.utils import console
 
 # merod's per-node data root inside a merobox container (CALIMERO_HOME), and the
@@ -233,3 +235,110 @@ def _decode(output: Any) -> str:
     if isinstance(output, bytes):
         return output.decode("utf-8", errors="replace").strip()
     return str(output).strip() if output is not None else ""
+
+
+class DeleteBlobStep(BaseStep):
+    """Delete a blob via the admin API (`DELETE admin-api/blobs/{id}`).
+
+    Unlike `delete_blob_on_disk` — which `rm`s the base58 PARENT id off disk and
+    is a NO-OP for any real (chunked) blob, because the parent id is RocksDB-only
+    metadata and the bytes live in chunk files named by an unexposed chunk hash —
+    this routes through the node's blob store (calimero-client-py `delete_blob`),
+    which cascades the parent metadata + every chunk file + chunk metadata. That
+    actually makes a rung's bytecode unobtainable, so it is the primitive the
+    stranded-context resync e2e needs. Works in both docker and binary mode.
+
+    Fields:
+      node:       target node.
+      blob_id:    base58 (parent) blob id to delete (e.g. from
+                  `list_application_versions` `blobId` or `get_application`
+                  `application.blob.bytecode`).
+      missing_ok: optional (default true) — a blob already absent on this node is
+                  still success (the goal is "absent here", reached either way).
+
+    Stores `{blob_id, deleted}` under `delete_blob_{node}` and exposes it to
+    `outputs:`.
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "blob_id"]
+
+    def _validate_field_types(self) -> None:
+        step_name = self.config.get(
+            "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+        )
+        for field in ("node", "blob_id"):
+            if not isinstance(self.config.get(field), str):
+                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
+        missing_ok = self.config.get("missing_ok")
+        if missing_ok is not None and not isinstance(missing_ok, bool):
+            raise ValueError(
+                f"Step '{step_name}': 'missing_ok' must be a boolean if provided"
+            )
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self._resolve_dynamic_value(
+            self.config["node"], workflow_results, dynamic_values
+        )
+        blob_id = self._resolve_dynamic_value(
+            self.config["blob_id"], workflow_results, dynamic_values
+        )
+        # `.get(..., True)` returns None (not the default) for an explicit
+        # `missing_ok: null`, and `bool(None)` is False — so collapse None here.
+        missing_ok_raw = self.config.get("missing_ok")
+        missing_ok = True if missing_ok_raw is None else bool(missing_ok_raw)
+        expected_failure = self._is_expected_failure()
+
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
+            api_result = client.delete_blob(blob_id)
+            result = ok(api_result)
+        except Exception as e:
+            # The admin API errors ("Blob not found") when the blob's metadata is
+            # already absent on this node; under missing_ok that IS the desired
+            # end state, reached either way — report success without deleting.
+            if missing_ok and "not found" in str(e).lower():
+                stored = {"blob_id": blob_id, "deleted": False}
+                workflow_results[f"delete_blob_{node_name}"] = stored
+                if "outputs" in self.config:
+                    self._export_variables(stored, node_name, dynamic_values)
+                console.print(
+                    f"[green]✓ delete_blob on {node_name}: blob {blob_id} "
+                    f"already absent[/green]"
+                )
+                if expected_failure:
+                    self._report_unexpected_success()
+                return True
+            result = fail("delete_blob failed", error=e)
+
+        if not result["success"]:
+            if expected_failure:
+                self._report_expected_failure(str(result.get("error", "Unknown error")))
+                return True
+            console.print(
+                f"[red]delete_blob failed on {node_name}: {result.get('error')}[/red]"
+            )
+            return False
+
+        if self._check_jsonrpc_error(result["data"]):
+            if expected_failure:
+                self._report_expected_failure("JSON-RPC error returned")
+                return True
+            return False
+
+        # client-py returns the flat `BlobDeleteResponse` (`{blob_id, deleted}`).
+        data = result["data"]
+        workflow_results[f"delete_blob_{node_name}"] = data
+        if "outputs" in self.config:
+            self._export_variables(data, node_name, dynamic_values)
+
+        deleted = data.get("deleted") if isinstance(data, dict) else None
+        console.print(
+            f"[green]✓ delete_blob {blob_id} on {node_name}: deleted={deleted}[/green]"
+        )
+        if expected_failure:
+            self._report_unexpected_success()
+        return True

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -11,7 +11,10 @@ from merobox.commands.bootstrap.steps.assert_log import (
 )
 from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.context import CreateContextStep
-from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobOnDiskStep
+from merobox.commands.bootstrap.steps.delete_blob import (
+    DeleteBlobOnDiskStep,
+    DeleteBlobStep,
+)
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
@@ -361,6 +364,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = InjectNetworkFaultStep
         elif step_type == "delete_blob_on_disk":
             step_class = DeleteBlobOnDiskStep
+        elif step_type == "delete_blob":
+            step_class = DeleteBlobStep
         elif step_type == "get_application":
             step_class = GetApplicationStep
         else:

--- a/merobox/tests/unit/test_delete_blob_api_step.py
+++ b/merobox/tests/unit/test_delete_blob_api_step.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for the `delete_blob` workflow step (admin-API variant).
+
+Covers `DeleteBlobStep` validation + execute: success (deleted=true), the
+`missing_ok` not-found path (success without deleting), not-found WITHOUT
+missing_ok (fail), generic client error, expected_failure, JSON-RPC error body,
+and outputs export. The client is a MagicMock patched in via
+`get_client_for_rpc_url`.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.delete_blob import DeleteBlobStep
+
+_MODULE = "merobox.commands.bootstrap.steps.delete_blob"
+
+_BLOB = "Bk8aZ2x9Qm"
+# client-py `delete_blob` returns the flat snake_case BlobDeleteResponse.
+_RESPONSE = {"blob_id": _BLOB, "deleted": True}
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class TestDeleteBlobValidation:
+    def setup_method(self):
+        self.base = {"type": "delete_blob", "node": "node-1", "blob_id": _BLOB}
+
+    def test_valid_config_passes(self):
+        DeleteBlobStep(self.base)
+
+    def test_missing_blob_id_raises(self):
+        with pytest.raises(ValueError, match="blob_id"):
+            DeleteBlobStep({"type": "delete_blob", "node": "node-1"})
+
+    def test_blob_id_not_string_raises(self):
+        with pytest.raises(ValueError, match="'blob_id' must be a string"):
+            DeleteBlobStep({**self.base, "blob_id": 5})
+
+    def test_missing_ok_not_bool_raises(self):
+        with pytest.raises(ValueError, match="'missing_ok' must be a boolean"):
+            DeleteBlobStep({**self.base, "missing_ok": "yes"})
+
+
+class TestDeleteBlobExecute:
+    def setup_method(self):
+        self.config = {"type": "delete_blob", "node": "node-1", "blob_id": _BLOB}
+
+    def _patched(self, step, client):
+        return (
+            patch.object(
+                step,
+                "_resolve_node_for_client",
+                return_value=("http://localhost:1234", "node-1"),
+            ),
+            patch(f"{_MODULE}.get_client_for_rpc_url", return_value=client),
+            patch.object(step, "_resolve_dynamic_value", side_effect=lambda v, *_: v),
+        )
+
+    def test_success_stores_response(self):
+        step = DeleteBlobStep(self.config)
+        client = MagicMock()
+        client.delete_blob.return_value = _RESPONSE
+        workflow_results = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute(workflow_results, {}))
+        assert result is True
+        client.delete_blob.assert_called_once_with(_BLOB)
+        assert workflow_results["delete_blob_node-1"] == _RESPONSE
+
+    def test_outputs_export_deleted(self):
+        cfg = {**self.config, "outputs": {"gone": "deleted"}}
+        step = DeleteBlobStep(cfg)
+        client = MagicMock()
+        client.delete_blob.return_value = _RESPONSE
+        dynamic_values = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, dynamic_values))
+        assert result is True
+        assert dynamic_values.get("gone") is True
+
+    def test_missing_ok_treats_not_found_as_success(self):
+        # Default missing_ok=True: the admin API erroring "Blob not found" is the
+        # desired end state (absent here), so the step succeeds without deleting.
+        step = DeleteBlobStep(self.config)
+        client = MagicMock()
+        client.delete_blob.side_effect = RuntimeError("Client error: Blob not found")
+        workflow_results = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute(workflow_results, {}))
+        assert result is True
+        assert workflow_results["delete_blob_node-1"] == {
+            "blob_id": _BLOB,
+            "deleted": False,
+        }
+
+    def test_not_found_without_missing_ok_fails(self):
+        step = DeleteBlobStep({**self.config, "missing_ok": False})
+        client = MagicMock()
+        client.delete_blob.side_effect = RuntimeError("Client error: Blob not found")
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_generic_client_error_fails(self):
+        # A non-not-found error fails even under missing_ok.
+        step = DeleteBlobStep(self.config)
+        client = MagicMock()
+        client.delete_blob.side_effect = RuntimeError("boom")
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_client_error_with_expected_failure_passes(self):
+        cfg = {**self.config, "expected_failure": True}
+        step = DeleteBlobStep(cfg)
+        client = MagicMock()
+        client.delete_blob.side_effect = RuntimeError("boom")
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, {}))
+        assert result is True
+
+    def test_jsonrpc_error_body_fails_step(self):
+        step = DeleteBlobStep(self.config)
+        client = MagicMock()
+        client.delete_blob.return_value = {"error": {"code": -1}}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3, patch.object(step, "_check_jsonrpc_error", return_value=True):
+            result = _run(step.execute({}, {}))
+        assert result is False

--- a/merobox/tests/unit/test_delete_blob_api_step.py
+++ b/merobox/tests/unit/test_delete_blob_api_step.py
@@ -124,6 +124,29 @@ class TestDeleteBlobExecute:
             result = _run(step.execute({}, {}))
         assert result is False
 
+    def test_unrelated_not_found_error_not_swallowed(self):
+        # The match is anchored to "blob not found": a network error whose text
+        # merely contains "not found" must still fail under missing_ok.
+        step = DeleteBlobStep(self.config)
+        client = MagicMock()
+        client.delete_blob.side_effect = RuntimeError("host not found")
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute({}, {}))
+        assert result is False
+
+    def test_non_dict_response_fails(self):
+        # A non-dict API response is rejected before storing, not silently kept.
+        step = DeleteBlobStep(self.config)
+        client = MagicMock()
+        client.delete_blob.return_value = "not-a-dict"
+        workflow_results = {}
+        p1, p2, p3 = self._patched(step, client)
+        with p1, p2, p3:
+            result = _run(step.execute(workflow_results, {}))
+        assert result is False
+        assert "delete_blob_node-1" not in workflow_results
+
     def test_client_error_with_expected_failure_passes(self):
         cfg = {**self.config, "expected_failure": True}
         step = DeleteBlobStep(cfg)


### PR DESCRIPTION
Closes #284.

## Why
`delete_blob_on_disk` (0.6.38) `rm`s `<data>/<node>/blobs/<blob_id>` using the base58 **parent** blob id — but merod blobs are content-**chunked**: the parent id is RocksDB-only metadata (`BlobMeta.links` → chunk ids), and the bytes live in chunk files named by each chunk's **own** hash (never exposed by any API). So the `rm` targets a path that doesn't exist for any real (multi-chunk) blob → no-op → the blob stays fully fetchable, and the stranded-context resync e2e (core #37) can't actually strand a context.

## What
New `delete_blob` step that deletes via the **admin API** (`DELETE admin-api/blobs/{id}` → calimero-client-py `delete_blob` → core `node_client.delete_blob`), which **cascades** the parent metadata + every chunk file + chunk metadata. Works in docker and binary mode.

Fields:
- `node` — target node
- `blob_id` — base58 **parent** id (from `list_application_versions` `blobId` or `get_application` `application.blob.bytecode`)
- `missing_ok` — default `true`; a blob already absent on the node is success (catches the admin API's "Blob not found")

Wired into the step registry (`steps/__init__.py`), executor dispatch, config (`STEP_TYPE_MODELS` + `DeleteBlobStepConfig`), and the validator. Modeled on the guard-free `get_application` step.

## Tests
11 unit tests (`test_delete_blob_api_step.py`): success/outputs, `missing_ok` not-found → success, not-found without `missing_ok` → fail, generic error → fail, `expected_failure`, JSON-RPC error body, validation. `ruff`/`black` clean.

> Note: the full local unit run shows 27 **pre-existing** failures in `test_abort_migration_step.py` / `test_cascade_status_steps.py` / `test_migrations_v2_steps.py` — these fail identically on clean `master` because the local venv has `calimero-client-py 0.3.0` (those steps version-guard ≥0.6.17/0.6.18). Unrelated to this PR; CI installs the correct version.

## Follow-up
Once released (0.6.39), core #37 (`37-stranded-resync`) swaps its two `delete_blob_on_disk` steps for `delete_blob`, bumps the merobox pin, and re-adds itself to the `app-migration-e2e` matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped new workflow step and test coverage; no changes to auth, persistence, or existing step semantics beyond additive registry wiring.
> 
> **Overview**
> **Merobox 0.6.39** adds a **`delete_blob`** workflow step that removes blobs through the node **admin API** (`DELETE admin-api/blobs/{id}` / `calimero-client-py` `delete_blob`), so deletion **cascades** parent metadata and all chunk files—unlike **`delete_blob_on_disk`**, which often cannot remove real chunked bytecode.
> 
> The step takes **`node`**, **`blob_id`** (base58 parent id), and optional **`missing_ok`** (default **true**, treats “blob not found” as success). It works in **docker and binary** mode, stores `{blob_id, deleted}` under `delete_blob_{node}`, supports **`outputs:`** and **`expected_failure`**, and is registered in config validation, the executor, and the validator.
> 
> **11 unit tests** cover success, outputs, `missing_ok` behavior, and error paths. Changelog and package version are bumped to **0.6.39**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d700e3230a20c0942663cba978dee748d3a4c0b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->