### PR TITLE
chore: release 0.6.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.53] - 2026-08-12
+
+### Changed
+
+- **Requires `calimero-client-py>=0.6.24`.** That release decodes member ids as the node writes them rather than parsing them as bs58 keys, which is what lets one client talk to a node that names governance principals by account (calimero-network/core#3391) as well as one that does not. The floor also excludes 0.6.22 and 0.6.23, which omit `upgradePolicy` from `create_namespace` and so cannot create a namespace on any released node.
+
+### Removed
+
+- **The upgrade-policy step in `workflow-group-upgrade-example.yml`.** The setting no longer exists (calimero-network/core#3393) — lazy-on-access is the only behaviour, and the route is gone. The example still exercises the upgrade itself, which now applies on next access.
+
 ## [0.6.52] - 2026-08-04
 
 ### Added

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.52"
+__version__ = "0.6.53"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Cuts the release that [#319](https://github.com/calimero-network/merobox/pull/319) needs to actually reach consumers.

## Why this is separate

#319 raised the `calimero-client-py` floor to `>=0.6.24` but did not touch `merobox/__init__.py`. The release pipeline gates on exactly that version changing — it ran on the merge, found no change, and published nothing. So the newest **published** binary still bundles a client from before the floor.

That matters because core's e2e does not build merobox; `setup-merobox` downloads the latest release asset. Until a release carries the new floor, [core#3391](https://github.com/calimero-network/core/pull/3391) cannot drop its temporary job that builds merobox from a branch.

## What's in it

Only the version bump and its changelog entry. The substance — the client floor, and removing the upgrade-policy step from the group-upgrade example — shipped in #319.

`MIN_MEROBOX` in core's `setup-merobox` is `0.6.52`, so 0.6.53 satisfies it with no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)