### PR TITLE
fix(bootstrap): actually export outputs from the account steps and node_exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.46] - 2026-08-02
+
+### Fixed
+
+- **`outputs:` on the account steps and `node_exec` exported nothing.** A step has
+  to call `_export_variables` for `outputs:` to do anything; recording the result
+  in `workflow_results` is a different thing, and nothing in the framework
+  enforces the second. So every `outputs:` on the steps added in 0.6.45 was inert,
+  and a scenario capturing e.g. `root_key: accountRootKey` carried the literal
+  `{{root_key}}` into whatever consumed it — surfacing far away as
+  `Field 'accountRootKey' must be exactly 64 characters (got 12)`.
+
+  Every step that declares outputs now has a test asserting the *exported
+  variables* by name, not just the recorded result. The original tests asserted
+  `workflow_results` and passed throughout.
+
 ## [0.6.45] - 2026-08-02
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.45"
+__version__ = "0.6.46"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/account.py
+++ b/merobox/commands/bootstrap/steps/account.py
@@ -64,10 +64,17 @@ class _AccountStepBase(BaseStep):
         result_key: str,
         data: dict[str, Any],
         workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
     ) -> bool:
         if self._check_jsonrpc_error(data):
             return False
         workflow_results[f"{result_key}_{node_name}"] = data
+        # Recording the result is NOT the same as exporting it: `outputs:` only
+        # does anything if the step calls this. Without it the placeholders a
+        # scenario writes stay literal, and the failure surfaces wherever they are
+        # consumed — a `{{root_key}}` reaching an api as a 12-character string —
+        # rather than here.
+        self._export_variables(data, node_name, dynamic_values)
         return True
 
 
@@ -132,7 +139,9 @@ class AccountCreateStep(_AccountStepBase):
             f"[green]✓[/green] {node_name} enrolled account {data['accountId']} "
             f"with device {data.get('deviceId')}"
         )
-        return self._finish(node_name, "account", data, workflow_results)
+        return self._finish(
+            node_name, "account", data, workflow_results, dynamic_values
+        )
 
 
 class AccountPairStep(_AccountStepBase):
@@ -239,7 +248,9 @@ class AccountPairStep(_AccountStepBase):
             f"{data.get('accountId')} as device {data.get('deviceId')} "
             f"(key delivered: {data.get('keyDelivered')})"
         )
-        return self._finish(node_name, "paired_account", data, workflow_results)
+        return self._finish(
+            node_name, "paired_account", data, workflow_results, dynamic_values
+        )
 
 
 class AccountRevokeStep(_AccountStepBase):
@@ -290,7 +301,7 @@ class AccountRevokeStep(_AccountStepBase):
             f"[green]✓[/green] {node_name} revoked device {device_id} "
             f"(key rotated: {data.get('keyRotated')})"
         )
-        return self._finish(node_name, "revoke", data, workflow_results)
+        return self._finish(node_name, "revoke", data, workflow_results, dynamic_values)
 
 
 class AccountShowStep(_AccountStepBase):
@@ -342,4 +353,6 @@ class AccountShowStep(_AccountStepBase):
             f"[green]✓[/green] {node_name} owns account {data.get('accountId')} "
             f"(device: {data.get('deviceId')})"
         )
-        return self._finish(node_name, "shown_account", data, workflow_results)
+        return self._finish(
+            node_name, "shown_account", data, workflow_results, dynamic_values
+        )

--- a/merobox/commands/bootstrap/steps/node_exec.py
+++ b/merobox/commands/bootstrap/steps/node_exec.py
@@ -230,4 +230,7 @@ class NodeExecStep(BaseStep):
 
         console.print(f"[green]✓[/green] node_exec on {node_name} succeeded")
         workflow_results[f"exec_{node_name}"] = result["data"]
+        # As above: recording is not exporting. `outputs: { phrase:
+        # stdout_first_line }` is inert unless this runs.
+        self._export_variables(result["data"], node_name, dynamic_values)
         return True

--- a/merobox/tests/unit/test_account_steps.py
+++ b/merobox/tests/unit/test_account_steps.py
@@ -321,3 +321,128 @@ class TestAccountShowStep:
 
         client.get_namespace_account.assert_called_once_with(NAMESPACE)
         assert results["shown_account_calimero-node-2"]["deviceId"] is None
+
+
+class TestOutputsAreActuallyExported:
+    """`outputs:` is inert unless a step calls `_export_variables`.
+
+    Recording a result in `workflow_results` is NOT the same as exporting it, and
+    nothing in the framework enforces the second. These steps shipped without it:
+    every `outputs:` on them exported nothing, so `{{root_key}}` stayed literal and
+    surfaced as a 12-character string hitting an api that wanted 64. The earlier
+    tests asserted `workflow_results` and passed throughout.
+
+    So: assert the exported variables, by name, for every step that declares any.
+    """
+
+    def test_account_create_exports_its_outputs(self):
+        client = MagicMock()
+        client.create_account.return_value = _envelope(
+            {
+                "accountId": "aa" * 32,
+                "deviceId": "bb" * 32,
+                "accountRootKey": "cc" * 32,
+                "accountNonce": "dd" * 16,
+            }
+        )
+        step = _step(
+            AccountCreateStep,
+            {
+                "type": "account_create",
+                "name": "Enrol",
+                "node": "calimero-node-2",
+                "namespace_id": NAMESPACE,
+                "outputs": {
+                    "account": "accountId",
+                    "root_key": "accountRootKey",
+                    "nonce": "accountNonce",
+                },
+            },
+            client,
+        )
+
+        dynamic_values = {}
+        assert _run(step.execute({}, dynamic_values)) is True
+        assert dynamic_values["account"] == "aa" * 32
+        assert dynamic_values["root_key"] == "cc" * 32
+        assert dynamic_values["nonce"] == "dd" * 16
+
+    def test_account_pair_exports_the_paired_device(self):
+        new_device = MagicMock()
+        init = {
+            "deviceId": "ee" * 32,
+            "kemPublicKey": "11" * 32,
+            "signPublicKey": "22" * 32,
+            "statement": "33" * 64,
+            "confirmationCode": "0011223344556677",
+        }
+        new_device.pair_device_init.return_value = _envelope(init)
+        holder = MagicMock()
+        holder.pair_device_complete.return_value = _envelope(
+            {
+                "accountId": "aa" * 32,
+                "keyDelivered": True,
+                "confirmationCode": init["confirmationCode"],
+            }
+        )
+        step = AccountPairStep(
+            {
+                "type": "account_pair",
+                "name": "Pair",
+                "node": "calimero-node-3",
+                "holder": "calimero-node-2",
+                "namespace_id": NAMESPACE,
+                "root_key": "cc" * 32,
+                "nonce": "dd" * 16,
+                "outputs": {"paired_device": "deviceId", "delivered": "keyDelivered"},
+            }
+        )
+        step._client = MagicMock(  # noqa: SLF001
+            side_effect=lambda name: (
+                new_device if name == "calimero-node-3" else holder
+            )
+        )
+
+        dynamic_values = {}
+        assert _run(step.execute({}, dynamic_values)) is True
+        assert dynamic_values["paired_device"] == "ee" * 32
+        assert dynamic_values["delivered"] is True
+
+    def test_account_revoke_exports_key_rotated(self):
+        client = MagicMock()
+        client.revoke_device.return_value = _envelope({"keyRotated": True})
+        step = _step(
+            AccountRevokeStep,
+            {
+                "type": "account_revoke",
+                "name": "Revoke",
+                "node": "calimero-node-1",
+                "namespace_id": NAMESPACE,
+                "device_id": "ee" * 32,
+                "outputs": {"rotated": "keyRotated"},
+            },
+            client,
+        )
+        dynamic_values = {}
+        assert _run(step.execute({}, dynamic_values)) is True
+        assert dynamic_values["rotated"] is True
+
+    def test_account_show_exports_the_account(self):
+        client = MagicMock()
+        client.get_namespace_account.return_value = _envelope(
+            {"accountId": "aa" * 32, "deviceId": None}
+        )
+        step = _step(
+            AccountShowStep,
+            {
+                "type": "account_show",
+                "name": "Show",
+                "node": "calimero-node-2",
+                "namespace_id": NAMESPACE,
+                "outputs": {"shown": "accountId"},
+            },
+            client,
+        )
+        dynamic_values = {}
+        assert _run(step.execute({}, dynamic_values)) is True
+        assert dynamic_values["shown"] == "aa" * 32

--- a/merobox/tests/unit/test_node_exec_step.py
+++ b/merobox/tests/unit/test_node_exec_step.py
@@ -232,3 +232,30 @@ class TestNodeExecExpectedFailure:
             manager.client.containers, "create", return_value=_stub_container()
         ):
             assert _run(step.execute({}, {})) is False
+
+
+def test_node_exec_exports_its_outputs(tmp_path):
+    """`outputs: { phrase: stdout_first_line }` must reach dynamic_values.
+
+    Same hole as the account steps had: recording the result is not exporting it,
+    and a scenario that captures a recovery phrase this way would otherwise carry
+    the literal `{{phrase}}` into the next command.
+    """
+    manager = _manager(tmp_path)
+    step = NodeExecStep(
+        {
+            "type": "node_exec",
+            "name": "Export",
+            "node": "calimero-node-2",
+            "args": ["account", "export"],
+            "outputs": {"phrase": "stdout_first_line", "code": "exit_code"},
+        },
+        manager=manager,
+    )
+    stub = _stub_container(stdout="word word word\nAccount root public key: X\n")
+    with patch.object(manager.client.containers, "create", return_value=stub):
+        dynamic_values = {}
+        assert _run(step.execute({}, dynamic_values)) is True
+
+    assert dynamic_values["phrase"] == "word word word"
+    assert dynamic_values["code"] == 0


### PR DESCRIPTION
## The bug

A step must call `_export_variables` for its `outputs:` to do anything. Writing the
result into `workflow_results` is a *different* thing, and nothing in the framework
enforces the second — so every `outputs:` on the steps added in 0.6.45 was inert.

The failure surfaces nowhere near the cause. A scenario capturing
`root_key: accountRootKey` gets no substitution at all, and the literal string
reaches an API several steps later:

```
Field 'accountRootKey' must be exactly 64 characters (got 12)
Field 'accountNonce' must be exactly 32 characters (got 9)
```

12 and 9 are the lengths of `{{root_key}}` and `{{nonce}}`.

Caught by calimero-network/core#3363, which switched core's e2e scenarios onto
these steps and immediately failed on both.

## Why the tests missed it

They asserted `workflow_results` — the recording — and passed throughout. That is
the same assertion the step already made true; it could never distinguish a step
that exports from one that does not.

Every step declaring outputs now has a test asserting the **exported variables by
name**, through `dynamic_values`, which is what a scenario actually reads:

- `account_create` → `accountId`, `accountRootKey`, `accountNonce`
- `account_pair` → `deviceId`, `keyDelivered`
- `account_revoke` → `keyRotated`
- `account_show` → `accountId`
- `node_exec` → `stdout_first_line`, `exit_code`

## Verification

51 failed / 1110 passed — failures unchanged from master's baseline of 51, and 5
new tests on top of the previous 1105. `make format-check` clean.

Version 0.6.46; core#3363 bumps `MIN_MEROBOX` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)