### PR TITLE
fix(bootstrap): resolve node_exec's data dir from what merobox recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.48] - 2026-08-03
+
+### Fixed
+
+- **`node_exec` resolved the data directory by convention and pointed at the
+  wrong one.** With the container removed by `stop_node` it rebuilt
+  `./data/<node>` from the CWD, which the manager's own comment already warns
+  against ("would break if the CWD changed, or if a custom data_dir was used") —
+  which is why it records `node_config_files` per node. `node_exec` now derives
+  the mount from that recorded absolute path (`<data_dir>/<node>/config.toml` →
+  its grandparent) and keeps the convention only as a last resort.
+
+  It also now checks for the node's **home** inside the resolved directory rather
+  than merely that the directory exists. An existing-but-wrong path passed the old
+  check and failed inside merod with `Node is not initialized in
+  "/app/data/<node>"`, naming a path the log never showed; the error now names the
+  directory it resolved and what it expected to find there.
+
 ## [0.6.47] - 2026-08-02
 
 ### Fixed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.47"
+__version__ = "0.6.48"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/node_exec.py
+++ b/merobox/commands/bootstrap/steps/node_exec.py
@@ -140,15 +140,30 @@ class NodeExecStep(BaseStep):
                 "`image:` on the step."
             )
 
-        source = (
-            source
-            or self.config.get("data_dir")
-            or os.path.abspath(os.path.join("data", node_name))
-        )
-        if not os.path.isdir(source):
+        if not source:
+            source = self.config.get("data_dir")
+        if not source:
+            # `<data_dir>/<node>/config.toml`, so the directory bound to
+            # /app/data is that path's grandparent. Exact, unlike rebuilding a
+            # relative path — the manager keeps this record precisely because
+            # reconstruction "would break if the CWD changed, or if a custom
+            # data_dir was used".
+            config_file = getattr(self.manager, "node_config_files", {}).get(node_name)
+            if config_file:
+                source = os.path.dirname(os.path.dirname(config_file))
+        if not source:
+            source = os.path.abspath(os.path.join("data", node_name))
+
+        # Check for the node's HOME, not just the directory: `--home /app/data
+        # --node <name>` reads `<source>/<name>/config.toml`, so an existing but
+        # wrong `source` passed an isdir() check and failed later inside merod
+        # with "Node is not initialized" — naming a path the log never showed.
+        node_home = os.path.join(source, node_name)
+        if not os.path.isdir(node_home):
             raise RuntimeError(
-                f"no data directory for {node_name} at '{source}'. Pass `data_dir:` "
-                "if the node's home is somewhere else."
+                f"'{source}' does not hold {node_name}'s home (expected "
+                f"'{node_home}'), so `--home {CONTAINER_HOME} --node {node_name}` "
+                "would find nothing. Pass `data_dir:` if it lives elsewhere."
             )
         return image, source
 

--- a/merobox/tests/unit/test_node_exec_step.py
+++ b/merobox/tests/unit/test_node_exec_step.py
@@ -25,7 +25,16 @@ def _run(coro):
         loop.close()
 
 
-def _manager(tmp_path, running=False, image="merod:local", mounted=True):
+def _manager(
+    tmp_path, running=False, image="merod:local", mounted=True, node="calimero-node-2"
+):
+    """A manager whose container mounts `tmp_path` at /app/data.
+
+    The node's home is created inside it, because that is what `--home /app/data
+    --node <name>` actually reads — a mount with no home in it is the shape that
+    used to pass validation and fail inside merod.
+    """
+    (tmp_path / node).mkdir(parents=True, exist_ok=True)
     manager = MagicMock()
     manager.is_node_running.return_value = running
 
@@ -284,7 +293,7 @@ class TestNodeExecAfterTheContainerIsGone:
     def test_falls_back_to_the_manager_record_and_the_data_convention(self, tmp_path):
         manager = self._gone(tmp_path, {"calimero-node-2": "merod:local"})
         data = tmp_path / "data" / "calimero-node-2"
-        data.mkdir(parents=True)
+        (data / "calimero-node-2").mkdir(parents=True)
         step = self._step(
             {
                 "type": "node_exec",
@@ -307,7 +316,7 @@ class TestNodeExecAfterTheContainerIsGone:
     def test_explicit_image_wins_when_merobox_has_no_record(self, tmp_path):
         manager = self._gone(tmp_path)
         data = tmp_path / "home"
-        data.mkdir()
+        (data / "calimero-node-2").mkdir(parents=True)
         step = self._step(
             {
                 "type": "node_exec",
@@ -329,7 +338,7 @@ class TestNodeExecAfterTheContainerIsGone:
         """The original failure printed 'node_exec failed: node_exec failed'."""
         manager = self._gone(tmp_path)
         data = tmp_path / "home"
-        data.mkdir()
+        (data / "calimero-node-2").mkdir(parents=True)
         step = self._step(
             {
                 "type": "node_exec",
@@ -355,3 +364,68 @@ class TestNodeExecAfterTheContainerIsGone:
             manager,
         )
         assert _run(step.execute({}, {})) is False
+
+
+class TestNodeExecUsesTheRecordedDataDir:
+    """The manager records each node's absolute config path; trust it over conventions.
+
+    Rebuilding `./data/<node>` assumes the CWD has not moved and no custom data
+    dir was used — the manager keeps `node_config_files` precisely because that
+    assumption breaks. Reconstructing it is what sent an export at a directory
+    that existed and held nothing, failing inside merod with "Node is not
+    initialized" and a path the log never printed.
+    """
+
+    def test_prefers_the_recorded_config_path_over_the_convention(self, tmp_path):
+        elsewhere = tmp_path / "somewhere-else" / "calimero-node-2"
+        (elsewhere / "calimero-node-2").mkdir(parents=True)
+
+        manager = MagicMock()
+        manager.is_node_running.return_value = False
+        manager.client.containers.get.side_effect = RuntimeError("No such container")
+        manager.node_images = {"calimero-node-2": "merod:local"}
+        manager.node_config_files = {
+            "calimero-node-2": str(elsewhere / "calimero-node-2" / "config.toml")
+        }
+
+        step = NodeExecStep(
+            {
+                "type": "node_exec",
+                "name": "Export",
+                "node": "calimero-node-2",
+                "args": ["account", "export"],
+            },
+            manager=manager,
+        )
+        with patch.object(
+            manager.client.containers, "create", return_value=_stub_container()
+        ) as create:
+            assert _run(step.execute({}, {})) is True
+
+        assert create.call_args.kwargs["volumes"] == {
+            str(elsewhere): {"bind": CONTAINER_HOME, "mode": "rw"}
+        }
+
+    def test_a_directory_without_the_node_home_is_rejected_up_front(self, tmp_path):
+        """Not merely `isdir(source)`: the home inside it is what merod reads."""
+        empty = tmp_path / "data" / "calimero-node-2"
+        empty.mkdir(parents=True)
+
+        manager = MagicMock()
+        manager.is_node_running.return_value = False
+        manager.client.containers.get.side_effect = RuntimeError("No such container")
+        manager.node_images = {"calimero-node-2": "merod:local"}
+        manager.node_config_files = {}
+
+        step = NodeExecStep(
+            {
+                "type": "node_exec",
+                "name": "Export",
+                "node": "calimero-node-2",
+                "args": ["account", "export"],
+                "data_dir": str(empty),
+            },
+            manager=manager,
+        )
+        assert _run(step.execute({}, {})) is False
+        manager.client.containers.create.assert_not_called()


### PR DESCRIPTION
## The failure

The export in calimero-network/core#3362 finally reached merod, and merod said:

```
stderr: Error: Node is not initialized in "/app/data/backup-node-2"
```

`node_exec` had rebuilt `./data/<node>` from the CWD. The manager's own comment
warns against precisely that:

```python
# Absolute path to each node's config.toml, recorded by run_node so the
# cluster-bootstrap wiring doesn't have to reconstruct it from a
# relative path (which would break if the CWD changed, or if a custom
# data_dir was used).
self.node_config_files: dict[str, str] = {}
```

So the authoritative record already existed and I reconstructed anyway. Resolution
now derives the mount from it — `<data_dir>/<node>/config.toml` → grandparent — and
keeps the convention only as a last resort.

## The validation was too weak to catch it

`isdir(source)` passed on a directory that existed and held nothing, so the failure
surfaced two layers later inside merod, naming a path the log never printed. It now
checks for the node's **home** (`<source>/<node>`) — what `--home /app/data --node
<name>` actually reads — and the error names both the directory it resolved and
what it expected to find there:

```
'<dir>' does not hold backup-node-2's home (expected '<dir>/backup-node-2'),
so `--home /app/data --node backup-node-2` would find nothing.
```

## The tests had the same blind spot

Every container-mount double pointed at a directory with **no node home inside**,
which is exactly the shape that used to validate and then fail in merod. The
fixture creates the home now, and two tests were added:

- prefers the recorded config path over the convention (mount lands on the
  recorded directory even when a plausible `./data/<node>` exists)
- rejects a directory without a node home up front, before creating a container

51 failed / 1116 passed — failures unchanged from master's baseline of 51.
`make format-check` clean. Version 0.6.48.

## Note

This is the third fix to `node_exec` in a day: it couldn't run after a stop
(#311), it hid its errors (#311), and it looked in the wrong place (here). Each
was found only by running the recovery scenario in core#3362 — none by the unit
tests, whose doubles agreed with my assumptions. The added checks now fail at the
step with a named path rather than inside merod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)