### PR TITLE
chore(steps): remove unused protocol field from create_context/create_mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.40] - 2026-06-22
+
+### Removed
+
+- Dropped the unused `protocol` field from the `create_context` and `create_mesh` workflow steps, plus the corresponding "Protocol" line from context display output. Calimero core is chain-free (DAG-based local group governance), so the field was parsed but never forwarded to the client. Removal is non-breaking: `BaseStepConfig` is `extra="allow"`, so any legacy workflow still specifying `protocol:` continues to load and is simply ignored.
+
 ## [0.6.39] - 2026-06-17
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.39"
+__version__ = "0.6.40"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -233,7 +233,6 @@ class CreateContextStep(BaseStepConfig):
     service_name: Optional[str] = Field(
         None, description="Optional service name for context creation"
     )
-    protocol: Optional[str] = Field(None, description="Protocol to use (e.g., near)")
 
 
 class CreateIdentityStep(BaseStepConfig):
@@ -1424,7 +1423,6 @@ class CreateMeshStep(BaseStepConfig):
     context_node: str = Field(..., description="Node to create context on")
     application_id: str = Field(..., description="Application ID")
     nodes: list[str] = Field(..., description="List of nodes to include in mesh")
-    protocol: Optional[str] = Field(None, description="Protocol to use")
     params: Optional[str] = Field(None, description="Initialization params JSON string")
 
 

--- a/merobox/commands/context.py
+++ b/merobox/commands/context.py
@@ -441,9 +441,6 @@ def show(node, context_id, verbose):
                     f"[cyan]Application ID:[/cyan] {context_data['applicationId']}"
                 )
 
-            if "protocol" in context_data:
-                console.print(f"[cyan]Protocol:[/cyan] {context_data['protocol']}")
-
             if "contextStateHash" in context_data:
                 console.print(
                     f"[cyan]Context State Hash:[/cyan] {context_data['contextStateHash']}"


### PR DESCRIPTION
## Summary

Calimero core is chain-free (DAG-based local group governance — see core PRs #2080 / #2078), so the `protocol` field on the `create_context` and `create_mesh` workflow steps is dead: it is parsed but never forwarded to the client.

## Changes
- Remove the `protocol` Pydantic field from `CreateContextStep` and `CreateMeshStep` (`merobox/commands/bootstrap/config.py`).
- Remove the "Protocol" line from context display output (`merobox/commands/context.py`).
- Bump version `0.6.39` → `0.6.40` + CHANGELOG entry.

## Compatibility
Non-breaking. `BaseStepConfig` is `extra="allow"`, so any existing workflow still specifying `protocol:` continues to load and the field is simply ignored.

## Verification
- `python -m py_compile` on the edited modules.
- `merobox bootstrap validate` on a workflow with `protocol:` removed → valid.
- Native (`--no-docker`) node boot + workflow load confirmed against a chain-free core build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and display cleanup only; legacy `protocol:` in YAML still loads via `extra="allow"` and no runtime behavior depended on the removed field.
> 
> **Overview**
> Removes the legacy **`protocol`** workflow knob from **`create_context`** and **`create_mesh`** step schemas and drops the **Protocol** line from **`merobox context show`** output.
> 
> Calimero core no longer uses chain-specific protocol selection for context/mesh setup, so the field was only accepted in YAML and never passed through to **`create_context`**. **0.6.40** release notes document the change; **`BaseStepConfig`** still allows extra keys, so workflows that still list **`protocol:`** keep loading and the key is ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951d602daa388e7c56f5c7ae2c788a25fbd5eb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->