### PR TITLE
feat(auth): embedded auth in Docker mode + auth-step fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Embedded auth in Docker mode**: `auth_mode: embedded` (workflow YAML) and
+  `--auth-mode embedded` (`merobox run` / `bootstrap run`) now work without
+  `--no-docker`. `--auth-mode` is a `merod init` flag, so containers accept it
+  the same way native processes do — node containers are initialised with the
+  in-node auth router and every API endpoint requires a JWT, exactly like
+  binary mode. `login`/`refresh` steps and the auto-auth
+  `--auth-username`/`--auth-password` path work unchanged against container
+  URLs. (`--auth-service` remains the separate proxy topology: a standalone
+  mero-auth container behind Traefik.) This unblocks flipping docker-mode e2e
+  fleets — e.g. calimero-network/core's scenario matrix — to run with auth
+  enforced, matching production shape.
+
+### Fixed
+
+- `bootstrap validate` no longer rejects the auth step types shipped in
+  0.6.33: `login`, `refresh`, and `ws_connect`/`ws_subscribe` were missing
+  from the validator's known-type list, so valid workflows (including
+  `workflow-embedded-auth-example.yml`) failed validation while executing
+  fine under `bootstrap run`.
+- Refresh 401s now surface the server's actual reason instead of a hardcoded
+  "Refresh token expired or invalid" — core also 401s *proactive* refresh
+  ("Access token still valid": `/auth/refresh` is only honored once the
+  access token has expired), and the canned message misdiagnosed that case.
+  `workflow-embedded-auth-example.yml` now pins core's real behavior: the
+  post-login refresh asserts `expected_failure: true`.
+
 ## [0.6.40] - 2026-06-22
 
 ### Removed

--- a/merobox/commands/auth.py
+++ b/merobox/commands/auth.py
@@ -337,8 +337,11 @@ class AuthManager:
                                 f"Invalid JSON response from refresh endpoint: {e}"
                             ) from e
                     elif response.status == 401:
+                        # Surface the server's own reason: core also 401s
+                        # proactive refresh ("Access token still valid"), which
+                        # is the opposite of an expired refresh token.
                         raise AuthenticationError(
-                            "Refresh token expired or invalid. Please re-authenticate."
+                            f"Refresh rejected (401): {response_text.strip() or 'no reason given'}"
                         )
                     else:
                         raise AuthenticationError(

--- a/merobox/commands/bootstrap/bootstrap.py
+++ b/merobox/commands/bootstrap/bootstrap.py
@@ -231,7 +231,7 @@ def bootstrap():
     "--auth-mode",
     type=click.Choice(["embedded", "proxy"], case_sensitive=False),
     default=None,
-    help="Authentication mode for merod (binary mode only). 'embedded' enables built-in auth with JWT protection on all endpoints. Default is 'proxy' (no embedded auth).",
+    help="Authentication mode for merod (binary and Docker mode). 'embedded' enables built-in auth with JWT protection on all endpoints. Default is 'proxy' (no embedded auth).",
 )
 @click.option(
     "--auth-username",
@@ -294,14 +294,6 @@ def run(
             "[yellow]⚠ --verbose and --quiet are mutually exclusive; "
             "--verbose takes precedence.[/yellow]"
         )
-
-    # Validate --auth-mode is only used with --no-docker (binary mode)
-    if auth_mode and not no_docker:
-        console.print(
-            "[red]--auth-mode is only supported with --no-docker (binary mode). "
-            "For Docker mode, use --auth-service instead.[/red]"
-        )
-        sys.exit(1)
 
     # --auth-username/--auth-password are optional under --auth-mode=embedded:
     # provide both to auto-authenticate every node up front, or omit both and

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -984,10 +984,10 @@ class WorkflowExecutor:
         """Build the keyword arguments for ``manager.run_node()``.
 
         Shared by every node-startup path (``_start_nodes`` and
-        ``_start_single_node``) so they stay in sync. ``merod_args`` /
-        ``auth_mode`` only apply in binary mode; ``use_image_entrypoint`` only
-        in Docker mode. ``mock_tee`` appends ``--mock-tee`` to ``merod run`` in
-        both modes.
+        ``_start_single_node``) so they stay in sync. ``merod_args`` only
+        applies in binary mode; ``use_image_entrypoint`` only in Docker mode.
+        ``auth_mode`` and ``mock_tee`` apply in both modes (``--auth-mode`` is
+        a merod init flag, mode-independent).
         """
         kwargs: dict[str, Any] = {
             "node_name": node_name,
@@ -1010,9 +1010,9 @@ class WorkflowExecutor:
             # launch with `merod run --mock-tee` for local TEE testing
             "mock_tee": mock_tee,
         }
+        if self.auth_mode:
+            kwargs["auth_mode"] = self.auth_mode
         if self.is_binary_mode:
-            if self.auth_mode:
-                kwargs["auth_mode"] = self.auth_mode
             if self.merod_args:
                 kwargs["merod_args"] = self.merod_args
         else:
@@ -1423,9 +1423,9 @@ class WorkflowExecutor:
                         run_multiple_kwargs["network_admin"] = nodes_config[
                             "network_admin"
                         ]
+                if self.auth_mode:
+                    run_multiple_kwargs["auth_mode"] = self.auth_mode
                 if self.is_binary_mode:
-                    if self.auth_mode:
-                        run_multiple_kwargs["auth_mode"] = self.auth_mode
                     if self.merod_args:
                         run_multiple_kwargs["merod_args"] = self.merod_args
                 else:

--- a/merobox/commands/bootstrap/run/run.py
+++ b/merobox/commands/bootstrap/run/run.py
@@ -109,7 +109,7 @@ async def run_workflow(
             detail); final summaries and errors are always shown
         auth_service: Whether to enable authentication service integration
         cli_remote_nodes: Remote nodes config from CLI options (--remote-node/--remote-auth)
-        auth_mode: Authentication mode for merod (binary mode only)
+        auth_mode: Authentication mode for merod (binary and Docker mode)
         auth_username: Username for embedded auth authentication
         auth_password: Password for embedded auth authentication
         dry_run: If True, validate workflow without executing steps
@@ -141,15 +141,12 @@ async def run_workflow(
         yaml_auth_mode = config.get("auth_mode")
         effective_auth_mode = auth_mode or yaml_auth_mode
 
-        # Validate auth_mode configuration
+        # Validate auth_mode configuration. Works in both binary and Docker
+        # mode: `--auth-mode` is a merod init flag, so containers accept it
+        # the same way native processes do. (`--auth-service` remains the
+        # separate proxy-topology option: a standalone mero-auth container
+        # behind Traefik.)
         if effective_auth_mode:
-            if not effective_no_docker:
-                console.print(
-                    "[red]auth_mode is only supported with --no-docker (binary mode) or no_docker: true in workflow config. "
-                    "For Docker mode, use --auth-service instead.[/red]"
-                )
-                return False
-
             # Note: --auth-username/--auth-password are optional. When provided,
             # merobox auto-authenticates every node up front (legacy convenience).
             # When omitted, the workflow is expected to drive auth declaratively
@@ -272,7 +269,7 @@ def run_workflow_sync(
             detail); final summaries and errors are always shown
         auth_service: Whether to enable authentication service integration
         cli_remote_nodes: Remote nodes config from CLI options (--remote-node/--remote-auth)
-        auth_mode: Authentication mode for merod (binary mode only)
+        auth_mode: Authentication mode for merod (binary and Docker mode)
         auth_username: Username for embedded auth authentication
         auth_password: Password for embedded auth authentication
         dry_run: If True, validate workflow without executing steps

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -19,9 +19,6 @@ from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
 from merobox.commands.bootstrap.steps.get_application import GetApplicationStep
-from merobox.commands.bootstrap.steps.login import LoginStep
-from merobox.commands.bootstrap.steps.refresh import RefreshStep
-from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
 from merobox.commands.bootstrap.steps.group_create import CreateNamespaceStep
 from merobox.commands.bootstrap.steps.group_governance import (
     DetachContextFromGroupStep,
@@ -80,6 +77,7 @@ from merobox.commands.bootstrap.steps.join_subgroup_inheritance import (
     JoinSubgroupInheritanceStep,
 )
 from merobox.commands.bootstrap.steps.json_assertion import JsonAssertStep
+from merobox.commands.bootstrap.steps.login import LoginStep
 from merobox.commands.bootstrap.steps.mesh import CreateMeshStep
 from merobox.commands.bootstrap.steps.namespace import (
     CreateGroupInNamespaceStep,
@@ -103,6 +101,7 @@ from merobox.commands.bootstrap.steps.proposals import (
     GetProposalStep,
     ListProposalsStep,
 )
+from merobox.commands.bootstrap.steps.refresh import RefreshStep
 from merobox.commands.bootstrap.steps.repeat import RepeatStep
 from merobox.commands.bootstrap.steps.restart import RestartContainerStep
 from merobox.commands.bootstrap.steps.script import ScriptStep
@@ -121,6 +120,7 @@ from merobox.commands.bootstrap.steps.tee import (
 )
 from merobox.commands.bootstrap.steps.wait import WaitStep
 from merobox.commands.bootstrap.steps.wait_for_sync import WaitForSyncStep
+from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
 from merobox.commands.constants import RESERVED_NODE_CONFIG_KEYS
 
 

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -19,6 +19,9 @@ from merobox.commands.bootstrap.steps.execute import ExecuteStep
 from merobox.commands.bootstrap.steps.fault import InjectNetworkFaultStep
 from merobox.commands.bootstrap.steps.fuzzy_test import FuzzyTestStep
 from merobox.commands.bootstrap.steps.get_application import GetApplicationStep
+from merobox.commands.bootstrap.steps.login import LoginStep
+from merobox.commands.bootstrap.steps.refresh import RefreshStep
+from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
 from merobox.commands.bootstrap.steps.group_create import CreateNamespaceStep
 from merobox.commands.bootstrap.steps.group_governance import (
     DetachContextFromGroupStep,
@@ -374,6 +377,12 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = DeleteBlobStep
         elif step_type == "get_application":
             step_class = GetApplicationStep
+        elif step_type == "login":
+            step_class = LoginStep
+        elif step_type == "refresh":
+            step_class = RefreshStep
+        elif step_type in ("ws_connect", "ws_subscribe"):
+            step_class = WebSocketConnectStep
         elif step_type == "set_tee_admission_policy":
             step_class = SetTeeAdmissionPolicyStep
         elif step_type == "tee_fleet_join":

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -365,6 +365,7 @@ class DockerManager(CleanupMixin):
         network_admin: bool = True,  # add NET_ADMIN cap for fault-injection steps
         preserve_default_bootstrap: bool = False,  # keep merod-init bootstrap.nodes in e2e mode
         mock_tee: bool = False,  # launch with `merod run --mock-tee` (mock TEE attestation)
+        auth_mode: str = None,  # merod auth mode ('embedded' mounts the auth router in-node)
     ) -> bool:
         """Run a Calimero node container."""
         try:
@@ -691,6 +692,8 @@ class DockerManager(CleanupMixin):
                         "--swarm-port",
                         str(DEFAULT_P2P_PORT),
                     ]
+                    if auth_mode:
+                        init_config["command"].extend(["--auth-mode", auth_mode])
                     # Note: Don't set entrypoint - use image default
                 else:
                     # Original behavior - bypass entrypoint for direct merod control
@@ -709,6 +712,8 @@ class DockerManager(CleanupMixin):
                         "--swarm-port",
                         str(DEFAULT_P2P_PORT),
                     ]
+                    if auth_mode:
+                        init_config["command"].extend(["--auth-mode", auth_mode])
                 init_config["detach"] = False
 
                 try:
@@ -882,6 +887,13 @@ class DockerManager(CleanupMixin):
                 hostname = node_name.replace("calimero-", "").replace("-", "")
                 console.print(
                     f"  - Auth Node URL: [link]http://{hostname}.127.0.0.1.nip.io[/link]"
+                )
+            if auth_mode == "embedded":
+                console.print(
+                    f"  - Auth endpoints: http://localhost:{display_rpc_port}/auth (register/login)"
+                )
+                console.print(
+                    "[yellow]  All API endpoints require a valid JWT token (embedded auth enabled)[/yellow]"
                 )
             return True
 
@@ -1311,6 +1323,7 @@ class DockerManager(CleanupMixin):
         mdns: Optional[bool] = None,
         network_admin: bool = True,
         preserve_default_bootstrap: bool = False,  # keep merod-init bootstrap.nodes in e2e mode
+        auth_mode: str = None,  # merod auth mode ('embedded' mounts the auth router in-node)
     ) -> bool:
         """Run multiple Calimero nodes with automatic port allocation."""
         console.print(f"[bold]Starting {count} Calimero nodes...[/bold]")
@@ -1372,6 +1385,7 @@ class DockerManager(CleanupMixin):
                 mdns=mdns,
                 network_admin=network_admin,
                 preserve_default_bootstrap=preserve_default_bootstrap,
+                auth_mode=auth_mode,
             )
 
         success_count = 0

--- a/merobox/commands/run.py
+++ b/merobox/commands/run.py
@@ -86,7 +86,7 @@ console = Console()
     "--auth-mode",
     type=click.Choice(["embedded", "proxy"], case_sensitive=False),
     default=None,
-    help="Authentication mode for merod (binary mode only). 'embedded' enables built-in auth with JWT protection on all endpoints. Default is 'proxy' (no embedded auth).",
+    help="Authentication mode for merod (binary and Docker mode). 'embedded' enables built-in auth with JWT protection on all endpoints. Default is 'proxy' (no embedded auth).",
 )
 def run(
     count,
@@ -109,14 +109,6 @@ def run(
     auth_mode,
 ):
     """Run Calimero node(s)."""
-    # Validate --auth-mode is only used with --no-docker (binary mode)
-    if auth_mode and not no_docker:
-        console.print(
-            "[red]--auth-mode is only supported with --no-docker (binary mode). "
-            "For Docker mode, use --auth-service instead.[/red]"
-        )
-        sys.exit(1)
-
     # Select manager based on mode
     if no_docker:
         calimero_manager = BinaryManager(binary_path=binary_path)
@@ -168,10 +160,10 @@ def run(
             "rust_backtrace": rust_backtrace,
         }
 
+        if auth_mode:
+            run_kwargs["auth_mode"] = auth_mode
         if no_docker:
             run_kwargs["foreground"] = foreground
-            if auth_mode:
-                run_kwargs["auth_mode"] = auth_mode
         else:
             # Only applicable in Docker mode
             run_kwargs["use_image_entrypoint"] = use_image_entrypoint
@@ -196,10 +188,9 @@ def run(
             "log_level": log_level,
             "rust_backtrace": rust_backtrace,
         }
-        if no_docker:
-            if auth_mode:
-                run_multiple_kwargs["auth_mode"] = auth_mode
-        else:
+        if auth_mode:
+            run_multiple_kwargs["auth_mode"] = auth_mode
+        if not no_docker:
             run_multiple_kwargs["use_image_entrypoint"] = use_image_entrypoint
 
         success = calimero_manager.run_multiple_nodes(**run_multiple_kwargs)

--- a/workflow-examples/workflow-embedded-auth-example.yml
+++ b/workflow-examples/workflow-embedded-auth-example.yml
@@ -5,8 +5,10 @@ description: >
   the refresh flow. Runs a single native `merod` node with the auth router
   mounted inside the node (no separate mero-auth container needed).
 
-# Embedded auth is only supported in binary/native mode (the auth router is
-# mounted inside merod itself). In Docker mode use `auth_service`/`auth_image`.
+# Embedded auth mounts the auth router inside merod itself and works in both
+# binary/native and Docker mode. (`auth_service`/`auth_image` remains the
+# separate proxy topology: a standalone mero-auth container behind Traefik.)
+# This example uses binary mode; drop `no_docker` to run it in Docker.
 no_docker: true
 
 # Enable the embedded auth router on the node (passes --auth-mode embedded to
@@ -110,15 +112,20 @@ steps:
     expected_failure: true
 
   # --- 6. Refresh flow ------------------------------------------------------
-  # Swap the refresh token for a fresh access token and re-seed the cache.
-  - name: "Refresh the access token"
+  # Core only honors /auth/refresh once the ACCESS token has expired; a
+  # proactive refresh while it is still valid is rejected with 401
+  # "Access token still valid" (refresh_token_handler). Seconds after login
+  # the access token is nowhere near expiry, so the correct assertion here
+  # is that the refresh is REJECTED. (A positive refresh e2e would need an
+  # expired access token, i.e. a node configured with a very short
+  # access_token_expiry.)
+  - name: "Proactive refresh is rejected while the access token is valid"
     type: refresh
     node: calimero-node-1
-    outputs:
-      access_token: access_token
+    expected_failure: true
 
-  # The refreshed token still authorizes calls.
-  - name: "Authenticated call after refresh"
+  # The cached (still-valid) token keeps authorizing calls.
+  - name: "Authenticated call after rejected refresh"
     type: call
     node: calimero-node-1
     context_id: "{{context_id}}"


### PR DESCRIPTION
## Why

`--auth-mode embedded` was gated to binary mode, but it's a `merod init` flag — containers accept it exactly the same way native processes do. The gate was the only thing keeping docker-mode fleets (like calimero-network/core's e2e scenario matrix, ~40 scenarios, all currently running **unauthenticated**) from flipping to auth-enforced runs that match production shape. Context: the core 0.11.0-rc.9 login-loop outage (calimero-network/auth-frontend#33) shipped precisely because no CI anywhere ran the auth layer.

## What

**Embedded auth in Docker mode**
- `DockerManager.run_node` / `run_multiple_nodes` accept `auth_mode` and append `--auth-mode` to the container init command (both entrypoint forms)
- the workflow executor passes `auth_mode` in both modes (was binary-gated in two places)
- the binary-only rejections in `merobox run` / `bootstrap run` are gone; `--auth-service` remains the separate proxy topology (standalone mero-auth behind Traefik)

**Fixes found while verifying end-to-end**
- `bootstrap validate` rejected the auth step types shipped in 0.6.33 — `login`, `refresh`, `ws_connect`/`ws_subscribe` were missing from the validator's known-type list, so valid auth workflows (including the shipped example) failed validation while running fine under `bootstrap run`
- `AuthManager.refresh` replaced every 401 with a hardcoded *"Refresh token expired or invalid"* — but core also 401s **proactive** refresh (*"Access token still valid"*: `/auth/refresh` is only honored once the access token has expired). The canned message misdiagnoses that case (it cost us a debugging detour). 401s now surface the server's actual reason, and `workflow-embedded-auth-example.yml` pins the real behavior: the post-login refresh asserts `expected_failure: true`.

## Verified

The embedded-auth example runs green end-to-end in **both modes**:
- **Docker** — against `merod:0.11.0-rc.9` and `merod:edge` images: init with embedded auth, login, negative login, authenticated install/namespace/context/call, unauthenticated 401, WS auth both ways, refresh-rejection pin — 12/12 steps
- **Binary** — same workflow against a locally-built core master merod — 12/12 steps
- `bootstrap validate` accepts the example (failed with "unknown type: login" before)
- unit suite unchanged: 628 passed, 281 pre-existing env failures identical on unmodified master
- changed files are black-clean

## Follow-up this unblocks

Flipping core's docker-mode e2e matrix to `auth_mode: embedded` (+ `login` step) per scenario — tracked on the core side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)