### PR TITLE
ci: exclude Open-subgroup TEE context-replication scenarios from required matrix (core#3198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,29 @@ jobs:
           # nothing. Docker mode runs against merod:edge (master), which
           # has the fix, so cascade-namespace keeps full coverage there.
           # Re-add to binary once the pinned release carries #2507.
+          #
+          # tee-g2-open-inheritance-replication / tee-matrix-open-join-with-created
+          # / tee-matrix-open-late-join exercise POSITIVE Open-subgroup context
+          # replication to an admitted mock-TEE replica: a context registered in
+          # an Open subgroup must replicate to the TEE via namespace-root
+          # inheritance (no direct ReadOnlyTee row — the context-inheritance
+          # auto-follow path). On current merod this path does not deliver: the
+          # replica's `meroctl context ls` stays `{"contexts":[]}` and the assert
+          # fails after 3 retries. This is a MEROD gap, not a merobox bug — it
+          # reproduces on BOTH the pinned release (Binary) and merod:edge/master
+          # (Docker), and ONLY for these three positive-inheritance scenarios.
+          # Every counterpart passes: the Restricted variants (tee-g1,
+          # tee-matrix-restricted-*) use direct-row auto-follow, and
+          # tee-r2-open-no-direct-row is Open but asserts NO replication row — so
+          # the break is specifically the Open inheritance replication path.
+          # Tracked upstream by calimero-network/core#3198 (regression first seen
+          # rc.9→rc.10, since widened from Docker-only to both transports); cf. the
+          # now-closed #2771 (born-Open no transient row) and #2491 (fleet-join
+          # mesh race). Excluded from the required matrix (both Binary and Docker)
+          # so master CI is not permanently red on an upstream gap; the scenarios
+          # remain in workflow-examples/ and runnable manually. Re-add to both
+          # matrices once core#3198 lands and merod replicates Open-subgroup
+          # contexts to inherited TEE replicas. Do NOT weaken the assert script.
           BINARY=$(ls workflow-examples/*.yml | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
@@ -105,12 +128,19 @@ jobs:
             grep -v fault-injection | \
             grep -v nat-topology | \
             grep -v cascade-namespace | \
+            grep -v tee-g2-open-inheritance-replication | \
+            grep -v tee-matrix-open-join-with-created | \
+            grep -v tee-matrix-open-late-join | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
           # Docker mode: same but also exclude binary-only workflow.
           # fault-injection-tc requires a custom merod image with iproute2
           # installed (the stock image lacks `tc`); skipped in CI.
+          # tee-*-open positive-inheritance scenarios excluded here too — same
+          # merod Open-subgroup context-replication gap as documented for the
+          # Binary matrix above (core#3198). Keep the exclusion symmetric across
+          # both matrices; re-add together once core#3198 lands.
           DOCKER=$(ls workflow-examples/*.yml | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
@@ -118,6 +148,9 @@ jobs:
             grep -v cached-frontends | \
             grep -v example-binary | \
             grep -v fault-injection-tc | \
+            grep -v tee-g2-open-inheritance-replication | \
+            grep -v tee-matrix-open-join-with-created | \
+            grep -v tee-matrix-open-late-join | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "docker=$DOCKER" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Problem

merobox `master` CI ("CI - Format Check & Merobox Integration Testing") has been red for weeks. Six jobs fail every run — the Binary **and** Docker variants of three scenarios:

- `tee-g2-open-inheritance-replication`
- `tee-matrix-open-join-with-created`
- `tee-matrix-open-late-join`

All three fail identically at their final assert step (`workflow-examples/scripts/assert-tee-context-replicated.sh`): `meroctl context ls` on the mock-TEE replica returns `{"data":{"contexts":[]}}` — the Open-subgroup context **never replicates** to the TEE replica. FAIL, retried 3×.

## Root-cause verdict: upstream merod (core) gap, NOT a merobox bug

Evidence from the latest `master` run (`9730f0e`, run `29410676789`):

| Scenario | Path | Binary | Docker |
|---|---|---|---|
| tee-g2-open-inheritance-replication | Open inheritance replication | ❌ | ❌ |
| tee-matrix-open-join-with-created | Open inheritance replication | ❌ | ❌ |
| tee-matrix-open-late-join | Open inheritance replication | ❌ | ❌ |
| tee-g1 / tee-matrix-restricted-* | Restricted direct-row auto-follow | ✅ | ✅ |
| tee-r2-open-no-direct-row | Open, asserts NO replication row | ✅ | ✅ |
| tee-g3 / tee-g4 / tee-r1 | other TEE paths | ✅ | ✅ |

The only material difference between the failing and passing cells is **Open-subgroup inheritance vs Restricted direct-row auto-follow**:

- **Restricted** subgroups give the admitted TEE an actual `ReadOnlyTee` row in the subgroup (direct-row auto-follow); the context backfills. These pass.
- **Open** subgroups give the TEE membership *purely via namespace-root inheritance* — no direct row (see `tee-r2-open-no-direct-row.yml`, the born-Open guard). Context replication is supposed to ride that inheritance/context-auto-follow path. That path does not deliver on current merod.

This fails on **both** the pinned latest *release* merod (Binary mode) and `merod:edge` = core master (Docker mode), so it is not a "fix not yet released" situation — master's merod is affected too. It is specifically the positive Open-inheritance replication path; every Restricted / no-replication-row counterpart is green.

**Upstream tracking issue: [calimero-network/core#3198](https://github.com/calimero-network/core/issues/3198)** — *"regression(rc.10): Open-subgroup TEE context replication stalls"* (OPEN). It was first filed as Docker-only at rc.10 with binary passing; on the current released+edge merod the gap has widened to **both** transports, which is what we observe here. Related (both now CLOSED): #2771 (born-Open no transient row) and #2491 (fleet-join mesh race).

## What this PR changes

`.github/workflows/ci.yml` — adds the three Open-inheritance scenarios to the existing `list-workflows` `grep -v` exclusions, **symmetrically across the Binary and Docker matrices**, with a documented comment explaining exactly why (the merod Open-subgroup → inherited-TEE context-replication gap, reproduces on both transports, only the positive-inheritance variants, tracked by core#3198).

This follows the repo's established pattern for known-broken-upstream scenarios (cascade-namespace, fault-injection, nat-topology are already excluded the same way). merobox has no per-scenario `continue-on-error`/allowed-failure mechanism for the required matrix, so matrix-exclusion-with-tracking is the right tool — and it is the same mechanism the repo already uses.

What this PR deliberately does **not** do:
- It does **not** delete the scenarios — they stay in `workflow-examples/` and remain runnable manually (`merobox bootstrap run ...`).
- It does **not** weaken `assert-tee-context-replicated.sh` or the scenarios. No fake pass.
- Re-add both to their matrices once core#3198 lands and merod replicates Open-subgroup contexts to inherited TEE replicas.

## Version bump: none (intentional)

This is a CI-workflow-only change with no library behavior change. The release pipeline (`release.yml`) only publishes when `merobox/__init__.py` `__version__` changes, and the repo's convention is that pure CI-only changes do not bump (e.g. #112 "exclude fuzzy-kv-store", #202 "remove format gate" — neither bumped). So `__version__` stays at `0.6.42` and no new package is cut.

## Reproduce

```
merobox bootstrap run workflow-examples/tee-g2-open-inheritance-replication.yml            # Docker
merobox bootstrap run workflow-examples/tee-g2-open-inheritance-replication.yml --no-docker # Binary
```
Both end in `FAIL: context <id> NOT found on the TEE replica` with `{"data":{"contexts":[]}}`.

## Local verification

- `python3 -m pytest merobox/tests/unit -q` → 884 passed, 27 failed. All 27 are pre-existing failures on clean master in `test_cascade_status_steps.py` / `test_migrations_v2_steps.py`, unrelated to this change (which touches only YAML). **Zero new failures.**
- Verified the new `grep -v` filters remove exactly the three Open scenarios and keep every Restricted / r1 / r2 / g1 / g3 / g4 scenario.

## Follow-up

Core must implement/fix Open-subgroup context replication to a late-joining / inherited `ReadOnlyTee` replica (ref [core#3198](https://github.com/calimero-network/core/issues/3198); cf. #2771 / #2491). Once shipped, revert this exclusion on both matrices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
