### PR TITLE
fix(bootstrap): run node_exec's container as root, like node containers do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.50] - 2026-08-03
+
+### Fixed
+
+- **`node_exec` ran as the image's user and could not read the node's data.** The
+  merod images set `USER user`; the bind-mounted data directory is owned by the
+  host user that created it, and merobox chmods the node's home to `0700`. A
+  non-root container user cannot traverse that, so merod found no config and
+  reported the node as uninitialised — the very directory the running node reads
+  without trouble, because `run_node` overrides the user to `root` for exactly this
+  reason. `node_exec` now does the same.
+
 ## [0.6.49] - 2026-08-03
 
 ### Fixed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.49"
+__version__ = "0.6.50"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/node_exec.py
+++ b/merobox/commands/bootstrap/steps/node_exec.py
@@ -232,6 +232,14 @@ class NodeExecStep(BaseStep):
 
             container = self.manager.client.containers.create(
                 image=image,
+                # `root`, for the same reason `run_node` overrides it on node
+                # containers: the merod images set `USER user`, while the bind
+                # mount is owned by the host user that created it and merobox
+                # chmods the node's home to 0700. A non-root container user cannot
+                # traverse that, so merod finds no config and reports the node as
+                # uninitialised — the same directory the running node reads fine,
+                # because that one is root.
+                user="root",
                 entrypoint="",
                 command=command,
                 volumes={host_home: {"bind": CONTAINER_HOME, "mode": "rw"}},

--- a/merobox/tests/unit/test_node_exec_step.py
+++ b/merobox/tests/unit/test_node_exec_step.py
@@ -125,6 +125,9 @@ class TestNodeExecExecution:
         # `merod` as argv[0] with the entrypoint cleared — the same shape
         # `run_node` uses, rather than trusting every image's ENTRYPOINT.
         assert kwargs["entrypoint"] == ""
+        # root, or the image's `USER user` cannot traverse the 0700 host-owned
+        # data directory and merod reports the node as uninitialised.
+        assert kwargs["user"] == "root"
         assert kwargs["command"] == [
             "merod",
             "--home",


### PR DESCRIPTION
## The cause, with evidence

calimero-network/core#3362's `Node is not initialized in "/app/data/backup-node-2"`.

merod's images set a non-root user:

```dockerfile
# .github/workflows/deps/prebuilt.Dockerfile
USER user
```

merobox's own `run_node` overrides it:

```python
"user": "root",  # Override the default user in the image
```

`node_exec` did not. Its one-shot container therefore ran as `user`, which cannot
traverse a bind mount owned by the host user that created it — and merobox chmods
the node's home to `0700`. merod finds no config and reports the node as
uninitialised. **Same image, same mount, different uid**, which is exactly why the
running node reads that directory without trouble and the one-shot container sees
nothing.

Every observation fits:

- the diagnostic in #3362 showed `drwx------ runner runner` on the data dir, with
  `root`-owned files inside written by the root node container;
- 0.6.49's new logging showed the mount resolving to precisely that path;
- the error came from merod itself, i.e. after argv parsing, so the command was fine.

## On the two previous attempts

I got this failure wrong twice — the data directory (0.6.48) and the entrypoint
(0.6.49) — and both were guesses dressed as fixes. Each was a real improvement on
its own terms (the recorded path *is* better than a reconstructed one; matching
`run_node`'s invocation *is* more robust), but neither was the cause, and I said as
much about the second at the time.

This one is read straight off merobox's own line and its comment, and it is the
only difference left between a container that can read that directory and one that
cannot.

51 failed / 1116 passed — unchanged from master's baseline of 51.
`make format-check` clean. Version 0.6.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)