### PR TITLE
fix(examples): blob-upload — use captured file ids, not hardcoded file_0

### DIFF
--- a/workflow-examples/workflow-blob-upload-example.yml
+++ b/workflow-examples/workflow-blob-upload-example.yml
@@ -95,7 +95,7 @@ steps:
       size: "{{pdf_blob_size}}"
       mime_type: application/pdf
     outputs:
-      file_0_id: result
+      file_0_id: result.output
 
   - name: Wait for blob announcement to propagate
     type: wait_for_sync
@@ -129,7 +129,7 @@ steps:
       size: "{{png_blob_size}}"
       mime_type: image/png
     outputs:
-      file_1_id: result
+      file_1_id: result.output
 
   # Step 8a: Upload real text file to blob storage
   - name: Upload TXT to Blob Storage
@@ -153,7 +153,7 @@ steps:
       size: "{{txt_blob_size}}"
       mime_type: text/plain
     outputs:
-      file_2_id: result
+      file_2_id: result.output
 
   # Step 9: List all files from Node 1
   - name: List All Files (Node 1)
@@ -200,7 +200,7 @@ steps:
     context_id: "{{context_id}}"
     method: get_file
     args:
-      file_id: file_0
+      file_id: "{{file_0_id}}"
     outputs:
       pdf_metadata: result
 
@@ -211,7 +211,7 @@ steps:
     context_id: "{{context_id}}"
     method: get_blob_id_b58
     args:
-      file_id: file_0
+      file_id: "{{file_0_id}}"
     outputs:
       retrieved_pdf_blob_id: result
 
@@ -255,7 +255,7 @@ steps:
     context_id: "{{context_id}}"
     method: delete_file
     args:
-      file_id: file_1
+      file_id: "{{file_1_id}}"
     outputs:
       delete_result: result
 


### PR DESCRIPTION
## Root cause of the blob-upload-example CI failures (first seen on #288)

core#3047 (Jun 29) deliberately changed the blobs app's file-id scheme: `file_<n>` → `<uploader-base58>_<n>` (a global counter silently collides across concurrent CRDT uploaders). This example's register steps **already captured** the returned id (`file_N_id` outputs) — but the later `get_file`/`delete` steps passed the literal `file_0`/`file_1`. Against any post-#3047 `merod:edge` that fails with `FunctionCallError: File not found: file_0` — which is exactly the failure on #288's CI run, initially misread as a core storage regression (the CI target is core-master-at-run-time: `merod:edge` + `force_pull_image: true` + `blobs.wasm` built from a fresh master clone, so master-green on Jun 24 said nothing about Jul 5).

## Fix

- `get_file`/`delete` steps use `{{file_0_id}}`/`{{file_1_id}}` instead of literals
- outputs capture `result.output` (the id string) instead of `result` (the whole object — passing it made `get_file` fail arg deserialization). Matches core's own `apps/blobs/workflows/blobs.yml`.

## Verified

Full workflow green end-to-end against `merod:edge` (current core master) with `blobs.wasm` built from the same master.

Companion on the core side: calimero-network/core#3195 wires core's own (already-correct) blobs scenarios into its e2e matrix, so the next blobs-app change is caught pre-merge in core instead of surfacing here against a moving target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)