### PR TITLE
feat(auth): pass through MERO_AUTH_ADMIN_USER/PASSWORD for init-time admin provisioning (0.6.43)

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.42"
+__version__ = "0.6.43"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -484,6 +484,17 @@ class DockerManager(CleanupMixin):
             if bootstrap_secret:
                 node_env["MERO_AUTH_BOOTSTRAP_SECRET"] = bootstrap_secret
 
+            # Forward init-time admin credentials (core rc.17+). `merod init`
+            # mints the admin root key from these before the node ever
+            # listens — the login path never mints keys, and the bootstrap
+            # secret above is inert on those cores. The init container reuses
+            # this same environment, so forwarding here covers both init and
+            # run. Binary mode inherits the environment automatically.
+            for admin_var in ("MERO_AUTH_ADMIN_USER", "MERO_AUTH_ADMIN_PASSWORD"):
+                admin_value = os.getenv(admin_var)
+                if admin_value:
+                    node_env[admin_var] = admin_value
+
             # Debug: Print the RUST_LOG value being set
             console.print(
                 f"[cyan]Setting RUST_LOG for node {node_name}: {log_level}[/cyan]"
@@ -1182,6 +1193,15 @@ class DockerManager(CleanupMixin):
             auth_bootstrap_secret = os.getenv("MERO_AUTH_BOOTSTRAP_SECRET")
             if auth_bootstrap_secret:
                 auth_env.append(f"MERO_AUTH_BOOTSTRAP_SECRET={auth_bootstrap_secret}")
+
+            # Forward init-time admin credentials to the standalone auth
+            # service too (core rc.17+ mints the admin root key at startup
+            # from these when no root keys exist; the login path never mints
+            # keys).
+            for admin_var in ("MERO_AUTH_ADMIN_USER", "MERO_AUTH_ADMIN_PASSWORD"):
+                admin_value = os.getenv(admin_var)
+                if admin_value:
+                    auth_env.append(f"{admin_var}={admin_value}")
 
             # By default, fetch fresh auth frontend unless explicitly disabled
             env_auth_fetch = os.getenv("CALIMERO_AUTH_FRONTEND_FETCH", "1")


### PR DESCRIPTION
Companion to calimero-network/core#3276, which removes the first-login bootstrap-secret flow: the admin root key is minted at `merod init` (or at auth startup when no root keys exist) from `MERO_AUTH_ADMIN_USER` / `MERO_AUTH_ADMIN_PASSWORD`, and the login path never mints keys.

- Forward `MERO_AUTH_ADMIN_USER` / `MERO_AUTH_ADMIN_PASSWORD` into **node containers** — the init container reuses the same environment dict, so docker-mode `merod init` mints the admin key before the node listens, and scenario `login` steps (dev/dev-password) authenticate as plain existing users.
- Same forward for the **standalone auth-service container** (core rc.17+ mints at startup there).
- `MERO_AUTH_BOOTSTRAP_SECRET` pass-through (#292) stays — still needed for cores ≤ rc.16, inert on rc.17+.
- Values fall under the existing `SECRET`/`PASSWORD`/`TOKEN` log redaction; binary mode inherits the environment automatically, unchanged.
- Version → **0.6.43**; core's `.github/actions/setup-merobox` bumps `MIN_MEROBOX` to 0.6.43 in core#3276, so its container-mode e2e matrix waits on this release.

Unit tests: `test_auth_steps.py` 19/19 (no behavior change to the login step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)