### PR TITLE
docs: drop Homebrew install path, standardize on pipx

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -12,7 +12,7 @@ Merobox is a Python CLI tool for managing Calimero nodes in Docker containers. I
 
 ## Installation
 
-**Option 1: Using pipx (PyPI - Recommended)**
+**Using pipx (PyPI - Recommended)**
 
 First, ensure you have pipx installed:
 
@@ -34,16 +34,6 @@ Then install merobox:
 ```bash
 # Install from PyPI using pipx
 pipx install merobox
-
-# Verify installation
-merobox --version
-```
-
-**Option 2: Using Homebrew (macOS)**
-
-```bash
-# Install via Homebrew
-brew install merobox
 
 # Verify installation
 merobox --version

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ A Python CLI for managing Calimero nodes (Docker or native) and orchestrating YA
 pipx install merobox
 ```
 
-**Homebrew:**
-
-```bash
-brew install merobox
-```
-
 **From source:**
 
 ```bash

--- a/docs/src/content/docs/get-started/quickstart.mdx
+++ b/docs/src/content/docs/get-started/quickstart.mdx
@@ -29,13 +29,6 @@ pipx install merobox
 ```
 
   </TabItem>
-  <TabItem label="Homebrew">
-
-```bash
-brew install merobox
-```
-
-  </TabItem>
   <TabItem label="From source">
 
 ```bash


### PR DESCRIPTION
Removes the Homebrew install instructions from `README.md`, `LLM.md`, and `quickstart.mdx`. Standardize on **pipx (PyPI)**; the GitHub-release binaries remain for binary users.

**Why:** `brew install merobox` is stale and effectively broken, independent of the recent apt removal:
- the tap formula (`calimero-network/homebrew-tap` `Formula/merobox.rb`) is pinned to **0.1.23** (current is **0.6.43**) and has never been bumped;
- its release-asset naming (`darwin-x64`/`linux-x64`) no longer matches what `release.yml` produces (`darwin-x86-64`/`linux-x86-64`), so the download URLs would 404 even after a version bump;
- nothing auto-bumps the formula on release; and
- the documented command was missing the required `brew tap …` step anyway.

pipx already covers macOS/Linux/Windows, so brew was a redundant, unmaintained channel. The formula itself is removed in a companion PR on the tap repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)