### PR TITLE
docs(tee): build harness merod with --features mock-attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,14 @@ jobs:
           # nothing. Docker mode runs against merod:edge (master), which
           # has the fix, so cascade-namespace keeps full coverage there.
           # Re-add to binary once the pinned release carries #2507.
+          # tee-* require a merod built with `--features mock-attestation`
+          # (calimero-network/core#3269). That feature is default-OFF, so
+          # neither the release binary (binary mode) nor merod:edge (docker
+          # mode) carries it — `merod run --mock-tee` hard-errors at boot and
+          # every tee-*.yml goes red before any admission logic runs. Mock-TEE
+          # testing is native/dev-only by design (build recipe documented in
+          # each tee-*.yml header); run these locally with a feature-enabled
+          # merod. Re-add here only behind a CI job that builds such a merod.
           BINARY=$(ls workflow-examples/*.yml | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
@@ -105,12 +113,15 @@ jobs:
             grep -v fault-injection | \
             grep -v nat-topology | \
             grep -v cascade-namespace | \
+            grep -v '/tee-' | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
           # Docker mode: same but also exclude binary-only workflow.
           # fault-injection-tc requires a custom merod image with iproute2
           # installed (the stock image lacks `tc`); skipped in CI.
+          # tee-* excluded here too — merod:edge lacks mock-attestation
+          # (see the binary-mode note above).
           DOCKER=$(ls workflow-examples/*.yml | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
@@ -118,6 +129,7 @@ jobs:
             grep -v cached-frontends | \
             grep -v example-binary | \
             grep -v fault-injection-tc | \
+            grep -v '/tee-' | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "docker=$DOCKER" >> $GITHUB_OUTPUT
 

--- a/workflow-examples/tee-g1-restricted-auto-admit.yml
+++ b/workflow-examples/tee-g1-restricted-auto-admit.yml
@@ -14,17 +14,21 @@
 #      already-admitted root TEE is auto-followed into the subgroup as a
 #      ReadOnlyTee member (direct-row auto-follow — the Restricted path).
 #
-# Run natively (macOS) against a locally-built --mock-tee merod:
+# Build the harness merod WITH mock attestation. `mock-attestation` is a
+# default-OFF Cargo feature in core: a plain `cargo build -p merod` produces a
+# binary with NO `--mock-tee` support, and every node below fails to boot.
+#   cargo build --release -p merod --features mock-attestation
+#
+# Run natively (macOS) against that locally-built --mock-tee merod:
 #   merobox bootstrap run workflow-examples/tee-g1-restricted-auto-admit.yml \
 #     --no-docker \
 #     --binary-path /Users/xilosada/dev/calimero-work/core/target/release/merod
 #
 # meroctl is not needed for G1 (assertions go through the admin API directly).
 #
-# NOTE on node boot: merobox's initial `nodes:` boot path does not thread the
-# `mock_tee` flag (only the `start_node` step does). So both nodes boot normally,
-# then we stop + restart the TEE replica with `mock_tee: true` to relaunch it as
-# `merod run --mock-tee`.
+# NOTE on node boot: merobox's initial `nodes:` boot path threads the `mock_tee`
+# flag, so the TEE replica is declared with `mock_tee: true` under `nodes:` below
+# and boots directly as `merod run --mock-tee` — no stop/restart dance needed.
 # =============================================================================
 
 name: TEE G1 — Restricted auto-admit (local mock)

--- a/workflow-examples/tee-g2-open-inheritance-replication.yml
+++ b/workflow-examples/tee-g2-open-inheritance-replication.yml
@@ -12,6 +12,11 @@
 #   - The TEE replica replicates that context: `meroctl context ls` on the
 #     replica lists the context id (the `script` step greps for it).
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS), with the locally-built --mock-tee merod on PATH so the
 # `script` step's meroctl resolves to it:
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \

--- a/workflow-examples/tee-g3-disable-cascade-purge.yml
+++ b/workflow-examples/tee-g3-disable-cascade-purge.yml
@@ -13,6 +13,11 @@
 #   - After sync, the TEE is ABSENT from BOTH the root AND the subgroup
 #     (assert_not_member on each).
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS):
 #   merobox bootstrap run workflow-examples/tee-g3-disable-cascade-purge.yml \
 #     --no-docker \

--- a/workflow-examples/tee-g4-inherited-role.yml
+++ b/workflow-examples/tee-g4-inherited-role.yml
@@ -12,6 +12,11 @@
 #   - The TEE is a member of the Open subgroup with role == ReadOnlyTee
 #     (assert_tee_member with role: ReadOnlyTee against the Open subgroup id).
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS):
 #   merobox bootstrap run workflow-examples/tee-g4-inherited-role.yml \
 #     --no-docker \

--- a/workflow-examples/tee-matrix-open-join-with-created.yml
+++ b/workflow-examples/tee-matrix-open-join-with-created.yml
@@ -20,6 +20,11 @@
 #   3. THEN the owner registers a context in the Open subgroup; the
 #      already-admitted TEE replicates it via namespace-root inheritance.
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS), meroctl on PATH for the script step:
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \
 #   merobox bootstrap run workflow-examples/tee-matrix-open-join-with-created.yml \

--- a/workflow-examples/tee-matrix-open-late-join.yml
+++ b/workflow-examples/tee-matrix-open-late-join.yml
@@ -20,6 +20,11 @@
 #   3. The pre-existing Open-subgroup context REPLICATES to the TEE replica via
 #      inheritance (`meroctl context ls` on the replica greps the context id).
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS), meroctl on PATH for the script step:
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \
 #   merobox bootstrap run workflow-examples/tee-matrix-open-late-join.yml \

--- a/workflow-examples/tee-matrix-restricted-join-with-created.yml
+++ b/workflow-examples/tee-matrix-restricted-join-with-created.yml
@@ -22,6 +22,11 @@
 #   3. THEN the owner registers a context in that subgroup; the already-admitted
 #      TEE replicates the newly-registered context.
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS), meroctl on PATH for the script step:
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \
 #   merobox bootstrap run workflow-examples/tee-matrix-restricted-join-with-created.yml \

--- a/workflow-examples/tee-matrix-restricted-late-join.yml
+++ b/workflow-examples/tee-matrix-restricted-late-join.yml
@@ -22,6 +22,11 @@
 #   4. The pre-existing Restricted context REPLICATES to the TEE replica
 #      (`meroctl context ls` on the replica greps the context id).
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS), meroctl on PATH for the script step:
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \
 #   merobox bootstrap run workflow-examples/tee-matrix-restricted-late-join.yml \

--- a/workflow-examples/tee-r1-offline-backfill.yml
+++ b/workflow-examples/tee-r1-offline-backfill.yml
@@ -23,6 +23,11 @@
 #   - After sync, the replica should have replicated the offline-created
 #     context (meroctl context ls greps the context id).
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot (including the restart below):
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS), meroctl on PATH for the script step:
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \
 #   merobox bootstrap run workflow-examples/tee-r1-offline-backfill.yml \

--- a/workflow-examples/tee-r2-open-no-direct-row.yml
+++ b/workflow-examples/tee-r2-open-no-direct-row.yml
@@ -21,6 +21,11 @@
 # inherited ReadOnlyTee entry, which is correct inheritance, not a stored
 # admission row — hence we assert on the skip log, not on member-list contents.)
 #
+# Build the harness merod WITH mock attestation — `mock-attestation` is a
+# default-OFF Cargo feature; without it merod has no `--mock-tee` and the node
+# fails to boot:
+#   cargo build --release -p merod --features mock-attestation
+#
 # Run natively (macOS):
 #   PATH="/Users/xilosada/dev/calimero-work/core/target/release:$PATH" \
 #   merobox bootstrap run workflow-examples/tee-r2-open-no-direct-row.yml \


### PR DESCRIPTION
## What

Two changes, both consequences of core PR https://github.com/calimero-network/core/pull/3269 (mock-attestation gated behind a default-off Cargo feature), now shipped in **core 0.11.0-rc.17**:

1. **CI: drop the ten `tee-*.yml` from the binary+docker matrix.** rc.17 is the first release to carry the feature gate. The release binary (binary mode) and `merod:edge` (docker mode) are both built **without** `mock-attestation`, so `merod run --mock-tee` hard-errors at boot and every `tee-*.yml` goes red before any admission logic runs. Mock-TEE testing is native/dev-only by design, so these are excluded from CI discovery — mirroring the existing `fault-injection`/`nat`/`cascade` exclusions. Re-add behind a job that builds a feature-enabled merod if continuous TEE coverage is wanted.

2. **Docs: the ten mock-TEE workflow headers** now carry the required build recipe `cargo build --release -p merod --features mock-attestation`, so anyone running them **natively** (the supported path) builds a capable merod.

**Zero Python changed.** merobox never builds merod — native mode consumes a prebuilt binary via `--binary-path`, and the `--mock-tee` plumbing already works end-to-end.

## Coverage note

Excluding `tee-*` from CI means the TEE admission/replication suite (including the core #3264 Open-subgroup regression guard) has **no CI coverage** — it runs native-only. Tracked as a follow-up: a CI job that builds merod with `--features mock-attestation` would restore it.

## Also fixed

The `tee-g1-restricted-auto-admit.yml` header comment was doubly stale: it claimed the `nodes:` boot path "does not thread the `mock_tee` flag" (it does — `executor.py:1502/1543/1566`), and described a stop/restart dance that no longer exists.

## Validation

- Core confirmed at the feature-gate commit; `cargo build --release -p merod --features mock-attestation` (exit 0); `merod run --mock-tee` parses/accepts the flag with zero "built without mock-attestation support" hard-errors.
- Matrix-discovery grep re-simulated locally: all 10 `tee-*` dropped, 30 non-tee workflows retained.
