### PR TITLE
refactor(steps): drop the upgrade-policy surface

### DIFF
--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -311,7 +311,7 @@ merobox namespace join <namespace_id> '<invitation_json>' --node calimero-node-2
 | ------------ | --------------------------------- | ----------------------------------------------- | ----------------------------------------- |
 | `list`       | —                                 | `--node`, `--verbose`                           | List namespaces on the node.              |
 | `identity`   | `NAMESPACE_ID`                    | `--node`, `--verbose`                           | Get the node's identity for a namespace.  |
-| `create`     | `APPLICATION_ID`                  | `--node`, `--alias`, `--upgrade-policy`, `--verbose` | Create a namespace for an application. |
+| `create`     | `APPLICATION_ID`                  | `--node`, `--alias`, `--verbose`                | Create a namespace for an application.    |
 | `invite`     | `NAMESPACE_ID`                    | `--node`, `--recursive`, `--verbose`            | Create a namespace invitation.            |
 | `join`       | `NAMESPACE_ID` `INVITATION_JSON`  | `--node`, `--verbose`                           | Join a namespace using an invitation.     |
 | `groups`     | `NAMESPACE_ID`                    | `--node`, `--verbose`                           | List groups in a namespace.               |

--- a/docs/src/content/docs/workflows/examples.mdx
+++ b/docs/src/content/docs/workflows/examples.mdx
@@ -117,7 +117,7 @@ Per-group and namespace-wide application upgrades.
 
 | Example | Teaches | Key steps |
 | --- | --- | --- |
-| [`workflow-group-upgrade-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-group-upgrade-example.yml) | The per-group upgrade lifecycle v1→v2: set policy, upgrade, poll status, retry (expected-fail after completion). | `update_group_settings`, `upgrade_group`, `get_group_upgrade_status`, `retry_group_upgrade` |
+| [`workflow-group-upgrade-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-group-upgrade-example.yml) | The per-group upgrade lifecycle v1→v2: upgrade, poll status, retry (expected-fail after completion). | `upgrade_group`, `get_group_upgrade_status`, `retry_group_upgrade` |
 | [`workflow-cascade-namespace-example.yml`](https://github.com/calimero-network/merobox/blob/master/workflow-examples/workflow-cascade-namespace-example.yml) | The namespace cascade: one signed op fans the target-application change out to every matching descendant subgroup. | `cascade_namespace_application`, `get_group_info`, `json_assert` |
 
 ## Auth

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -609,18 +609,6 @@ accept an optional `requester` (admin key) for admin-guarded groups.
     tier: gold
 ```
 
-### update_group_settings
-
-Update a group's upgrade policy. Fields: `node`, `group_id`, `upgrade_policy`
-(`automatic` or `lazy-on-access`).
-
-```yaml
-- type: update_group_settings
-  node: calimero-node-1
-  group_id: '{{group_id}}'
-  upgrade_policy: automatic
-```
-
 ### detach_context_from_group
 
 Detach a context from its group. Fields: `node`, `group_id`, `context_id`.

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -78,7 +78,6 @@ VALID_STEP_TYPES = frozenset(
         "get_member_metadata",
         "set_context_metadata",
         "get_context_metadata",
-        "update_group_settings",
         "detach_context_from_group",
         "sync_group",
         "register_group_signing_key",
@@ -1359,23 +1358,6 @@ class GetContextMetadataStepConfig(BaseStepConfig):
     context_id: str = Field(..., description="Group-registered context ID")
 
 
-class UpdateGroupSettingsStepConfig(BaseStepConfig):
-    """Configuration for update_group_settings step (currently exposes upgrade_policy)."""
-
-    type: Literal["update_group_settings"] = "update_group_settings"
-    node: str = Field(..., description="Target node")
-    group_id: str = Field(..., description="Group ID")
-    # The server accepts only 'automatic' or 'lazy-on-access'; the former
-    # 'coordinated' policy was removed and is now rejected on deserialize.
-    upgrade_policy: Literal[
-        "automatic",
-        "lazy",
-        "lazy-on-access",
-        "lazy_on_access",
-        "lazyonaccess",
-    ] = Field(..., description="Group upgrade policy")
-
-
 class DetachContextFromGroupStepConfig(BaseStepConfig):
     """Configuration for detach_context_from_group step."""
 
@@ -1689,7 +1671,6 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "get_member_metadata": GetMemberMetadataStepConfig,
     "set_context_metadata": SetContextMetadataStepConfig,
     "get_context_metadata": GetContextMetadataStepConfig,
-    "update_group_settings": UpdateGroupSettingsStepConfig,
     "detach_context_from_group": DetachContextFromGroupStepConfig,
     "sync_group": SyncGroupStepConfig,
     "register_group_signing_key": RegisterGroupSigningKeyStepConfig,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -85,7 +85,6 @@ from merobox.commands.bootstrap.steps import (
     SyncGroupStep,
     TeeFleetJoinStep,
     UninstallApplicationStep,
-    UpdateGroupSettingsStep,
     UpdateMemberRoleStep,
     UpgradeGroupStep,
     UploadBlobStep,
@@ -2308,8 +2307,6 @@ class WorkflowExecutor:
             return SetContextMetadataStep(step_config, **common_kwargs)
         elif step_type == "get_context_metadata":
             return GetContextMetadataStep(step_config, **common_kwargs)
-        elif step_type == "update_group_settings":
-            return UpdateGroupSettingsStep(step_config, **common_kwargs)
         elif step_type == "detach_context_from_group":
             return DetachContextFromGroupStep(step_config, **common_kwargs)
         elif step_type == "sync_group":

--- a/merobox/commands/bootstrap/steps/__init__.py
+++ b/merobox/commands/bootstrap/steps/__init__.py
@@ -26,7 +26,6 @@ from merobox.commands.bootstrap.steps.group_create import (
 from merobox.commands.bootstrap.steps.group_governance import (
     DetachContextFromGroupStep,
     SyncGroupStep,
-    UpdateGroupSettingsStep,
 )
 from merobox.commands.bootstrap.steps.group_invite import (
     CreateGroupInvitationStep,
@@ -204,7 +203,6 @@ __all__ = [
     "GetMemberMetadataStep",
     "SetContextMetadataStep",
     "GetContextMetadataStep",
-    "UpdateGroupSettingsStep",
     "DetachContextFromGroupStep",
     "SyncGroupStep",
     "RegisterGroupSigningKeyStep",

--- a/merobox/commands/bootstrap/steps/group_governance.py
+++ b/merobox/commands/bootstrap/steps/group_governance.py
@@ -1,7 +1,7 @@
 """
 Group governance workflow step executors.
 
-Steps for group settings, context-group association, and manual sync.
+Steps for context-group association and manual sync.
 """
 
 from typing import Any
@@ -10,66 +10,6 @@ from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
 from merobox.commands.utils import console
-
-
-class UpdateGroupSettingsStep(BaseStep):
-    """Update group-level settings (currently: upgrade_policy)."""
-
-    def _get_required_fields(self) -> list[str]:
-        return ["node", "group_id", "upgrade_policy"]
-
-    def _validate_field_types(self) -> None:
-        step_name = self.config.get(
-            "name", f"Unnamed {self.config.get('type', 'Unknown')} step"
-        )
-        for field in ("node", "group_id", "upgrade_policy"):
-            if not isinstance(self.config.get(field), str):
-                raise ValueError(f"Step '{step_name}': '{field}' must be a string")
-
-    async def execute(
-        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
-    ) -> bool:
-        node_name = self.config["node"]
-        group_id = self._resolve_dynamic_value(
-            self.config["group_id"], workflow_results, dynamic_values
-        )
-        upgrade_policy = self._resolve_dynamic_value(
-            self.config["upgrade_policy"], workflow_results, dynamic_values
-        )
-        try:
-            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
-            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-            api_result = client.update_group_settings(
-                group_id=group_id, upgrade_policy=upgrade_policy
-            )
-            result = ok(api_result)
-        except Exception as e:
-            result = fail(f"update_group_settings failed: {e}", error=e)
-
-        expected_failure = self._is_expected_failure()
-
-        if not result["success"]:
-            if expected_failure:
-                return self._report_expected_failure(self._failure_detail(result))
-            console.print(
-                f"[red]update_group_settings failed on {node_name}: {result.get('error')}[/red]"
-            )
-            return False
-
-        if self._check_jsonrpc_error(result["data"]):
-            if expected_failure:
-                return self._report_expected_failure(
-                    self._jsonrpc_error_detail(result["data"])
-                )
-            return False
-
-        workflow_results[f"update_group_settings_{node_name}"] = result["data"]
-        console.print(
-            f"[green]✓ Updated group {group_id} settings (upgrade_policy={upgrade_policy}) on {node_name}[/green]"
-        )
-        if expected_failure:
-            return self._report_unexpected_success()
-        return True
 
 
 class DetachContextFromGroupStep(BaseStep):

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -32,7 +32,6 @@ from merobox.commands.bootstrap.steps.group_create import CreateNamespaceStep
 from merobox.commands.bootstrap.steps.group_governance import (
     DetachContextFromGroupStep,
     SyncGroupStep,
-    UpdateGroupSettingsStep,
 )
 from merobox.commands.bootstrap.steps.group_invite import CreateNamespaceInvitationStep
 from merobox.commands.bootstrap.steps.group_join import JoinNamespaceStep
@@ -347,8 +346,6 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = SetContextMetadataStep
         elif step_type == "get_context_metadata":
             step_class = GetContextMetadataStep
-        elif step_type == "update_group_settings":
-            step_class = UpdateGroupSettingsStep
         elif step_type == "detach_context_from_group":
             step_class = DetachContextFromGroupStep
         elif step_type == "sync_group":

--- a/merobox/commands/namespace.py
+++ b/merobox/commands/namespace.py
@@ -137,9 +137,8 @@ def namespace_identity(namespace_id, node, verbose):
 @click.argument("application_id")
 @click.option("--node", "-n", required=True, help="Node name")
 @click.option("--alias", help="Namespace alias")
-@click.option("--upgrade-policy", help="Upgrade policy")
 @click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
-def create_namespace(node, application_id, alias, upgrade_policy, verbose):
+def create_namespace(node, application_id, alias, verbose):
     """Create a namespace."""
     manager = DockerManager()
     rpc_url = get_node_rpc_url(node, manager)
@@ -150,8 +149,6 @@ def create_namespace(node, application_id, alias, upgrade_policy, verbose):
     kwargs = {}
     if alias is not None:
         kwargs["alias"] = alias
-    if upgrade_policy is not None:
-        kwargs["upgrade_policy"] = upgrade_policy
 
     result = run_async_function(
         call_namespace_api,

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -1034,39 +1034,7 @@ class TestMetadataStepSchemas:
 
 
 class TestGroupGovernanceStepSchemas:
-    """Schema validation for update_group_settings / detach_context_from_group / sync_group."""
-
-    def test_valid_update_group_settings(self, config_module):
-        step = {
-            "type": "update_group_settings",
-            "node": "calimero-node-1",
-            "group_id": "{{group_id}}",
-            "upgrade_policy": "automatic",
-        }
-        assert config_module.validate_workflow_step(step, 0) == []
-
-    def test_valid_update_group_settings_lazy_variants(self, config_module):
-        for policy in ("lazy", "lazy-on-access", "lazy_on_access", "lazyonaccess"):
-            step = {
-                "type": "update_group_settings",
-                "node": "calimero-node-1",
-                "group_id": "{{group_id}}",
-                "upgrade_policy": policy,
-            }
-            assert config_module.validate_workflow_step(step, 0) == [], policy
-
-    def test_invalid_update_group_settings_bad_policy(self, config_module):
-        # 'coordinated' was removed from the server and must now be rejected at
-        # schema time alongside any other unknown policy.
-        for policy in ("eager", "coordinated"):
-            step = {
-                "type": "update_group_settings",
-                "node": "calimero-node-1",
-                "group_id": "{{group_id}}",
-                "upgrade_policy": policy,
-            }
-            errors = config_module.validate_workflow_step(step, 0)
-            assert any("upgrade_policy" in e.lower() for e in errors), policy
+    """Schema validation for detach_context_from_group / sync_group."""
 
     def test_valid_detach_context_from_group(self, config_module):
         step = {

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "docker>=6.0.0",
         "rich>=13.0.0",
         "PyYAML>=6.0.0",
-        "calimero-client-py>=0.6.21",
+        "calimero-client-py>=0.6.24,<0.6.26",
         "aiohttp>=3.8.0",
         "toml>=0.10.2",
         "base58>=2.1.0",

--- a/workflow-examples/workflow-group-upgrade-example.yml
+++ b/workflow-examples/workflow-group-upgrade-example.yml
@@ -1,8 +1,8 @@
 name: Group Upgrade Lifecycle Example
 description: >
   Demonstrates the group-application upgrade lifecycle: install two distinct
-  application binaries, set upgrade policy, initiate upgrade from v1 to v2,
-  poll upgrade status, and attempt retry (which is expected to fail once the
+  application binaries, initiate upgrade from v1 to v2, poll upgrade
+  status, and attempt retry (which is expected to fail once the
   upgrade has completed — exercising the expected_failure flag).
 
   Requires kv_store_v2.wasm in workflow-examples/res/, which is a purpose-
@@ -76,13 +76,7 @@ steps:
     type: wait
     seconds: 5
 
-  # Phase 3 used to set an upgrade policy here. The concept is gone
-  # (calimero-network/core#3393): 'coordinated' went first, then the setting
-  # itself, and the route with it — lazy-on-access is now the only behaviour, so
-  # there is nothing left to choose. The upgrade below is unaffected; it simply
-  # applies on next access rather than immediately.
-
-  # Phase 4: Initiate upgrade v1 -> v2
+  # Phase 3: Initiate upgrade v1 -> v2
   - name: Upgrade Subgroup Application to v2
     type: upgrade_group
     node: calimero-node-1
@@ -98,7 +92,7 @@ steps:
     node: calimero-node-1
     group_id: '{{group_id}}'
 
-  # Phase 5: Retry is expected to fail once the upgrade completed
+  # Phase 4: Retry is expected to fail once the upgrade completed
   # (the server rejects retry when there is no active in-progress upgrade).
   - name: Attempt Retry on Completed Upgrade
     type: retry_group_upgrade
@@ -106,7 +100,7 @@ steps:
     group_id: '{{group_id}}'
     expected_failure: true
 
-  # Phase 6: Teardown
+  # Phase 5: Teardown
   # Unlocked by calimero-client-py 0.6.2+ (requester field on
   # delete_context/delete_group/delete_namespace).
   - name: Delete Context


### PR DESCRIPTION
## Summary

Core removed the `UpgradePolicy` concept: the enum, the `upgrade_policy` field on create-namespace and create-group requests, and the entire `update_group_settings` endpoint. calimero-client-py no longer exposes an `update_group_settings` binding, so the step merobox still wires end to end can never succeed. It is dead code that is nonetheless documented and schema-validated. This removes it.

- Deleted the `update_group_settings` step type end to end: `UpdateGroupSettingsStepConfig`, the `VALID_STEP_TYPES` entry, the config map entry, `UpdateGroupSettingsStep`, and the executor and validator dispatch branches. `detach_context_from_group` and `sync_group` still do real work and stay in `steps/group_governance.py`; only the settings step is gone.
- Dropped `--upgrade-policy` from `merobox namespace create`, since `create_namespace` no longer accepts it, and from the `namespace create` row of the CLI reference table in `docs/.../reference/cli.mdx`, which was the last place still advertising the flag.
- Dropped the "Set Upgrade Policy to Automatic" step from `workflow-examples/workflow-group-upgrade-example.yml` and renumbered the remaining phases, which are now 1 to 5. The rest of the upgrade lifecycle (`upgrade_group`, `get_group_upgrade_status`, `retry_group_upgrade`) is unaffected.
- Removed the three schema tests covering the deleted step.
- Removed the step's section from `docs/.../workflows/yaml.mdx` and its entry in the `examples.mdx` step list, so the docs stop describing a step that no longer exists.
- Pointed `setup.py`'s stale `calimero-client-py` floor at the pin `requirements.txt` carries. `setup.py` is unused metadata that `pyproject.toml` supersedes; this only stops it from claiming a floor nothing else does. The dependency pin itself is unchanged by this PR.

## Behaviour change

Any workflow yaml with an `update_group_settings` step now fails validation with `Invalid step type 'update_group_settings'`, and `merobox namespace create --upgrade-policy ...` fails with "no such option". There is no replacement: the server-side concept is gone, not renamed.

`CHANGELOG.md` is hand-maintained and deliberately untouched; it should get its entry as part of a release bump, by a human. No version bump is included here, so merging alone will not trigger the release pipeline.

## Test plan

Run in a fresh venv built from `requirements.txt`, which resolves calimero-client-py 0.6.25:

- `python -m pytest merobox/tests -q`: 1369 passed, 0 failed. The same venv run against this branch's base gives 1373 passed. Diffing the collected node ids, the difference is exactly the four cases that covered the removed step: three schema tests in `test_workflow_schema_validation.py` and one parametrized case in `test_validator_step_type_coverage.py`, whose parameters come from `VALID_STEP_TYPES`. Nothing else was lost and nothing was added.
- Repo sweep for `update_group_settings`, `upgrade_policy` and `--upgrade-policy` outside `CHANGELOG.md`: no matches remain in code, workflows or docs.

Not run locally: the workflow-execution CI matrix, which needs a live merod.
