### PR TITLE
feat(bootstrap): account_revoke accepts a proof signed elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.51] - 2026-08-04
+
+### Added
+
+- **`account_revoke` accepts a `proof:`.** A revocation signed wherever the account
+  root lives (core's `merod account revoke-proof`) can now be published by any
+  member node, which is the lost-device case: the machine that held the device is
+  gone, so the node that would have minted the proof is gone with it. The node
+  running the step needs no authority of its own — it only publishes. Omitting the
+  field keeps the previous behaviour, where the node must be an admin or hold the
+  account itself.
+
+  A blank `proof:` is refused rather than forwarded. Sent as-is it reads to the node
+  as "no proof", so the step would quietly revoke on the node's own authority
+  instead — succeeding for a reason the scenario author did not intend.
+
+  Requires `calimero-client-py >= 0.6.21`, where `revoke_device` grew the argument.
+  Below that the call is a `TypeError` at run time rather than an install-time
+  resolution failure, so the floor is raised in `pyproject.toml`. (`setup.py`'s copy
+  of the pin was stale at `>=0.6.11` and has been brought in line.)
+
 ## [0.6.50] - 2026-08-03
 
 ### Fixed

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.50"
+__version__ = "0.6.51"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -954,6 +954,12 @@ class AccountRevokeStepConfig(BaseStepConfig):
     )
     namespace_id: str = Field(..., description="Namespace the device is bound in")
     device_id: str = Field(..., description="Device to withdraw")
+    proof: Optional[str] = Field(
+        None,
+        description="Hex revocation proof signed elsewhere (`merod account "
+        "revoke-proof`). With it the node needs no authority of its own and only "
+        "publishes; without it the node must be an admin or hold the account",
+    )
 
 
 class AccountShowStepConfig(BaseStepConfig):

--- a/merobox/commands/bootstrap/steps/account.py
+++ b/merobox/commands/bootstrap/steps/account.py
@@ -256,9 +256,18 @@ class AccountPairStep(_AccountStepBase):
 class AccountRevokeStep(_AccountStepBase):
     """Withdraw a device from an account, rotating the scope key.
 
-    Run on a node with the authority to do it (an admin, or the account itself).
+    Run on a node with the authority to do it — an admin, or the account itself.
     Exports `keyRotated` so a scenario can assert the rotation happened rather
     than inferring it from a later read.
+
+    `proof:` supplies a revocation signed **elsewhere** (`merod account
+    revoke-proof`), which is the lost-device case: the account root never reaches a
+    node, and the node running this step needs no authority of its own — it only
+    publishes. Without it, the node must be an admin or hold the account itself.
+
+    Only an admin can rotate the scope key, so a proof-published revocation stops
+    the device writing immediately and leaves it able to read until an admin
+    rotates. `keyRotated` reports which happened rather than hiding the difference.
     """
 
     def _get_required_fields(self) -> list[str]:
@@ -266,6 +275,21 @@ class AccountRevokeStep(_AccountStepBase):
 
     def _validate_field_types(self) -> None:
         self._require_strings(("node", "namespace_id", "device_id"))
+        # Optional, so absence is fine — but a present non-string is a scenario
+        # bug, and an empty string is one too: it would reach the node as "no
+        # proof" while the author clearly meant to pass one.
+        proof = self.config.get("proof")
+        if proof is not None:
+            step_name = self.config.get(
+                "name", f'Unnamed {self.config.get("type", "Unknown")} step'
+            )
+            if not isinstance(proof, str):
+                raise ValueError(f"Step '{step_name}': 'proof' must be a string")
+            if not proof.strip():
+                raise ValueError(
+                    f"Step '{step_name}': 'proof' is empty — omit the field entirely "
+                    "if this node revokes on its own authority"
+                )
 
     def _get_exportable_variables(self):
         return [
@@ -282,10 +306,19 @@ class AccountRevokeStep(_AccountStepBase):
         node_name = self._resolved("node", dynamic_values)
         namespace_id = self._resolved("namespace_id", dynamic_values)
         device_id = self._resolved("device_id", dynamic_values)
+        # Resolved through the same path as every other field, so `{{proof}}` from
+        # a `node_exec` capture works without the scenario copying the hex inline.
+        proof = (
+            self._resolved("proof", dynamic_values)
+            if self.config.get("proof") is not None
+            else None
+        )
 
         try:
             client = self._client(node_name)
-            result = ok(self._data(client.revoke_device(namespace_id, device_id)))
+            result = ok(
+                self._data(client.revoke_device(namespace_id, device_id, proof))
+            )
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
             result = fail("account revoke failed", error=e)
 
@@ -299,7 +332,8 @@ class AccountRevokeStep(_AccountStepBase):
         data = result["data"]
         console.print(
             f"[green]✓[/green] {node_name} revoked device {device_id} "
-            f"(key rotated: {data.get('keyRotated')})"
+            f"(key rotated: {data.get('keyRotated')}"
+            f"{', via supplied proof' if proof else ''})"
         )
         return self._finish(node_name, "revoke", data, workflow_results, dynamic_values)
 

--- a/merobox/tests/unit/test_account_steps.py
+++ b/merobox/tests/unit/test_account_steps.py
@@ -271,7 +271,7 @@ class TestAccountRevokeStep:
         results = {}
         assert _run(step.execute(results, {})) is True
 
-        client.revoke_device.assert_called_once_with(NAMESPACE, "ee" * 32)
+        client.revoke_device.assert_called_once_with(NAMESPACE, "ee" * 32, None)
         # Exported so a scenario asserts the rotation happened rather than
         # inferring it from a later read that could pass for other reasons.
         assert results["revoke_calimero-node-1"]["keyRotated"] is True
@@ -284,7 +284,59 @@ class TestAccountRevokeStep:
             AccountRevokeStep, {**self.config, "device_id": "{{paired_device}}"}, client
         )
         assert _run(step.execute({}, {"paired_device": "ee" * 32})) is True
-        client.revoke_device.assert_called_once_with(NAMESPACE, "ee" * 32)
+        client.revoke_device.assert_called_once_with(NAMESPACE, "ee" * 32, None)
+
+    def test_passes_a_supplied_proof_through(self):
+        """The lost-device path: the node publishes a proof it did not mint.
+
+        Signed wherever the account root lives (`merod account revoke-proof`), so
+        the node running this step needs no authority of its own.
+        """
+        client = MagicMock()
+        client.revoke_device.return_value = _envelope({"keyRotated": False})
+        step = _step(AccountRevokeStep, {**self.config, "proof": "ab" * 40}, client)
+
+        assert _run(step.execute({}, {})) is True
+        client.revoke_device.assert_called_once_with(NAMESPACE, "ee" * 32, "ab" * 40)
+
+    def test_resolves_a_placeholder_proof(self):
+        """The proof normally arrives from a `node_exec` capture, not inline."""
+        client = MagicMock()
+        client.revoke_device.return_value = _envelope({"keyRotated": False})
+        step = _step(
+            AccountRevokeStep, {**self.config, "proof": "{{proof_hex}}"}, client
+        )
+
+        assert _run(step.execute({}, {"proof_hex": "cd" * 40})) is True
+        client.revoke_device.assert_called_once_with(NAMESPACE, "ee" * 32, "cd" * 40)
+
+    def test_omitting_the_proof_sends_none_rather_than_an_empty_string(self):
+        """`None` means "revoke on this node's own authority"; "" would be a lie.
+
+        An empty string reaches the node as a present-but-unusable proof, so the
+        distinction has to survive all the way to the client call.
+        """
+        client = MagicMock()
+        client.revoke_device.return_value = _envelope({"keyRotated": True})
+        step = _step(AccountRevokeStep, self.config, client)
+
+        assert _run(step.execute({}, {})) is True
+        assert client.revoke_device.call_args.args[2] is None
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    def test_an_empty_proof_is_refused_rather_than_silently_ignored(self, bad):
+        """Passing a blank proof is always a scenario bug.
+
+        Forwarded as-is it would read to the node as "no proof" and the step would
+        revoke on the node's own authority instead — succeeding for a reason the
+        author did not intend, which is worse than failing.
+        """
+        with pytest.raises(ValueError, match="proof"):
+            AccountRevokeStep({**self.config, "proof": bad})
+
+    def test_a_non_string_proof_is_refused(self):
+        with pytest.raises(ValueError, match="proof"):
+            AccountRevokeStep({**self.config, "proof": 1234})
 
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,10 @@ dependencies = [
     "docker>=6.0.0",
     "rich>=13.0.0,<14.3.4",
     "PyYAML>=6.0.0",
-    "calimero-client-py>=0.6.20",
+    # 0.6.21 is where `revoke_device` grew its `proof` argument. Below it the
+    # account_revoke step's three-argument call is a TypeError at run time, not a
+    # resolution failure at install time, so the floor has to say so.
+    "calimero-client-py>=0.6.21",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "docker>=6.0.0",
         "rich>=13.0.0",
         "PyYAML>=6.0.0",
-        "calimero-client-py>=0.6.11",
+        "calimero-client-py>=0.6.21",
         "aiohttp>=3.8.0",
         "toml>=0.10.2",
         "base58>=2.1.0",


### PR DESCRIPTION
Consumes calimero-client-py 0.6.21 (calimero-network/calimero-client-py#74), which follows core#3367.

## Why

core#3367 made device revocation exercisable from the account root alone: the root signs a proof wherever it lives, and **any** member node publishes it, needing no authority of its own. That is the lost-device case — the machine that held the device is gone, so the node that would have minted the proof is gone with it.

`account_revoke` could not express it, so no scenario could drive that path at all. That matters because the e2e for core#3354 is the only thing that proves the flow end to end: wipe the device's node, revoke from the root elsewhere, assert the tombstone stuck.

## What changed

```yaml
- name: Revoke the lost laptop using only the account root
  type: account_revoke
  node: node-3                      # needs no authority of its own
  namespace_id: '{{namespace_id}}'
  device_id: '{{lost_device}}'
  proof: '{{proof_hex}}'            # from a node_exec `merod account revoke-proof`
```

Omitting `proof:` keeps the previous behaviour exactly: the node must be an admin or hold the account itself.

Resolved through `_resolved`, so a `{{placeholder}}` captured from a `node_exec` step works without pasting hex into the scenario — which is how it will actually be used.

## A blank proof is refused, not forwarded

Sent as-is, an empty string reaches the node as "no proof", so the step would quietly revoke on the node's **own authority** instead — succeeding for a reason the scenario author did not intend. That is worse than failing, because the scenario would then claim to test the offline path while testing the admin path. Same reasoning as the empty-string rejection on the core side.

## Tests

38/38 in `test_account_steps.py`. Five new cases: proof forwarded, placeholder resolved, `None` rather than `""` when omitted, and refused when blank (parametrized over `""` and whitespace) or non-string.

**Two existing tests had to change.** They asserted `revoke_device(namespace, device)` and the call is now three-argument. Flagging it because that is exactly the sort of signature change that reads fine in review and fails CI.

## The dependency floor

`calimero-client-py>=0.6.21` in `pyproject.toml`. Below that, the three-argument call is a `TypeError` **at run time** rather than a resolution failure at install time — so the floor has to say so or the failure surfaces mid-scenario as something unrelated.

`setup.py` carried its own copy of the pin, stale at `>=0.6.11`; brought in line. Worth someone deciding whether that file is still authoritative, since two pins will drift again.

## Verification notes

- `make format-check` clean (black, then ruff — black is the formatter here; ruff format disagrees and fails CI).
- The 17 failures in `test_abort_migration_step.py` / `test_migrations_v2_steps.py` are **pre-existing on master** — verified by stashing this branch and re-running, identical 17. Untouched by this change.

## Next

core gets the #3354 scenario, plus a `MIN_MEROBOX` bump to 0.6.51.
