### PR TITLE
feat(bootstrap): json_not_equal, and fix the argument splitter it exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.52] - 2026-08-04
+
+### Added
+
+- **`json_not_equal(A, B)` / `not_equal(A, B)` in `json_assert` statements.** Some
+  properties are only expressible as a difference, and there was no way to say so:
+  a revocation is terminal, so a device re-enrolling after being revoked must get a
+  NEW id — and the new id is unpredictable, so there is no literal to compare it
+  against. Scenarios were shelling out to a script or asserting equality against a
+  stand-in, which tests the stand-in.
+
+### Fixed
+
+- **`json_assert` mis-parsed a statement whose LEFT operand contained a comma.**
+  The argument splitter took the first comma, which is the operand separator only
+  when the left side has none of its own — true for the usual
+  placeholder-against-literal shape, and false the moment the left side is a
+  multi-key object or an array. `json_equal({"a": 1, "b": 2}, {"a": 1, "b": 2})`
+  split into `{"a": 1` and `"b": 2}, {"a": 1, "b": 2}` and failed on unparseable
+  halves rather than on the values. Now splits at the first comma at bracket depth
+  zero and outside a string, so a comma inside `"a,b"` is not a separator either.
+  Verified against the existing right-hand-literal shapes: no behaviour change.
+
 ## [0.6.51] - 2026-08-04
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.51"
+__version__ = "0.6.52"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/steps/json_assertion.py
+++ b/merobox/commands/bootstrap/steps/json_assertion.py
@@ -49,6 +49,11 @@ class JsonAssertStep(BaseStep):
       left: "{{some_json}}"
       right: {"nested": {"key": "value"}}
       mode: subset
+
+    The `statements:` form additionally supports inequality, which `mode:` does
+    not: `json_not_equal(A, B)`. Use it for properties only expressible as a
+    difference — a re-enrolled device must not reuse a revoked id, and the new id
+    is unpredictable, so there is no literal to compare against.
     """
 
     def _get_required_fields(self) -> list[str]:
@@ -134,8 +139,20 @@ class JsonAssertStep(BaseStep):
 
         Supported forms:
         - json_equal(A, B) / equal(A, B)
+        - json_not_equal(A, B) / not_equal(A, B)
         - json_subset(A, B) / subset(A, B)
         Arguments can be placeholders or JSON strings.
+
+        `json_not_equal` exists because some properties are only expressible as a
+        difference. A revocation is terminal, so a re-enrolled device must get a
+        NEW id — and the new value is unpredictable, so there is no literal to
+        compare it against. Without this, scenarios either shelled out to a script
+        or asserted equality against a stand-in, which tests the stand-in.
+
+        Order in the table below does not affect matching — `_call_like` is a
+        `startswith` test anchored at position 0, so `equal(` cannot match
+        `json_not_equal(...)` or `not_equal(...)`. The negatives are listed first
+        only so the pairs read together.
         """
         expr = statement.strip()
 
@@ -143,9 +160,43 @@ class JsonAssertStep(BaseStep):
             return expr.lower().startswith(name + "(") and expr.endswith(")")
 
         def _args(body: str) -> list[str]:
-            return [p.strip() for p in body.split(",", 1)] if "," in body else [body]
+            """Split on the comma separating the two operands, not the first one.
+
+            `body.split(",", 1)` happens to work whenever the LEFT operand has no
+            comma of its own — which is the common shape, a captured placeholder
+            against a JSON literal. It silently mis-parses the moment the left side
+            is itself a multi-key object or an array: `{"a": 1, "b": 2}, {"a": 1}`
+            splits into `{"a": 1` and `"b": 2}, {"a": 1}`, neither of which is JSON,
+            and the assertion then fails for a reason that has nothing to do with
+            the values.
+
+            So: split at the first comma that is at depth zero and outside a string.
+            """
+            depth = 0
+            in_string = False
+            escaped = False
+            for index, char in enumerate(body):
+                if escaped:
+                    escaped = False
+                    continue
+                if char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = not in_string
+                elif in_string:
+                    continue
+                elif char in "{[":
+                    depth += 1
+                elif char in "}]":
+                    depth -= 1
+                elif char == "," and depth == 0:
+                    return [body[:index].strip(), body[index + 1 :].strip()]
+            return [body.strip()]
 
         for func, desc, mode in (
+            # Grouped with their positive counterparts; order is not significant.
+            ("json_not_equal", "JSON inequality", "not_equal"),
+            ("not_equal", "JSON inequality", "not_equal"),
             ("json_equal", "JSON equality", "equal"),
             ("equal", "JSON equality", "equal"),
             ("json_subset", "JSON subset", "subset"),
@@ -173,11 +224,12 @@ class JsonAssertStep(BaseStep):
                 )
                 left_norm = _normalize_json(left_val)
                 right_norm = _normalize_json(right_val)
-                passed = (
-                    (left_norm == right_norm)
-                    if mode == "equal"
-                    else self._is_subset(left_norm, right_norm)
-                )
+                if mode == "equal":
+                    passed = left_norm == right_norm
+                elif mode == "not_equal":
+                    passed = left_norm != right_norm
+                else:
+                    passed = self._is_subset(left_norm, right_norm)
                 return passed, desc, left_val, right_val
 
         # Fallback: try simple equality if pattern not matched

--- a/merobox/tests/unit/test_json_assertion_statements.py
+++ b/merobox/tests/unit/test_json_assertion_statements.py
@@ -1,0 +1,131 @@
+"""The `statements:` forms of `json_assert`, and inequality in particular.
+
+`json_not_equal` exists because some properties are only expressible as a
+difference. The case that prompted it: a revocation is terminal, so a device that
+re-enrols after being revoked must receive a NEW id — and the new id is
+unpredictable, so there is no literal to compare it against. Before this, a
+scenario had to shell out to a script or assert equality against a stand-in, which
+tests the stand-in rather than the property.
+
+The other reason to pin these here: an unrecognised function name does **not**
+raise. `_eval_statement` falls through to `return False, "Unrecognized JSON
+assertion", None, None`, so a typo or a function that does not exist reads as a
+FAILING assertion rather than a broken scenario. That is the safe direction, but it
+means a scenario can be quietly asserting nothing meaningful, so the recognised
+surface is worth locking down.
+"""
+
+import asyncio
+
+from merobox.commands.bootstrap.steps.json_assertion import JsonAssertStep
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _step(statements: list[str]) -> JsonAssertStep:
+    return JsonAssertStep(
+        {
+            "type": "json_assert",
+            "name": "Assert",
+            "statements": statements,
+        }
+    )
+
+
+def _eval(statement: str, dynamic: dict | None = None) -> bool:
+    step = _step([statement])
+    passed, _desc, _left, _right = step._eval_statement(statement, {}, dynamic or {})
+    return passed
+
+
+class TestJsonNotEqual:
+    def test_differing_values_pass(self):
+        assert _eval('json_not_equal("aa", "bb")') is True
+
+    def test_equal_values_fail(self):
+        assert _eval('json_not_equal("aa", "aa")') is False
+
+    def test_bare_alias_works(self):
+        assert _eval('not_equal("aa", "bb")') is True
+        assert _eval('not_equal("aa", "aa")') is False
+
+    def test_resolves_placeholders_on_both_sides(self):
+        """The real shape: two captured outputs, neither known in advance."""
+        dynamic = {"old_device": "ee" * 32, "new_device": "ff" * 32}
+        assert _eval("json_not_equal({{new_device}}, {{old_device}})", dynamic) is True
+
+    def test_a_device_that_was_not_re_minted_is_caught(self):
+        """The regression this primitive exists to catch.
+
+        If a revoked device id were handed back on re-enrolment, both placeholders
+        resolve to the same value and the assertion must fail.
+        """
+        dynamic = {"old_device": "ee" * 32, "new_device": "ee" * 32}
+        assert _eval("json_not_equal({{new_device}}, {{old_device}})", dynamic) is False
+
+    def test_normalises_before_comparing_so_json_shape_wins_over_spelling(self):
+        """`{"a": 1}` and `{ "a": 1 }` are the same JSON and must not differ."""
+        assert _eval('json_not_equal({"a": 1}, { "a": 1 })') is False
+
+
+class TestRecognisedSurface:
+    def test_equality_still_works(self):
+        assert _eval('json_equal("aa", "aa")') is True
+        assert _eval('json_equal("aa", "bb")') is False
+
+    def test_subset_still_works(self):
+        assert _eval('json_subset({"a": 1, "b": 2}, {"a": 1})') is True
+        assert _eval('json_subset({"a": 1}, {"a": 1, "b": 2})') is False
+
+    def test_negative_form_is_not_swallowed_by_the_positive_one(self):
+        """`_call_like` anchors with `startswith`, so `equal(` cannot match here.
+
+        Pinned because it is the plausible way to break this: if matching ever
+        became a substring scan, `json_not_equal(a, b)` would be handled by the
+        `equal` arm and quietly invert every assertion using it.
+        """
+        assert _eval('json_not_equal("aa", "bb")') is True
+
+    def test_a_multi_key_literal_on_the_left_is_split_correctly(self):
+        """Regression for the argument splitter.
+
+        It used to split on the FIRST comma, which is the operand separator only
+        when the left side has no comma of its own — true for the common
+        placeholder-vs-literal shape, and false the moment the left side is a
+        multi-key object. `{"a": 1, "b": 2}, {"a": 1}` became `{"a": 1` and
+        `"b": 2}, {"a": 1}`, so the assertion failed on unparseable halves rather
+        than on the values.
+        """
+        assert _eval('json_equal({"a": 1, "b": 2}, {"a": 1, "b": 2})') is True
+        assert _eval('json_equal({"a": 1, "b": 2}, {"a": 1, "b": 3})') is False
+        assert _eval('json_not_equal({"a": 1, "b": 2}, {"a": 1, "b": 3})') is True
+
+    def test_a_comma_inside_a_json_string_is_not_a_separator(self):
+        """Depth tracking is not enough on its own — strings need it too."""
+        assert _eval('json_equal({"k": "a,b"}, {"k": "a,b"}) ') is True
+        assert _eval('json_not_equal({"k": "a,b"}, {"k": "a;b"})') is True
+
+    def test_arrays_on_the_left_survive_too(self):
+        assert _eval("json_equal([1, 2, 3], [1, 2, 3])") is True
+        assert _eval("json_not_equal([1, 2, 3], [1, 2])") is True
+
+    def test_an_unknown_function_fails_rather_than_raising(self):
+        """Documents the fallback, which is easy to mistake for a real failure."""
+        step = _step(['json_greater_than("2", "1")'])
+        passed, desc, _l, _r = step._eval_statement(
+            'json_greater_than("2", "1")', {}, {}
+        )
+        assert passed is False
+        assert "Unrecognized" in desc
+
+
+class TestExecution:
+    def test_all_statements_must_pass(self):
+        step = _step(['json_not_equal("aa", "bb")', 'json_equal("cc", "cc")'])
+        assert _run(step.execute({}, {})) is True
+
+    def test_one_failing_statement_fails_the_step(self):
+        step = _step(['json_not_equal("aa", "bb")', 'json_not_equal("cc", "cc")'])
+        assert _run(step.execute({}, {})) is False


### PR DESCRIPTION
Needed by the core e2e for calimero-network/core#3354, which asserts a property that can only be stated as a difference.

## `json_not_equal`

`json_assert` statements supported `json_equal` and `json_subset` only. Some properties are inherently negative: a revocation is **terminal**, so a device that re-enrols after being revoked must receive a **new** id — and the new id is unpredictable, so there is no literal to compare it against.

The available workarounds were a `script` step, or asserting equality against a stand-in, which tests the stand-in rather than the property. This is the second time the gap has come up (core#3362 worked around it by asserting equality against a literal to prove a root had *changed*).

```yaml
- name: The replacement device is not the revoked one
  type: json_assert
  statements:
    - 'json_not_equal({{replacement_device}}, {{lost_device}})'
```

`not_equal` is accepted as the bare alias, matching the existing `equal` / `subset` pairs.

## The bug it exposed

Writing the test surfaced a pre-existing defect. `_args` split on the **first** comma, which is the operand separator only when the left operand contains no comma of its own:

```
json_equal({"a": 1, "b": 2}, {"a": 1, "b": 2})
  ->  left  = '{"a": 1'
      right = '"b": 2}, {"a": 1, "b": 2}'
```

Both halves unparseable, so the assertion failed on its own parsing rather than on the values — and reported a value mismatch while doing it.

**Existing scenarios are unaffected**, which is why this went unnoticed: the usual shape is a captured placeholder against a JSON literal (`json_equal({{result}}, {"output": "x"})`), where the first comma genuinely *is* the separator. Around a hundred assertions across core's suite are that shape.

Now split at the first comma at bracket depth zero and outside a string, so a comma inside `"a,b"` is not a separator either.

I verified no behaviour change rather than assuming it, by replaying the real shapes from core's scenarios: right-hand literals with internal commas, placeholder-vs-placeholder, `json_equal({{k}}, false)`. Zero differences.

## Tests

15 new in `test_json_assertion_statements.py`, plus the existing 38 account-step tests still pass (53 together). Coverage includes:

- inequality passing/failing, both spellings, placeholders on both sides
- the regression the primitive exists to catch: if a revoked id *were* handed back, both placeholders resolve equal and the assertion must fail
- the splitter regressions: multi-key object on the left, array on the left, comma inside a JSON string
- that an unrecognised function name **fails rather than raises** — worth pinning, because it means a typo reads as a failing assertion rather than a broken scenario, and a scenario can be quietly asserting nothing

## One correction

My first draft of the docstring claimed the negative forms had to be matched before the positive ones. They don't — `_call_like` is `startswith`, anchored at position 0, so `equal(` cannot match `json_not_equal(...)`. Corrected, but pinned by a test anyway, since a move to substring matching would silently invert every inequality assertion.

## Verification

`make format-check` clean (black then ruff). The 17 failures in `test_abort_migration_step.py` / `test_migrations_v2_steps.py` are pre-existing on master — verified by stashing — and untouched here.

Releases 0.6.52.
