### PR TITLE
docs: add animated sequence diagrams to the flow pages

### DIFF
--- a/docs/src/content/docs/get-started/first-workflow.mdx
+++ b/docs/src/content/docs/get-started/first-workflow.mdx
@@ -6,6 +6,7 @@ sidebar:
 ---
 
 import { Steps } from '@astrojs/starlight/components';
+import SeqDiagram from '../../../components/SeqDiagram.astro';
 
 This tutorial builds a single workflow from scratch. By the end you will have a
 YAML file that boots two Calimero nodes, writes a value on one node, waits for it
@@ -256,6 +257,35 @@ responses. See the [workflow YAML reference](/workflows/yaml/).
 :::
 
 ## The complete workflow
+
+The whole run as one sequence across `merobox` and the two nodes it drives:
+
+<SeqDiagram
+  id="d-first-workflow"
+  title="First workflow: write on node 1, read on node 2"
+  lanes={[
+    { label: 'merobox', color: '#3fb950' },
+    { label: 'Node 1', color: '#58a6ff' },
+    { label: 'Node 2', color: '#a371f7' },
+  ]}
+  steps={[
+    { from: 0, to: 1, label: 'install_application → app_id' },
+    { from: 0, to: 1, label: 'create_namespace → namespace_id' },
+    { from: 0, to: 1, label: 'create_context → context_id' },
+    { from: 0, to: 1, label: 'create_namespace_invitation → invitation' },
+    { from: 0, to: 0, label: 'wait 5s (namespace gossip)' },
+    { from: 0, to: 2, label: 'join_namespace (invitation)' },
+    { from: 0, to: 2, label: 'join_context (context_id)' },
+    { from: 0, to: 1, label: 'call set(hello=world)', color: '#a5ff11' },
+    { from: 0, to: 1, label: 'wait_for_sync: poll state hash' },
+    { from: 0, to: 2, label: 'poll state hash' },
+    { from: 1, to: 2, label: 'context state converges', dashed: true },
+    { type: 'divider', label: 'nodes agree on context state' },
+    { from: 0, to: 2, label: 'call get(hello) → get_result' },
+    { from: 0, to: 0, label: 'assert contains(get_result, "world")' },
+    { type: 'divider', label: 'value propagated' },
+  ]}
+/>
 
 Putting every step together:
 

--- a/docs/src/content/docs/workflows/engine.mdx
+++ b/docs/src/content/docs/workflows/engine.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 1
 ---
 
+import SeqDiagram from '../../../components/SeqDiagram.astro';
+
 A merobox **workflow** is a YAML file that boots one or more Calimero nodes and
 drives them through an ordered list of typed **steps**. This page explains *how*
 a workflow runs — the execution model behind `merobox bootstrap run`. For the
@@ -58,6 +60,31 @@ running after `bootstrap run` returns — otherwise the manager's exit handler
 would tear them down immediately. Set `stop_all_nodes: true` to shut everything
 down at the end.
 :::
+
+<SeqDiagram
+  id="d-run-lifecycle"
+  title="Run lifecycle of merobox bootstrap run"
+  lanes={[
+    { label: 'merobox', color: '#3fb950' },
+    { label: 'Docker', color: '#58a6ff' },
+    { label: 'Nodes', color: '#a371f7' },
+  ]}
+  steps={[
+    { from: 0, to: 0, label: 'Resolver setup' },
+    { from: 0, to: 1, label: 'Nuke on start (delete data)', dashed: true },
+    { from: 0, to: 1, label: 'Force pull images', dashed: true },
+    { from: 0, to: 1, label: 'Start / restart nodes' },
+    { from: 1, to: 2, label: 'Boot merod containers' },
+    { from: 0, to: 2, label: 'Poll /admin-api/health' },
+    { from: 2, to: 0, label: 'Ready', dashed: true },
+    { from: 0, to: 2, label: 'Embedded-auth login', dashed: true },
+    { type: 'divider', label: 'run steps sequentially' },
+    { from: 0, to: 2, label: 'Execute step (admin-API / JSON-RPC)', color: '#a5ff11' },
+    { from: 2, to: 0, label: 'Result + capture outputs', dashed: true },
+    { type: 'divider', label: 'teardown (always)' },
+    { from: 0, to: 1, label: 'Stop nodes / nuke data' },
+  ]}
+/>
 
 ## Step lifecycle
 


### PR DESCRIPTION
## Description

Puts the shared Calimero **animated-SVG sequence-diagram engine** (`SeqDiagram`, ported during the migration but unused) to work on the two merobox pages that describe a flow. The diagrams **complement** the existing prose/steps.

- **`workflows/engine`** — the run lifecycle as a sequence: `merobox` ⇄ Docker ⇄ Nodes (resolver setup → nuke → force-pull → start/restart → readiness → embedded-auth → run steps → teardown).
- **`get-started/first-workflow`** — the tutorial workflow across two nodes (install → namespace → context → invite/join → `call` set → `wait_for_sync` → get → `assert`).

Lanes/steps are derived from each page's own verified content. **Authoring-only** — no edits to `SeqDiagram.astro`, `diagrams.client.ts`, or `theme.css`.

## Test plan
`cd docs && npm run check` — **passes, 18 pages, links OK.**

## Note
I deliberately did **not** add diagrams to reference/config/glossary/gallery pages — tables and prose read better there, and a forced diagram would be noise. Only the genuinely flow-shaped pages got one.