### PR TITLE
fix(docs): ship the diagram engine as an external module (not inlined)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,6 +8,9 @@ export default defineConfig({
   site: 'https://calimero-network.github.io',
   // GitHub project Pages serve under /<repo>/. Change if a custom domain is used.
   base: '/merobox',
+  // Keep the animated-diagram engine as an external module (like core) instead
+  // of inlining it per page — assetsInlineLimit 0 stops small-asset inlining.
+  vite: { build: { assetsInlineLimit: 0 } },
   integrations: [
     starlight({
       title: 'merobox',


### PR DESCRIPTION
Same fix as mero-tee: the animated `SeqDiagram` engine was being inlined per-page by Vite; core emits it as an external module. `vite.build.assetsInlineLimit: 0` externalizes it so the page loads `_astro/SeqDiagram.astro_…_script.js` (matching core). Verified: `npm run check` passes (18 pages, links OK).