### PR TITLE
fix(bootstrap): invoke merod as merobox does, and log what node_exec resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.49] - 2026-08-03
+
+### Fixed
+
+- **`node_exec` now invokes `merod` the way merobox itself does** — entrypoint
+  cleared, `merod` passed as argv[0] — instead of relying on the image's
+  `ENTRYPOINT`. `run_node` has always done it this way; depending on every image
+  agreeing is a needless assumption, and one that fails silently (an entrypoint
+  that wraps or ignores its arguments produces a merod that never sees `--home`,
+  which looks exactly like an uninitialised node).
+
+### Changed
+
+- **`node_exec` logs the image and mount it resolved.** Three consecutive bugs in
+  this step were diagnosed by reading merobox's source rather than the CI log,
+  because the step never reported the two values that decide whether it can work.
+  It prints them now.
+
 ## [0.6.48] - 2026-08-03
 
 ### Fixed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.48"
+__version__ = "0.6.49"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/node_exec.py
+++ b/merobox/commands/bootstrap/steps/node_exec.py
@@ -217,11 +217,22 @@ class NodeExecStep(BaseStep):
                 with open(host_path, "w", encoding="utf-8") as handle:
                     handle.write(content if content.endswith("\n") else content + "\n")
 
-            command = ["--home", CONTAINER_HOME, "--node", node_name, *args]
-            console.print(f"[cyan]node_exec[/cyan] {node_name}: merod {' '.join(args)}")
+            # `merod` explicitly with the entrypoint cleared, which is how merobox
+            # starts node containers itself (`run_node` sets `entrypoint = ""` and
+            # passes "merod" as argv[0]). Relying on the image's ENTRYPOINT works
+            # for the images that have one and silently does the wrong thing for
+            # any that wrap it — matching the pattern that already works here is
+            # cheaper than depending on every image agreeing with us.
+            command = ["merod", "--home", CONTAINER_HOME, "--node", node_name, *args]
+            console.print(
+                f"[cyan]node_exec[/cyan] {node_name}: merod {' '.join(args)}\n"
+                f"  image: {image}\n"
+                f"  mount: {host_home} -> {CONTAINER_HOME}"
+            )
 
             container = self.manager.client.containers.create(
                 image=image,
+                entrypoint="",
                 command=command,
                 volumes={host_home: {"bind": CONTAINER_HOME, "mode": "rw"}},
                 environment={"CALIMERO_HOME": CONTAINER_HOME},

--- a/merobox/tests/unit/test_node_exec_step.py
+++ b/merobox/tests/unit/test_node_exec_step.py
@@ -122,7 +122,11 @@ class TestNodeExecExecution:
 
         kwargs = create.call_args.kwargs
         assert kwargs["image"] == "merod:local"
+        # `merod` as argv[0] with the entrypoint cleared — the same shape
+        # `run_node` uses, rather than trusting every image's ENTRYPOINT.
+        assert kwargs["entrypoint"] == ""
         assert kwargs["command"] == [
+            "merod",
             "--home",
             CONTAINER_HOME,
             "--node",


### PR DESCRIPTION
## Where this stands

calimero-network/core#3362 still fails on 0.6.48 with:

```
stderr: Error: Node is not initialized in "/app/data/backup-node-2"
```

and the data directory is provably correct. A diagnostic step in that PR shows the
host layout:

```
data/backup-node-2/backup-node-2/config.toml     ← exists
drwx------ runner runner  data/backup-node-2
-rw------- runner runner  .../config.toml
-rw------- root   root    .../auth.kek           ← node container runs as root
```

That is exactly the directory `node_exec` resolves and mounts, and root can read
those 0700 paths. So the mount source is right.

## Two changes, one of them a hypothesis

**Hypothesis (not confirmed):** the step relied on the image's `ENTRYPOINT` being
`merod` and passed only arguments. merobox's own `run_node` never does that — it
clears the entrypoint and passes `"merod"` as argv[0]:

```python
init_config["entrypoint"] = ""
init_config["command"] = ["merod", "--home", "/app/data", "--node", node_name, ...]
```

An entrypoint that wraps, reorders or drops its arguments yields a merod that never
sees `--home`, which presents as an uninitialised node — precisely the symptom.
Matching the pattern that demonstrably works in this repo costs nothing and removes
the assumption. I cannot verify it locally: there is no Docker daemon in my
environment, so the mount mechanics are untestable here.

**Certain:** the step now logs the image and mount it resolved.

```
node_exec backup-node-2: merod account export
  image: merod:local
  mount: /home/.../data/backup-node-2 -> /app/data
```

Three consecutive bugs in this step — it could not run after a stop, it hid its
errors, it looked in the wrong place — were each diagnosed by reading merobox's
source rather than the CI log, because the two values that decide whether it can
work were never printed. If the hypothesis above is wrong, the next run says so in
one line instead of costing another round of inference.

51 failed / 1116 passed — unchanged from master's baseline of 51.
`make format-check` clean. Version 0.6.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)