### PR TITLE
docs: level up — onboarding track, examples gallery, recipes, pytest tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ steps:
 ## Features
 
 - **Node Management** — Start, stop, and monitor nodes in Docker or as native processes
-- **Workflow Orchestration** — 35+ step types for complex multi-step YAML workflows
+- **Workflow Orchestration** — ~100 step types for complex multi-step YAML workflows
 - **Remote Nodes** — Connect to remote Calimero nodes with user/password or API key auth
 - **Auth Integration** — Traefik proxy (Docker) or embedded JWT auth (binary mode)
 - **Fuzzy Testing** — Long-duration randomized load tests with weighted operations

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -47,16 +47,20 @@ export default defineConfig({
           href: 'https://github.com/calimero-network/merobox',
         },
       ],
-      // Explicit, grouped navigation: Understand → Workflows → Guides → Reference.
+      // Explicit, grouped navigation: Get Started → Understand → Workflows → Guides → Reference.
       sidebar: [
         { label: 'Home', link: '/' },
+        {
+          label: 'Get Started',
+          items: ['get-started/quickstart', 'get-started/first-workflow'],
+        },
         {
           label: 'Understand',
           items: ['understand/system-overview', 'understand/glossary'],
         },
         {
           label: 'Workflows',
-          items: ['workflows/engine', 'workflows/yaml'],
+          items: ['workflows/engine', 'workflows/yaml', 'workflows/examples'],
         },
         {
           label: 'Guides',
@@ -64,6 +68,8 @@ export default defineConfig({
             'guides/node-management',
             'guides/remote-nodes',
             'guides/testing',
+            'guides/pytest-tutorial',
+            'guides/recipes',
             'guides/near-integration',
           ],
         },

--- a/docs/src/content/docs/get-started/first-workflow.mdx
+++ b/docs/src/content/docs/get-started/first-workflow.mdx
@@ -1,0 +1,374 @@
+---
+title: Your first workflow
+description: Build one merobox workflow step by step — two nodes, install an app, create a namespace and context, invite and join a second node, call a method, wait for sync, and assert the result.
+sidebar:
+  order: 2
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+This tutorial builds a single workflow from scratch. By the end you will have a
+YAML file that boots two Calimero nodes, writes a value on one node, waits for it
+to replicate, reads it back on the other node, and asserts the result — the
+canonical shape of a merobox end-to-end test.
+
+We build it one step at a time and explain each piece as it appears, including
+how `outputs:` captures values and how `{{name}}` references them later. The
+finished file is at the [end of the page](#the-complete-workflow).
+
+:::note
+This assumes merobox is installed and Docker is running. If not, start with the
+[quickstart](/get-started/quickstart/). For the execution model behind these
+steps, see the [workflow engine](/workflows/engine/); for every step type and
+field, the [workflow YAML reference](/workflows/yaml/).
+:::
+
+## The shape of a workflow
+
+Every workflow is a YAML file with a bit of metadata, a `nodes:` block declaring
+the cluster, and an ordered list of `steps:`. Steps run top to bottom, and the
+run stops the moment one fails.
+
+```yaml
+name: My First Workflow
+description: Write a value on one node and read it back on another.
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: calimero-node
+
+steps:
+  # ... we fill this in below
+```
+
+`count: 2` boots two nodes named by `prefix` with a numeric suffix:
+`calimero-node-1` and `calimero-node-2`. Every step addresses a node by that
+full name.
+
+Run the file at any point with:
+
+```bash
+merobox bootstrap run my-first-workflow.yml
+```
+
+## Step 1 — install the application
+
+A context runs a WASM application, so the first step installs one. We use the
+bundled `kv_store` app (a simple key/value store) that ships under
+`workflow-examples/res/`.
+
+```yaml
+- name: Install Application on Node 1
+  type: install_application
+  node: calimero-node-1
+  path: workflow-examples/res/kv_store.wasm
+  dev: true
+  outputs:
+    app_id: applicationId
+```
+
+This is where **variable capture** enters. When a step succeeds, its `outputs:`
+block copies fields out of the response into a shared value store:
+
+```yaml
+outputs:
+  app_id: applicationId   # store response.applicationId under the name "app_id"
+```
+
+The left side (`app_id`) is a **name you choose**; the right side
+(`applicationId`) is the **field in the step's response**. From now on,
+`{{app_id}}` anywhere in a later step resolves to that installed application's
+ID. Nothing is hardcoded — the ID is discovered at runtime and threaded forward.
+
+## Step 2 — create a namespace
+
+A namespace is the identity and application-instance boundary that a shared
+context lives in. We create one on node 1, tied to the app we just installed —
+note the `{{app_id}}` reference pulling in the value captured in step 1.
+
+```yaml
+- name: Create Namespace on Node 1
+  type: create_namespace
+  node: calimero-node-1
+  application_id: '{{app_id}}'
+  outputs:
+    namespace_id: namespaceId
+```
+
+We capture the new namespace's ID as `namespace_id` for the steps that create
+the context and the invitation.
+
+## Step 3 — create a context
+
+The context is the actual running instance of the app whose state the nodes will
+keep in sync. It belongs to the namespace (passed as `group_id`) and runs the
+installed app.
+
+```yaml
+- name: Create Context on Node 1
+  type: create_context
+  node: calimero-node-1
+  application_id: '{{app_id}}'
+  group_id: '{{namespace_id}}'
+  outputs:
+    context_id: contextId
+    member_public_key: memberPublicKey
+```
+
+A single step can capture **several** outputs. Here we keep `context_id` (which
+every later `call` targets) and `member_public_key` (node 1's identity inside
+the context). Both come from the same response.
+
+## Step 4 — invite and join
+
+Node 2 does not know about the context yet. Bringing it in is a two-part
+handshake: node 1 issues a namespace invitation, then node 2 joins the namespace
+and the context.
+
+<Steps>
+
+1. **Node 1 creates an invitation** to its namespace and captures the
+   invitation payload:
+
+   ```yaml
+   - name: Invite Node 2
+     type: create_namespace_invitation
+     node: calimero-node-1
+     namespace_id: '{{namespace_id}}'
+     outputs:
+       invitation: invitation
+   ```
+
+2. **Wait briefly** so the namespace gossip reaches node 2 before it tries to
+   join. `wait` just pauses for a fixed number of seconds:
+
+   ```yaml
+   - name: Wait for Namespace Gossip
+     type: wait
+     seconds: 5
+   ```
+
+3. **Node 2 joins the namespace** using the captured invitation:
+
+   ```yaml
+   - name: Node 2 Joins Namespace
+     type: join_namespace
+     node: calimero-node-2
+     namespace_id: '{{namespace_id}}'
+     invitation: '{{invitation}}'
+   ```
+
+4. **Node 2 joins the context** via its group membership. It references the same
+   `context_id` node 1 created:
+
+   ```yaml
+   - name: Node 2 Joins Context
+     type: join_context
+     node: calimero-node-2
+     context_id: '{{context_id}}'
+   ```
+
+</Steps>
+
+Both nodes are now members of the same context and will replicate its state.
+
+## Step 5 — call a method (set)
+
+`call` invokes a method on the app running in a context. The `kv_store` app
+exposes `set` and `get`. We write `hello = world` on node 1:
+
+```yaml
+- name: Set a Value on Node 1
+  type: call
+  node: calimero-node-1
+  context_id: '{{context_id}}'
+  method: set
+  args:
+    key: hello
+    value: world
+```
+
+`args:` are passed to the method as its arguments. This mutates the context's
+state on node 1 — which then needs to propagate to node 2.
+
+## Step 6 — wait for sync
+
+Rather than guessing with a fixed `wait`, use `wait_for_sync`. It polls the
+named nodes' context state hashes and returns as soon as they **converge** (or
+fails after `timeout` seconds). This is the reliable way to gate on replicated
+state.
+
+```yaml
+- name: Wait for State Sync
+  type: wait_for_sync
+  context_id: '{{context_id}}'
+  nodes:
+    - calimero-node-1
+    - calimero-node-2
+  timeout: 30
+```
+
+When this step passes, both nodes agree on the context state — so node 2 now has
+the value node 1 wrote.
+
+## Step 7 — read it back (get)
+
+Now we `call` `get` on **node 2** and capture the result, proving the write
+crossed the network:
+
+```yaml
+- name: Get the Value from Node 2
+  type: call
+  node: calimero-node-2
+  context_id: '{{context_id}}'
+  method: get
+  args:
+    key: hello
+  outputs:
+    get_result: result
+```
+
+We store the returned value as `get_result` so the final step can check it.
+
+## Step 8 — assert the result
+
+`assert` evaluates one or more boolean `statements` and fails the workflow if any
+is false. This turns the workflow into a real test. `{{get_result}}` expands to
+the value we captured from node 2:
+
+```yaml
+- name: Assert the Value Propagated
+  type: assert
+  statements:
+    - "is_set({{context_id}})"
+    - "contains({{get_result}}, 'world')"
+```
+
+`is_set(...)` checks a value is present and non-empty; `contains(...)` checks a
+substring. If node 2 returned `world`, the assertion passes and the workflow
+exits successfully.
+
+:::tip
+`assert` supports many helpers (`equal`, `not_contains`, `regex`, numeric
+comparisons), and `json_assert` adds `json_equal` / `json_subset` for structured
+responses. See the [workflow YAML reference](/workflows/yaml/).
+:::
+
+## The complete workflow
+
+Putting every step together:
+
+```yaml
+name: My First Workflow
+description: Write a value on one node and read it back on another.
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: calimero-node
+
+steps:
+  - name: Install Application on Node 1
+    type: install_application
+    node: calimero-node-1
+    path: workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace on Node 1
+    type: create_namespace
+    node: calimero-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Context on Node 1
+    type: create_context
+    node: calimero-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+
+  - name: Invite Node 2
+    type: create_namespace_invitation
+    node: calimero-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invitation: invitation
+
+  - name: Wait for Namespace Gossip
+    type: wait
+    seconds: 5
+
+  - name: Node 2 Joins Namespace
+    type: join_namespace
+    node: calimero-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invitation}}'
+
+  - name: Node 2 Joins Context
+    type: join_context
+    node: calimero-node-2
+    context_id: '{{context_id}}'
+
+  - name: Set a Value on Node 1
+    type: call
+    node: calimero-node-1
+    context_id: '{{context_id}}'
+    method: set
+    args:
+      key: hello
+      value: world
+
+  - name: Wait for State Sync
+    type: wait_for_sync
+    context_id: '{{context_id}}'
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 30
+
+  - name: Get the Value from Node 2
+    type: call
+    node: calimero-node-2
+    context_id: '{{context_id}}'
+    method: get
+    args:
+      key: hello
+    outputs:
+      get_result: result
+
+  - name: Assert the Value Propagated
+    type: assert
+    statements:
+      - "is_set({{context_id}})"
+      - "contains({{get_result}}, 'world')"
+
+stop_all_nodes: false
+```
+
+Save it as `my-first-workflow.yml` and run:
+
+```bash
+# Validate the schema first (no nodes started)
+merobox bootstrap run my-first-workflow.yml --dry-run
+
+# Then run it for real
+merobox bootstrap run my-first-workflow.yml
+```
+
+`stop_all_nodes: false` leaves the nodes running afterward so you can inspect
+them with `merobox health` or `merobox logs`. Set it to `true` to shut them down
+at the end, or clean up manually with `merobox stop --all`.
+
+## Where to go next
+
+- [Workflow engine](/workflows/engine/) — the full run and step lifecycle,
+  variable substitution, failure handling, retries, and parallelism.
+- [Workflow YAML reference](/workflows/yaml/) — every step type and field.
+- [Testing with merobox](/guides/testing/) — drive workflows from pytest.
+- [CLI reference](/reference/cli/) — every command and flag.

--- a/docs/src/content/docs/get-started/quickstart.mdx
+++ b/docs/src/content/docs/get-started/quickstart.mdx
@@ -1,0 +1,180 @@
+---
+title: Quickstart
+description: Install merobox, verify the install, start a two-node Calimero cluster, check its health, run your first workflow, and tear everything down.
+sidebar:
+  order: 1
+---
+
+import { Steps, Tabs, TabItem, LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+merobox is a Python CLI that boots real Calimero (`merod`) nodes — as Docker
+containers by default — and drives them through declarative YAML
+[workflows](/workflows/engine/). This page takes you from an empty machine to a
+running two-node cluster and a first passing workflow.
+
+## Prerequisites
+
+- **Docker** running locally (the default backend runs each node as a
+  container). Binary mode (`--no-docker`) is available if you have a local
+  `merod` build — see [node management](/guides/node-management/).
+- **Python 3.9+** if you install from PyPI or source.
+
+## Install
+
+<Tabs>
+  <TabItem label="pipx (PyPI)">
+
+```bash
+pipx install merobox
+```
+
+  </TabItem>
+  <TabItem label="APT (Debian/Ubuntu)">
+
+```bash
+curl -fsSL https://calimero-network.github.io/merobox/gpg.key \
+  | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
+  | sudo tee /etc/apt/sources.list.d/merobox.list
+sudo apt update
+sudo apt install merobox
+```
+
+  </TabItem>
+  <TabItem label="Homebrew">
+
+```bash
+brew install merobox
+```
+
+  </TabItem>
+  <TabItem label="From source">
+
+```bash
+git clone https://github.com/calimero-network/merobox.git
+cd merobox
+pipx install -e .
+```
+
+  </TabItem>
+</Tabs>
+
+### Verify
+
+```bash
+merobox --version
+```
+
+If that prints a version, you are ready. `merobox --help` lists every command.
+
+## Start two nodes
+
+```bash
+merobox run --count 2
+```
+
+This starts two Docker containers named `calimero-node-1` and `calimero-node-2`.
+Each node opens a libp2p **swarm** port and an HTTP **server / RPC** port,
+allocated per node from an auto-detected base (override with `--base-port` /
+`--base-rpc-port`). See [node management](/guides/node-management/) for the
+full set of `run` flags.
+
+:::note
+`merobox run` **only starts nodes** — it does not execute workflow YAML. Running
+a workflow is a separate command, `merobox bootstrap run` (below).
+:::
+
+## Check health
+
+```bash
+merobox health
+```
+
+`merobox health` polls each running node's admin API (`/admin-api/health`,
+`/admin-api/is-authed`, `/admin-api/peers`) and prints a table of health status,
+auth state, and connected-peer count. Target a single node with
+`merobox health --node calimero-node-1`, or add `--verbose` for raw responses.
+
+:::tip
+`merobox list` shows which node containers are running, and
+`merobox logs calimero-node-1 --follow` streams a node's logs live.
+:::
+
+## Run your first workflow
+
+A workflow is a YAML file describing nodes and an ordered list of steps. The
+repository ships runnable examples under `workflow-examples/`. Run one:
+
+```bash
+merobox bootstrap run workflow-examples/workflow-groups-example.yml
+```
+
+This boots the nodes the file declares, then executes each step in order —
+installing an app, creating a namespace and context, inviting the second node,
+and verifying that state syncs between the two. The process exits non-zero the
+moment any step fails.
+
+Two flags worth knowing early:
+
+```bash
+# Validate the YAML without starting anything — a fast lint for CI
+merobox bootstrap run workflow-examples/workflow-groups-example.yml --dry-run
+
+# Generate a starter workflow to edit
+merobox bootstrap create-sample
+```
+
+:::note
+`bootstrap run` starts the nodes a workflow declares under `nodes:`, so you do
+not need a prior `merobox run`. Unless the workflow sets `stop_all_nodes: true`,
+the nodes are left running after it finishes so you can inspect them.
+:::
+
+Ready to build one yourself? The [first workflow tutorial](/get-started/first-workflow/)
+walks through writing one step by step.
+
+## Stop and clean up
+
+```bash
+# Stop every running node (and the auth stack, if any)
+merobox stop --all
+
+# Or stop just one node
+merobox stop calimero-node-1
+```
+
+`stop` leaves each node's data on disk (under `./data/<node-name>/`) so a
+restart keeps its identity and state. To wipe that data for a completely fresh
+start, use `nuke`:
+
+:::caution
+`merobox nuke` is destructive and has no undo. It deletes node **data
+directories** under `./data/`, removes the node/auth/proxy containers, and drops
+the `auth_data` volume — a nuked node loses its identity and replicated state.
+
+```bash
+merobox nuke --dry-run   # show what would be deleted, delete nothing
+merobox nuke --force     # delete without the confirmation prompt
+```
+:::
+
+## Next steps
+
+<CardGrid>
+  <LinkCard
+    title="Write your first workflow"
+    href="/get-started/first-workflow/"
+    description="A narrated tutorial that builds one workflow step by step." />
+  <LinkCard
+    title="Workflow engine"
+    href="/workflows/engine/"
+    description="How a workflow runs: lifecycle, variables, failure handling." />
+  <LinkCard
+    title="Node management"
+    href="/guides/node-management/"
+    description="Docker vs binary backends, ports, auth, and logging." />
+  <LinkCard
+    title="CLI reference"
+    href="/reference/cli/"
+    description="Every command and flag in full." />
+</CardGrid>

--- a/docs/src/content/docs/guides/node-management.mdx
+++ b/docs/src/content/docs/guides/node-management.mdx
@@ -37,7 +37,7 @@ merobox run --count 3
 merobox run --count 2 --base-port 2428 --base-rpc-port 2528 --prefix my-node
 
 # A specific image
-merobox run --image ghcr.io/calimero-network/merod:edge
+merobox run --image ghcr.io/calimero-network/merod:prerelease
 ```
 
 Each node opens two listeners, matching `merod`'s own defaults:

--- a/docs/src/content/docs/guides/pytest-tutorial.mdx
+++ b/docs/src/content/docs/guides/pytest-tutorial.mdx
@@ -1,0 +1,339 @@
+---
+title: Using merobox in pytest
+description: A hands-on walkthrough of merobox's Python harness — build a pytest suite around real merod nodes with cluster()/workflow(), the nodes()/run_workflow() fixture decorators, and a session-scoped shared cluster, following the repo's example-project.
+sidebar:
+  order: 6
+---
+
+import { Steps, Aside, Tabs, TabItem, LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+This is the hands-on companion to [Testing with pytest](/guides/testing/). Where
+that page is the reference for the harness, this tutorial walks you through
+building a real suite: start nodes, point a client at them, assert, and reuse one
+cluster across the whole run. Every fixture and helper here is copied from the
+harness in `merobox/testing.py` and the working consumer in the repo's
+`example-project/` — nothing is invented.
+
+<Aside type="note">
+The harness starts **real `merod` Docker containers** via `DockerManager`, so
+your tests exercise the actual node over its RPC endpoint. That makes it the
+end-to-end layer — expect container start-up to be the slow part, and design the
+suite to reuse nodes (see [Reuse one cluster](#reuse-one-cluster-per-session)).
+</Aside>
+
+## Before you start
+
+<Steps>
+
+1. **Python 3.9–3.11** (3.12+ is not supported) and **Docker 20.10+** running
+   locally — the same requirements as the rest of merobox.
+
+2. Install merobox plus pytest into your project's virtualenv:
+
+   ```bash
+   python -m venv .venv && source .venv/bin/activate
+   pip install merobox pytest requests
+   ```
+
+3. Confirm Docker can pull and run the node image once, so the first test run
+   isn't waiting on a cold pull. See [Node Management](/guides/node-management/)
+   for what gets started under the hood.
+
+</Steps>
+
+## Two ways in: context manager or fixture
+
+`merobox/testing.py` gives you the same capability in two shapes. The **context
+managers** (`cluster()`, `workflow()`) are for a `with` block — good for a script
+or a single self-contained test. The **decorators** (`nodes()`, `run_workflow()`)
+wrap those same context managers as pytest fixtures — the form you'll use for a
+real suite. Start with the context-manager form to see the shape, then graduate
+to fixtures.
+
+<Aside type="caution" title="They are synchronous">
+`cluster()` and `workflow()` are ordinary (synchronous) context managers — use
+plain `with`, not `async with`. `workflow()` runs its own event loop internally
+via `asyncio.run(...)`.
+</Aside>
+
+## Step 1 — a cluster in a `with` block
+
+`cluster(count)` starts N nodes, waits for readiness, yields a `ClusterEnv`, and
+tears the nodes down on exit:
+
+```python
+from merobox.testing import cluster
+
+def test_nodes_are_up():
+    with cluster(count=2, prefix="tut") as env:
+        assert len(env["nodes"]) == 2            # ["tut-1", "tut-2"]
+        for name, url in env["endpoints"].items():
+            assert url.startswith("http://")     # name -> RPC URL
+```
+
+The yielded `ClusterEnv` is a dict with exactly three keys — `nodes`
+(`list[str]`), `endpoints` (`dict[str, str]`, node name → RPC URL), and `manager`
+(the live `DockerManager`). Keyword parameters, all optional except `count`:
+`prefix="test"`, `image=None`, `base_port=None`, `base_rpc_port=None`,
+`stop_all=True`, `wait_for_ready=True`. Leave `base_port` / `base_rpc_port` as
+`None` to auto-detect free ports.
+
+## Step 2 — a workflow in a `with` block
+
+`workflow(path)` executes a [workflow YAML](/workflows/yaml/) end to end, then
+exposes the nodes it left running so you can assert against the result:
+
+```python
+from merobox.testing import workflow
+
+def test_workflow_runs():
+    with workflow("./workflows/workflow-example.yml", prefix="e2e") as env:
+        assert env["workflow_result"] is True    # bool — not a result object
+        for value_key, value in (env["dynamic_values"] or {}).items():
+            ...                                   # values captured by `outputs:`
+```
+
+`WorkflowEnv` adds two keys to the cluster set: `workflow_result` (a **`bool`** —
+`True` on success) and `dynamic_values` (a `dict | None` holding everything the
+workflow captured via its `outputs:` blocks, e.g. `app_id`, `context_id`,
+`public_key`). Same keyword parameters as `cluster()`, but `prefix` defaults to
+`"test-node"`, and the workflow path is the one positional argument.
+
+<Aside type="caution">
+Assert `env["workflow_result"] is True`, not truthiness of an object. A workflow
+that fails raises inside the context manager, so a green `with` block already
+means it ran; the bool is there for explicit assertions.
+</Aside>
+
+## Step 3 — turn it into a fixture
+
+For a suite, decorate a placeholder function. The body is ignored (`pass` is
+fine) — the decorator returns a real `@pytest.fixture` that yields a convenience
+object with attribute access instead of a raw dict.
+
+<Tabs>
+  <TabItem label="nodes()">
+
+```python
+from merobox.testing import nodes
+
+@nodes(count=2, prefix="multi-test", scope="function")
+def multi_test_nodes():
+    """Two nodes, function-scoped for isolation."""
+    pass
+
+def test_two_nodes(multi_test_nodes):
+    assert len(multi_test_nodes.nodes) == 2
+    endpoint = multi_test_nodes.endpoint(0)      # by index
+```
+
+  </TabItem>
+  <TabItem label="run_workflow()">
+
+```python
+from merobox.testing import run_workflow
+
+@run_workflow("./workflows/workflow-example.yml",
+              prefix="shared-workflow", scope="session")
+def shared_workflow():
+    """Workflow-provisioned environment, reused across the session."""
+    pass
+
+def test_workflow_env(shared_workflow):
+    assert shared_workflow.success is True
+    ep = shared_workflow.endpoint(0)
+    context_id = shared_workflow.get_captured_value("context_id")
+```
+
+  </TabItem>
+</Tabs>
+
+The object handed to your test exposes:
+
+- `.nodes`, `.endpoints`, `.manager` — mirror the env dict (dict-style
+  `obj["nodes"]` also works for backward compatibility).
+- `.node(index_or_name)` — the node name by list index (int) or passed through by
+  name (str).
+- `.endpoint(index_or_name)` — the RPC URL for that node; accepts an index
+  **or** a name, so `env.endpoint(0)` and `env.endpoint(env.nodes[0])` return the
+  same URL.
+- **From `run_workflow()` only:** `.success` (the `workflow_result` bool),
+  `.dynamic_values`, `.get_captured_value(key, default=None)`, and
+  `.list_captured_values()` (the list of captured keys).
+
+`scope` takes any pytest scope — `function`, `class`, `module`, or `session`.
+
+## Step 4 — drive a real client and assert
+
+The endpoint is a plain RPC URL, so point any HTTP client at it. The example
+project ships a small `Client` and tests it against a live node exactly this way:
+
+```python
+from hello_world.client import Client
+
+def test_client_against_node(single_node):
+    endpoint = single_node.endpoint(0)
+    client = Client(endpoint)
+
+    assert client.base_url == endpoint
+    assert endpoint.startswith("http://") and ":" in endpoint  # host:port
+```
+
+Because `.endpoint()` accepts either form, you can cross-check index vs name —
+this is a real assertion from `example-project/tests/`:
+
+```python
+def test_endpoint_consistency(single_node):
+    by_index = single_node.endpoint(0)
+    by_name  = single_node.endpoint(single_node.nodes[0])
+    assert by_index == by_name
+```
+
+You can also reach the underlying `DockerManager` through `.manager` — e.g.
+`single_node.manager.get_running_nodes()` returns the live node list, and the
+example project even reads a node's `config.toml` out of the container through
+`manager.client.containers.get(name)`.
+
+## Step 5 — assert on captured workflow values
+
+When you provision with `run_workflow()`, the workflow's `outputs:` become
+captured values you can assert on. The example workflow captures `app_id`,
+`context_id`, `public_key`, and contract-call results like `set_result` /
+`get_result`:
+
+```python
+def test_workflow_captured_values(workflow_environment):
+    assert workflow_environment.success is True
+
+    keys = workflow_environment.list_captured_values()   # e.g. ["app_id", ...]
+    context_id = workflow_environment.get_captured_value("context_id")
+    if context_id:
+        assert isinstance(context_id, str) and len(context_id) > 0
+```
+
+<Aside type="tip">
+`get_captured_value(key, default)` never raises on a missing key — it returns the
+default (`None` unless you pass one). Use `list_captured_values()` first if you
+want to assert a key is present.
+</Aside>
+
+## Reuse one cluster per session
+
+Starting containers is the slow part, so the winning pattern — and what
+`example-project/conftest.py` does — is **one session-scoped fixture** with a
+layer of thin aliases pointing at it. Every test that asks for any alias shares
+the same running nodes:
+
+```python
+# conftest.py
+import pytest
+from merobox.testing import nodes, run_workflow
+
+@nodes(count=3, prefix="shared-test", scope="session")
+def shared_cluster():
+    """Main shared cluster with 3 nodes — session scoped for maximum reuse."""
+    pass
+
+@run_workflow("./workflows/workflow-example.yml",
+              prefix="shared-workflow", scope="session")
+def shared_workflow():
+    """Shared workflow setup — session scoped for reuse."""
+    pass
+
+# Thin aliases — each just returns the one shared fixture.
+@pytest.fixture
+def single_node(shared_cluster):
+    return shared_cluster
+
+@pytest.fixture
+def workflow_environment(shared_workflow):
+    return shared_workflow
+
+@pytest.fixture
+def client(shared_cluster):
+    from hello_world.client import Client
+    return Client(shared_cluster.endpoint(0))   # pre-wired client fixture
+```
+
+Tests then request whichever alias reads best; they all resolve to the same
+session cluster:
+
+```python
+def test_simple_setup(single_node):
+    assert len(single_node.nodes) == 3
+    client = Client(single_node.endpoint(0))
+    assert client.base_url == single_node.endpoint(0)
+
+def test_preconfigured_client(client):       # uses the pre-wired fixture
+    assert client.base_url.startswith("http://")
+```
+
+<Aside type="tip">
+Prefer one `scope="session"` cluster shared by aliases over many small clusters.
+It avoids port conflicts and cuts total run time, since the containers start once
+per session rather than once per test.
+</Aside>
+
+## Combining fixtures with `using()`
+
+`testing.py` also exports a `using(*fixtures)` helper for grouping fixtures. It is
+exported but the example project does not exercise it, so treat this as the basic
+form from its signature — it takes the fixtures to combine and returns a wrapper
+applied to the test function:
+
+```python
+from merobox.testing import nodes, run_workflow, using
+
+@nodes(count=2)
+def cluster_fixture():
+    pass
+
+@run_workflow("./workflows/workflow-example.yml")
+def workflow_fixture():
+    pass
+
+@using(cluster_fixture, workflow_fixture)
+def test_combined(cluster_fixture, workflow_fixture):
+    ...
+```
+
+<Aside type="note">
+In its current form `using()` is a light wrapper that returns the test function
+unchanged; the fixtures are still resolved by pytest through the parameter names.
+For most suites, requesting the fixtures directly as test arguments (as in the
+earlier steps) is all you need.
+</Aside>
+
+## Running the suite
+
+The example project configures pytest in its own `pyproject.toml`
+(`testpaths = ["tests"]`, `addopts = "-v --tb=short"`), so from the project root:
+
+```bash
+pytest                     # discover and run tests/
+pytest -k workflow         # just the workflow tests
+pytest tests/test_merobox_integration.py::test_simple_setup
+```
+
+Each session-scoped fixture starts its nodes on first use and tears them down at
+the end of the run; if a run is interrupted, `stop_all=True` (the default) still
+tries to clean up the containers it created.
+
+<CardGrid>
+  <LinkCard
+    title="Testing with pytest (reference)"
+    href="/guides/testing/"
+    description="The full API surface this tutorial is built on." />
+  <LinkCard
+    title="Workflow YAML"
+    href="/workflows/yaml/"
+    description="Author the scenarios run_workflow() executes, and their outputs:." />
+  <LinkCard
+    title="Node management"
+    href="/guides/node-management/"
+    description="What cluster() starts under the hood." />
+  <LinkCard
+    title="System overview"
+    href="/understand/system-overview/"
+    description="Where this end-to-end layer sits in the bigger picture." />
+</CardGrid>

--- a/docs/src/content/docs/guides/recipes.mdx
+++ b/docs/src/content/docs/guides/recipes.mdx
@@ -1,0 +1,262 @@
+---
+title: Recipes
+description: Goal-first how-tos for common merobox tasks — sync recovery after a partition, negative auth tests, namespace upgrades, load tests, blob sharing, capturing values between steps, and keeping nodes alive.
+sidebar:
+  order: 5
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Short, task-oriented answers to "how do I …" questions. Each recipe shows only
+the distinctive steps — assume nodes, an installed application, and a context
+already exist. Every step, field, and flag here is grounded in the
+[workflow YAML reference](/workflows/yaml/) (which also covers the setup steps)
+and a real `workflow-examples/*.yml` scenario. Validate any file first:
+
+```bash
+merobox bootstrap run workflow.yml --dry-run
+```
+
+## How do I test sync recovery after a network partition?
+
+Cut libp2p traffic between a node and its peers with
+[`partition_peers`](/workflows/yaml/#partition_peers--heal_peers), write to the
+isolated node (its RPC stays reachable), then restore delivery with `heal_peers`
+and confirm state reconverges with
+[`wait_for_sync`](/workflows/yaml/#wait_for_sync). This is the surgical
+alternative to `disconnect_node`, which also severs RPC. It is Docker-only and
+needs Linux with `iptables` and passwordless `sudo`.
+
+```yaml
+# after a baseline key has replicated to node-1, node-2 and node-3…
+- type: partition_peers
+  node: calimero-node-1
+  peers: [calimero-node-2, calimero-node-3]
+
+- type: call            # RPC still works on the isolated node
+  node: calimero-node-1
+  context_id: '{{context_id}}'
+  method: set
+  args: { key: from_n1, value: while_partitioned }
+
+- type: heal_peers
+  node: calimero-node-1
+  peers: [calimero-node-2, calimero-node-3]
+
+- type: wait_for_sync   # the write converges everywhere after the heal
+  context_id: '{{context_id}}'
+  nodes: [calimero-node-1, calimero-node-2, calimero-node-3]
+  timeout: 90
+  trigger_sync: true
+```
+
+<Aside type="tip">
+For a coarser fault, [`inject_network_fault`](/workflows/yaml/#inject_network_fault)
+adds packet `loss` or `delay` for a duration, and `disconnect_node` /
+`connect_node` detach a container from its Docker network entirely.
+</Aside>
+
+## How do I write a negative / auth-failure test?
+
+Set [`expected_failure: true`](/workflows/engine/#failure-handling) on a
+[`call`](/workflows/yaml/#call) so the step passes **only if** the operation is
+rejected — the workflow fails if it unexpectedly succeeds. For an authorization
+test, add `unauthenticated: true` to force a no-token request and assert the 401.
+The same flags work on [`ws_connect`](/workflows/yaml/#ws_connect),
+[`login`](/workflows/yaml/#login), and `refresh`.
+
+```yaml
+# a bad call is expected to be rejected
+- type: call
+  node: calimero-node-1
+  context_id: '{{context_id}}'
+  method: invalid_method_that_does_not_exist
+  args: {}
+  expected_failure: true
+
+# a no-token call against an auth-protected node must 401
+- type: call
+  node: calimero-node-1
+  context_id: '{{context_id}}'
+  method: get
+  args: { key: hello }
+  unauthenticated: true
+  expected_failure: true
+```
+
+## How do I upgrade an app across a namespace?
+
+Emit one signed cascade with
+[`cascade_namespace_application`](/workflows/yaml/#cascade_namespace_application)
+from an admin node; it fans the target-application change out to every matching
+descendant subgroup in one sync round. Then block until it lands with
+[`assert_cascade_complete`](/workflows/yaml/#assert_cascade_complete), which
+polls [`get_cascade_status`](/workflows/yaml/#get_cascade_status) under the hood
+until the subtree finishes or the timeout elapses.
+
+```yaml
+- type: cascade_namespace_application
+  node: calimero-node-1
+  namespace_id: '{{namespace_id}}'
+  target_application_id: '{{app_v2}}'
+
+- type: assert_cascade_complete
+  node: calimero-node-1
+  namespace_id: '{{namespace_id}}'
+  timeout_seconds: 60
+```
+
+## How do I load-test a context?
+
+Use [`fuzzy_test`](/workflows/yaml/#fuzzy_test) to hammer a context with
+weighted, randomized operation patterns for a set duration. Each operation is a
+mini-sequence of steps; random generators (`{{random_int(min, max)}}`, `{{uuid}}`,
+`{{random_node}}`) and the auto-captured `{{fuzzy_key}}` / `{{fuzzy_value}}` from a
+prior `call` keep the load varied. Mark per-iteration checks `non_blocking: true`
+so a single miss is tracked, not fatal.
+
+```yaml
+- type: fuzzy_test
+  duration_minutes: 5          # 30–60 for a real run
+  context_id: '{{context_id}}'
+  nodes:
+    - name: calimero-node-1
+    - name: calimero-node-2
+  operations:
+    - name: set_and_verify
+      weight: 70
+      steps:
+        - type: call
+          node: '{{random_node}}'
+          context_id: '{{context_id}}'
+          method: set
+          args:
+            key: 'fuzzy_key_{{random_int(1, 10000)}}'
+            value: 'value_{{uuid}}'
+        - type: call
+          node: '{{random_node}}'
+          context_id: '{{context_id}}'
+          method: get
+          args: { key: '{{fuzzy_key}}' }
+          outputs:
+            fuzzy_get_result: result
+        - type: assert
+          non_blocking: true
+          statements:
+            - 'contains({{fuzzy_get_result}}, {{fuzzy_value}})'
+```
+
+## How do I run against a locally-built merod?
+
+Pass `--no-docker` to run `merod` as a native process instead of a container,
+and `--binary-path` to point at your build. Extra `merod run` arguments go
+through `--merod-args` (binary mode only — it is ignored under Docker). See
+[`bootstrap run`](/reference/cli/#bootstrap-run) for the full flag list.
+
+```bash
+merobox bootstrap run workflow.yml \
+  --no-docker \
+  --binary-path ./target/release/merod \
+  --merod-args="--sync-strategy delta"
+```
+
+<Aside type="note">
+A workflow can opt into binary mode itself with top-level `no_docker: true` and
+`binary_path:` keys; the CLI flags take precedence when both are set. To pin a
+specific Docker image instead, use `--image` (or the `image:` field under
+`nodes:`).
+</Aside>
+
+## How do I share a file via blobs?
+
+Push a file into a node's blob store with
+[`upload_blob`](/workflows/yaml/#upload_blob) and capture the returned `blob_id`
+(and `size`) for later steps — for example, to register the blob inside your
+application. Remove it later through the admin API with
+[`delete_blob`](/workflows/yaml/#delete_blob), which cascades chunked blobs.
+
+```yaml
+- type: upload_blob
+  node: calimero-node-1
+  file_path: workflow-examples/blob-test-files/sample.pdf
+  context_id: '{{context_id}}'
+  outputs:
+    pdf_blob_id: blob_id
+    pdf_blob_size: size
+
+# …use {{pdf_blob_id}} in a call, then clean up:
+- type: delete_blob
+  node: calimero-node-1
+  blob_id: '{{pdf_blob_id}}'
+```
+
+## How do I capture a value from one step and reuse it?
+
+Add an [`outputs:`](/workflows/engine/#capturing-outputs) block that maps a new
+variable name to a field in the step's response, then reference it anywhere later
+as `{{name}}` (see [variable substitution](/workflows/engine/#variable-substitution)).
+This is how ids thread through a workflow — an `applicationId` becomes a
+namespace's `application_id`, whose `contextId` becomes a call's `context_id`.
+
+```yaml
+- type: install_application
+  node: calimero-node-1
+  path: ./workflow-examples/res/kv_store.wasm
+  dev: true
+  outputs:
+    app_id: applicationId        # store response.applicationId as {{app_id}}
+
+- type: create_context
+  node: calimero-node-1
+  application_id: '{{app_id}}'   # …and read it back here
+  group_id: '{{namespace_id}}'
+  outputs:
+    context_id: contextId
+    member_key: memberPublicKey
+```
+
+## How do I keep nodes running after a workflow?
+
+Leave `stop_all_nodes` at its default of `false` (or set it explicitly) and the
+executor calls `keep_resources_on_exit()` during
+[teardown](/workflows/engine/#teardown), so the containers stay up after
+`bootstrap run` returns — ready for inspection or a follow-up workflow. Set it to
+`true` to shut everything down at the end instead.
+
+```yaml
+name: Leave nodes running
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+
+steps:
+  - type: wait
+    seconds: 1
+
+stop_all_nodes: false   # default — nodes keep running after the run
+```
+
+<Aside type="tip">
+Inspect the still-running nodes afterwards with `merobox list`, `merobox health`,
+and `merobox logs <node>`, and tear them down when done with `merobox stop --all`
+(see [node management](/guides/node-management/)).
+</Aside>
+
+<CardGrid>
+  <LinkCard
+    title="Workflow YAML reference"
+    href="/workflows/yaml/"
+    description="Every step type with its full field list." />
+  <LinkCard
+    title="Workflow engine"
+    href="/workflows/engine/"
+    description="Outputs, substitution, failure handling, teardown." />
+  <LinkCard
+    title="Testing with merobox"
+    href="/guides/testing/"
+    description="Drive these flows from pytest, and the fuzzy load model." />
+  <LinkCard
+    title="Node management"
+    href="/guides/node-management/"
+    description="Docker vs binary backends, lifecycle, and logs." />
+</CardGrid>

--- a/docs/src/content/docs/guides/remote-nodes.mdx
+++ b/docs/src/content/docs/guides/remote-nodes.mdx
@@ -135,7 +135,7 @@ remote_nodes:
   production-node:
     url: https://node.example.com
     auth:
-      method: user_password
+      method: password
       username: admin
   staging-node:
     url: https://staging.example.com

--- a/docs/src/content/docs/understand/glossary.mdx
+++ b/docs/src/content/docs/understand/glossary.mdx
@@ -48,7 +48,7 @@ these build on (context, group, namespace, CRDT), see the
 | **RetryConfig / `@with_retry`** | Retry primitives (`commands/retry.py`): `RetryConfig` holds retry settings (max attempts, delay, exponential backoff) and `@with_retry` wraps async network calls with them. `NETWORK_RETRY_CONFIG` is the shared preset. |
 | **scenario** | An informal name for a workflow YAML file — a declarative description of nodes and steps that merobox executes end to end. |
 | **`script` (step)** | Step that runs a shell command or script, optionally targeting the host image or the nodes. |
-| **step** | The atomic unit of work in a workflow. Each step has a `type`, an optional `name`, an optional `outputs:` map, and type-specific fields. There are more than eighty step types. |
+| **step** | The atomic unit of work in a workflow. Each step has a `type`, an optional `name`, an optional `outputs:` map, and type-specific fields. There are nearly 100 step types. |
 | **Traefik** | Reverse proxy that `DockerManager` deploys alongside the containers when the auth service is enabled, routing requests to nodes and applying the auth middleware. |
 | **`wait` / `wait_for_sync` (step)** | `wait` pauses for a fixed duration; `wait_for_sync` polls nodes until they report a synchronized state for a context. |
 | **workflow** | A YAML file declaring `nodes:` and an ordered list of `steps:`, executed by `WorkflowExecutor` from setup through teardown. |

--- a/docs/src/content/docs/understand/system-overview.mdx
+++ b/docs/src/content/docs/understand/system-overview.mdx
@@ -107,7 +107,7 @@ can reference earlier values.
 
 - **Steps** live in `merobox/commands/bootstrap/steps/`. Every step subclasses
   `BaseStep` (`steps/base.py`), which defines an async `execute()` plus field
-  validation helpers. There are more than eighty step types — application
+  validation helpers. There are nearly 100 step types — application
   install, context create, identity create, invite/join, `call`, `assert`,
   `wait`, `repeat`, `parallel`, `script`, blob upload, group/namespace
   governance, fault injection, `fuzzy_test`, and more.

--- a/docs/src/content/docs/workflows/examples.mdx
+++ b/docs/src/content/docs/workflows/examples.mdx
@@ -1,0 +1,205 @@
+---
+title: Examples gallery
+description: An index of the runnable workflow-examples shipped with merobox — what each YAML scenario teaches and the key step types it demonstrates.
+sidebar:
+  order: 3
+---
+
+merobox ships ~54 runnable workflows under
+[`workflow-examples/`](https://github.com/calimero-network/merobox/tree/master/workflow-examples).
+Each one is a self-contained, CI-verified scenario: pick the behaviour you want
+to learn, run its file, and read the steps. This page groups them by topic and
+says, in one line, what each teaches.
+
+For the schema behind every step type, see the
+[workflow YAML reference](/workflows/yaml/); for the execution model (variables,
+retries, parallelism), the [workflow engine](/workflows/engine/).
+
+## Running any example
+
+Clone the repo and point `bootstrap run` at the file (paths are relative to the
+repo root):
+
+```bash
+merobox bootstrap run workflow-examples/workflow-example.yml
+```
+
+Validate first without booting nodes:
+
+```bash
+merobox bootstrap run workflow-examples/workflow-example.yml --dry-run
+```
+
+Some workflows document their own switches in a top-of-file comment — e.g. the
+open-invitation example expects `--e2e-mode`, and the binary/auth examples run
+in native (`--no-docker`) mode. Read the header before running.
+
+When you're done, stop the nodes the run left behind:
+
+```bash
+merobox stop --all
+```
+
+:::note[These run in CI]
+Every example here is wired into merobox CI. A discovery job fans the files into
+three matrices: **Binary** (native `merod` from the latest core release),
+**Docker** (`merod:edge`), and **TEE** (native `merod` built with
+`--features mock-attestation`). A few are deliberately excluded from one matrix
+where the environment can't support them — the fuzzy/load, auth, fault-injection
+and NAT-topology workflows are Docker-only; `workflow-example-binary.yml` is
+binary-only; and the `tee-*` scenarios run only in the dedicated TEE job. So a
+green CI run means these files actually pass, not just that they parse.
+:::
+
+## Basics
+
+The canonical shapes: a two-node workflow, binary vs Docker mode, and the
+run-hygiene flags.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-example.yml) | The canonical Docker two-node flow: install → namespace → context → invite/join → call → sync, with dynamic value capture via `outputs`. | `install_application`, `create_namespace`, `create_context`, `create_namespace_invitation`, `join_namespace`, `call`, `wait_for_sync` |
+| [`workflow-example-binary.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-example-binary.yml) | The same end-to-end flow run in native binary mode (`no_docker: true`) instead of containers. | same as above, `no_docker` |
+| [`workflow-mesh-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-mesh-example.yml) | The `create_mesh` convenience: create a context and wire multiple nodes into it in a single step. | `create_mesh`, `call`, `wait_for_sync`, `assert`, `json_assert` |
+| [`workflow-script-test.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-script-test.yml) | The `script` step at each `target`: `image` (pre-node setup), `nodes` (post-node health check). | `script` |
+| [`workflow-nuke-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-nuke-example.yml) | Full data isolation with `nuke_on_start` / `nuke_on_end` (fresh state before and after). | `nuke_on_start`, `nuke_on_end`, `call`, `wait_for_sync` |
+| [`workflow-restart-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-restart-example.yml) | The `restart: true` flag — stop then start nodes at the beginning instead of reusing running ones. | `restart`, `call`, `wait_for_sync` |
+| [`workflow-force-pull-test.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-force-pull-test.yml) | The `force_pull_image` flag — re-pull Docker images even when present locally. | `force_pull_image`, `wait` |
+
+## Control flow
+
+Loops and active sync waits.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-repeat-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-repeat-example.yml) | The `repeat` step and its auto-exported iteration counters used inside nested steps. | `repeat`, `call`, `wait_for_sync` |
+| [`workflow-context-loop.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-context-loop.yml) | A minimal loop: create a context 100 times to stress context creation. | `repeat`, `create_context` |
+| [`workflow-wait-for-sync-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-wait-for-sync-example.yml) | `wait_for_sync` — actively verify convergence by comparing root hashes instead of fixed sleeps. | `wait_for_sync`, `call`, `json_assert` |
+
+## Assertions & outputs
+
+Verifying results, capturing variables, and negative testing.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-assert-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-assert-example.yml) | The `assert` and `json_assert` steps (`is_set`, `contains`, `==`, JSON subset/equality). | `assert`, `json_assert` |
+| [`workflow-assert-log-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-assert-log-example.yml) | Log-scanning assertions: `assert_log_present` / `assert_log_absent`. | `assert_log_present`, `assert_log_absent` |
+| [`workflow-custom-outputs-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-custom-outputs-example.yml) | Custom `outputs` capture for dynamic variables reused across later steps. | `outputs`, `call`, `wait_for_sync`, `repeat` |
+| [`workflow-execute-variables-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-execute-variables-example.yml) | Exporting variables from a `call` (execute) step and reusing them in a `script`. | `call`, `script`, `outputs` |
+| [`workflow-nested-json-parsing-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-nested-json-parsing-example.yml) | Automatic parsing of deeply nested JSON responses, asserted with `json_assert`. | `call`, `json_assert` |
+| [`workflow-negative-testing-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-negative-testing-example.yml) | Negative testing on `call` with `expected_failure: true`. | `call` (`expected_failure`), `assert` |
+| [`workflow-expected-failure-steps-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-expected-failure-steps-example.yml) | `expected_failure: true` honoured on non-`call` step types too. | `join_namespace`, `join_context`, `create_group_in_namespace` (each with `expected_failure`) |
+
+## Groups & namespaces
+
+Namespaces, subgroups, and invitation-based joins.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-groups-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-groups-example.yml) | Context group management: invite node 2 to a namespace, share a context, join via group membership, verify state propagates. | `create_namespace_invitation`, `join_namespace`, `join_context`, `wait_for_sync` |
+| [`workflow-subgroups-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-subgroups-example.yml) | Subgroup management: create a subgroup, add a member, create a context in it, sync through the subgroup. | `create_group_in_namespace`, `add_group_members`, `join_context`, `wait_for_sync` |
+| [`workflow-open-invitation-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-open-invitation-example.yml) | The open-invitation flow following the e2e test pattern (run with `--e2e-mode`). | `create_namespace_invitation`, `join_namespace`, `call`, `json_assert` |
+
+## Membership & capabilities
+
+Roles, capability bitmasks, auto-follow, and metadata.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-group-admin-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-group-admin-example.yml) | The full group admin-API surface: default policy, roles, capabilities, context detach, member removal, explicit governance sync. | `set_default_capabilities`, `set_member_capabilities`, `update_member_role`, `detach_context_from_group`, `remove_group_members`, `sync_group` |
+| [`workflow-set-member-auto-follow-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-set-member-auto-follow-example.yml) | The `set_member_auto_follow` step (admin-or-self) toggling auto-follow of contexts and subgroups. | `set_member_auto_follow`, `add_group_members` |
+| [`workflow-group-metadata-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-group-metadata-example.yml) | The six metadata steps (group/member/context set+get) and the `CAN_MANAGE_METADATA` capability gate. | `set_group_metadata`, `get_group_metadata`, `set_member_metadata`, `set_context_metadata`, `set_member_capabilities` |
+
+## Upgrades & migration
+
+Per-group and namespace-wide application upgrades.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-group-upgrade-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-group-upgrade-example.yml) | The per-group upgrade lifecycle v1→v2: set policy, upgrade, poll status, retry (expected-fail after completion). | `update_group_settings`, `upgrade_group`, `get_group_upgrade_status`, `retry_group_upgrade` |
+| [`workflow-cascade-namespace-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-cascade-namespace-example.yml) | The namespace cascade: one signed op fans the target-application change out to every matching descendant subgroup. | `cascade_namespace_application`, `get_group_info`, `json_assert` |
+
+## Auth
+
+The two auth topologies — proxied `mero-auth` and embedded — plus frontend caching.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-auth-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-auth-example.yml) | Enabling the `auth_service` (a `mero-auth` container behind a Traefik proxy). | `auth_service`, `wait` |
+| [`workflow-auth-image-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-auth-image-example.yml) | Pointing the auth service at a custom `auth_image`. | `auth_service`, `auth_image` |
+| [`workflow-cached-frontends-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-cached-frontends-example.yml) | Cached auth + WebUI frontends via `auth_use_cached` / `webui_use_cached`. | `auth_use_cached`, `webui_use_cached`, `create_identity` |
+| [`workflow-embedded-auth-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-embedded-auth-example.yml) | End-to-end embedded auth (router mounted inside `merod`): login, authenticated calls, negative asserts, WebSocket, refresh. | `login`, `call`, `ws_connect`, `refresh` |
+| [`workflow-websocket-auth-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-websocket-auth-example.yml) | WebSocket auth via the `?token=` query param (JWT in the URL): valid token connects, missing token is rejected. | `login`, `ws_connect`, `ws_subscribe` |
+
+## Blobs
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-blob-upload-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-blob-upload-example.yml) | The blob API for file sharing: upload a file, reference it from a call, sync across nodes. | `upload_blob`, `call`, `wait_for_sync` |
+
+## Fault-injection & resilience
+
+Pausing, disconnecting, partitioning, degrading, and recovering nodes — and the
+regression guards that prove convergence still holds.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-fault-injection-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-fault-injection-example.yml) | The Docker-native fault primitives (pause/unpause, restart, disconnect/connect), each paired with a container-state assertion script. | `pause_container`, `unpause_container`, `restart_container`, `disconnect_node`, `connect_node`, `script` |
+| [`workflow-fault-injection-convergence-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-fault-injection-convergence-example.yml) | Behavioural proof that each primitive has its claimed effect: partition blocks propagation, heal + sync converges. | `create_mesh`, `disconnect_node`, `connect_node`, `wait_for_sync`, `assert` |
+| [`workflow-fault-injection-partition-peers-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-fault-injection-partition-peers-example.yml) | `partition_peers` / `heal_peers` — a surgical libp2p cut that keeps RPC reachable (unlike `disconnect_node`). | `partition_peers`, `heal_peers`, `create_mesh`, `wait_for_sync` |
+| [`workflow-fault-injection-tc-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-fault-injection-tc-example.yml) | `inject_network_fault` (tc netem packet loss / added latency). Requires a merod image with `iproute2`. | `inject_network_fault` |
+| [`workflow-stop-start-nodes.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-stop-start-nodes.yml) | Stopping and restarting nodes mid-workflow with `stop_node` / `start_node`. | `stop_node`, `start_node`, `call` |
+| [`workflow-snapshot-finalize-regression-3252.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-snapshot-finalize-regression-3252.yml) | Regression guard for core #3252: a snapshot-bootstrapping joiner must converge to a non-zero state hash. | `create_mesh`, `wait_for_sync`, `json_assert`, `assert_log_absent` |
+
+## NAT topology
+
+Multi-bridge NAT layouts with a relay boot-node — for exercising relay/hole-punching paths.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-nat-topology-cone-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-nat-topology-cone-example.yml) | Smoke test for `topology: { type: nat, nat_mode: cone }` (plain MASQUERADE gateway). | `topology` (nat/cone), `wait_for_sync`, `assert_log_present`, `assert_log_absent` |
+| [`workflow-nat-topology-symmetric-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-nat-topology-symmetric-example.yml) | Smoke test for `nat_mode: symmetric` (random-fully MASQUERADE — defeats STUN-style port prediction). | `topology` (nat/symmetric), `wait_for_sync`, `assert_log_present`, `assert_log_absent` |
+
+## Bootstrap edge-cases
+
+Controlling the default boot-node list under `--e2e-mode`.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-preserve-default-bootstrap.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-preserve-default-bootstrap.yml) | `preserve_default_bootstrap: true` opts out of e2e-mode's boot-list clearing (single node). | `preserve_default_bootstrap`, `assert_log_present`, `assert_log_absent` |
+| [`workflow-preserve-default-bootstrap-cluster.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-preserve-default-bootstrap-cluster.yml) | The preserved boot-node survives the multi-node cluster-wiring step. | `preserve_default_bootstrap`, `assert_log_present`, `assert_log_absent` |
+
+## Fuzzy & load
+
+Randomized load, throughput timing, and propagation monitoring.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`workflow-fuzzy-kv-store.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-fuzzy-kv-store.yml) | The `fuzzy_test` step: weighted randomized operations for a configurable duration with assertion validation. | `fuzzy_test`, `call`, `assert` |
+| [`kv-store-benchmark.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/kv-store-benchmark.yml) | Throughput testing with timing metrics, combining `repeat` and `parallel`. | `repeat`, `parallel`, `call`, `script`, `assert` |
+| [`workflow-propagation-monitoring.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-propagation-monitoring.yml) | Monitoring DAG propagation reliability over ~75 seconds on a mesh. | `create_mesh`, `repeat`, `call`, `json_assert` |
+
+## TEE
+
+Local mock-TEE admission and replication scenarios. All require a `merod` built
+with `--features mock-attestation` and nodes booted with `mock_tee: true` (see
+each file's header); in CI they run in the dedicated TEE matrix.
+
+| Example | Teaches | Key steps |
+| --- | --- | --- |
+| [`tee-g1-restricted-auto-admit.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-g1-restricted-auto-admit.yml) | Restricted subgroup auto-admit of an admitted root TEE. | `set_tee_admission_policy`, `tee_fleet_join`, `assert_tee_member` |
+| [`tee-g2-open-inheritance-replication.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-g2-open-inheritance-replication.yml) | An admitted root TEE *replicates* (not just authorizes) a context in an Open subgroup via inheritance. | `set_subgroup_visibility`, `tee_fleet_join`, `assert_tee_member`, `create_context` |
+| [`tee-g3-disable-cascade-purge.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-g3-disable-cascade-purge.yml) | Removing an admitted TEE at the root cascades a purge from every subgroup. | `remove_group_members`, `assert_not_member` |
+| [`tee-g4-inherited-role.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-g4-inherited-role.yml) | An inherited root TEE carries the `ReadOnlyTee` role into an Open subgroup (not a downgrade). | `set_subgroup_visibility`, `tee_fleet_join`, `assert_tee_member` |
+| [`tee-matrix-open-join-with-created.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-matrix-open-join-with-created.yml) | Timing×visibility matrix: Open, interleaved join-with-created (concurrent). | `set_subgroup_visibility`, `tee_fleet_join`, `create_context` |
+| [`tee-matrix-open-late-join.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-matrix-open-late-join.yml) | Timing×visibility matrix: Open, late-join (subgroup + context exist before the TEE joins). | `set_subgroup_visibility`, `create_context`, `tee_fleet_join` |
+| [`tee-matrix-restricted-join-with-created.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-matrix-restricted-join-with-created.yml) | Timing×visibility matrix: Restricted, interleaved join-with-created. | `tee_fleet_join`, `create_context`, `assert_tee_member` |
+| [`tee-matrix-restricted-late-join.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-matrix-restricted-late-join.yml) | Timing×visibility matrix: Restricted, late-join. | `create_context`, `tee_fleet_join`, `assert_tee_member` |
+| [`tee-r1-offline-backfill.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-r1-offline-backfill.yml) | Recovery (core #2848): a TEE that went offline during a context create backfills on rejoin. | `stop_node`, `create_context`, `start_node`, `assert_tee_member` |
+| [`tee-r2-open-no-direct-row.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/tee-r2-open-no-direct-row.yml) | Born-Open guard (core #2771): a born-Open subgroup has no direct `ReadOnlyTee` row. | `tee_fleet_join`, `assert_tee_member`, `assert_log_present` |
+
+## See also
+
+- [Workflow YAML reference](/workflows/yaml/) — every step type and field.
+- [Workflow engine](/workflows/engine/) — variables, retries, parallelism.
+- [Testing with merobox](/guides/testing/) — E2E scenarios and fuzzy load testing.

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -34,7 +34,7 @@ description: What this workflow proves
 
 nodes:
   count: 2
-  image: ghcr.io/calimero-network/merod:edge
+  image: ghcr.io/calimero-network/merod:prerelease
   prefix: calimero-node
 
 steps:
@@ -79,7 +79,7 @@ The quickest form: ask for N identical nodes and let merobox name and port them.
 nodes:
   count: 3
   prefix: calimero-node          # nodes become calimero-node-1, -2, -3
-  image: ghcr.io/calimero-network/merod:edge
+  image: ghcr.io/calimero-network/merod:prerelease
   base_port: 2428                # first node's server port (increments per node)
   base_rpc_port: 2528            # first node's RPC port (increments per node)
 ```


### PR DESCRIPTION
## Description

Levels up the merobox docs. The migrated reference pages were accurate but the site had **no onboarding path** — no install, no quickstart, no tutorial. This adds a Get Started track and the task/example content a new user needs, plus a few accuracy fixes.

### New pages
- **`get-started/quickstart`** — install (pipx / apt `.deb` / Homebrew / source), verify, start 2 nodes, run a first workflow, teardown.
- **`get-started/first-workflow`** — a narrated tutorial that builds one workflow step by step (install → namespace → context → invite/join → `call` set/get → `wait_for_sync` → `assert`), explaining `outputs:` capture and `{{name}}` substitution as they appear.
- **`workflows/examples`** — a gallery of all **54** `workflow-examples/` scenarios, grouped into 13 topics with "what it teaches" + key steps, each linked to source.
- **`guides/recipes`** — 8 task how-tos (partition recovery, negative/auth-failure tests, namespace app upgrade, fuzzy load-test, local merod, blobs, value capture, keep-nodes-running).
- **`guides/pytest-tutorial`** — hands-on companion to the testing reference, grounded in `example-project/` (fixtures, context managers, `.endpoint()`, captured values).

### Accuracy fixes
- YAML remote-node `auth.method: user_password` → `password` (`user_password` is a CLI-only value; the YAML enum is `none|api_key|password`).
- `merod:edge` → `merod:prerelease` in examples (matches `constants.py`).
- Step-count "more than eighty" → "nearly 100"; README "35+ step types" → "~100".

### Nav
Added a **Get Started** track; surfaced the examples gallery under Workflows and the new guides.

## Test plan
`cd docs && npm run check` (astro build + internal link check) — **passes, 18 pages, all internal links resolve.** Content verified against the Python package (`cli.py`, `commands/`, `testing.py`), `workflow-examples/`, and `example-project/`.