### PR TITLE
chore: release 0.6.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.41] - 2026-07-05
+
 ### Added
 
 - **Embedded auth in Docker mode**: `auth_mode: embedded` (workflow YAML) and
@@ -34,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   access token has expired), and the canned message misdiagnosed that case.
   `workflow-embedded-auth-example.yml` now pins core's real behavior: the
   post-login refresh asserts `expected_failure: true`.
+- `workflow-blob-upload-example.yml` now passes the captured file ids to `get_file`/`delete` (and captures `result.output`, the id string) instead of the hardcoded `file_0`/`file_1`. core#3047 changed the blobs app's file-id scheme (`file_<n>` → `<uploader>_<n>`), so the literals produced `File not found: file_0` against current merod.
 
 ## [0.6.40] - 2026-06-22
 

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.40"
+__version__ = "0.6.41"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Bumps `__version__` 0.6.40 → 0.6.41 to cut a release.

**Why now:** three feature PRs landed on master since v0.6.40 (Jun 23) without a version bump, so the release workflow — which tags/publishes only when `__version__` changes vs `HEAD~1` — never fired. None of these have shipped to PyPI or the apt repo:

- #287 Mock-TEE fleet test harness
- #288 embedded auth in Docker mode + auth-step fixes
- #289 blob-upload example: use captured file ids

**Blocker it clears:** calimero-network/core#3196 (flip the e2e fleet to `auth_mode: embedded`) installs merobox from the apt repo and needs docker-mode embedded auth (#288). Its CI currently fails at `auth_mode is only supported with --no-docker` because the released 0.6.40 predates #288.

Moves the `[Unreleased]` changelog entries under `[0.6.41]` and adds the #289 note.

On merge to master the release workflow auto-tags `v0.6.41` and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)