### PR TITLE
fix(bootstrap): surface real exceptions and stop Rich markup crashes on node output

### DIFF
--- a/merobox/commands/binary_manager.py
+++ b/merobox/commands/binary_manager.py
@@ -799,13 +799,13 @@ class BinaryManager(CleanupMixin):
                             bytes_to_read = min(f.tell(), block_size)
                         lines_buf = data.splitlines()[-tail:]
                         for line in lines_buf:
-                            console.print(line)
+                            console.print(line, markup=False)
                     except Exception:
                         # Fallback: read all and slice
                         f.seek(0)
                         lines_buf = f.readlines()[-tail:]
                         for line in lines_buf:
-                            console.print(line.rstrip("\n"))
+                            console.print(line.rstrip("\n"), markup=False)
 
                 # Now follow appended content
                 f.seek(0, os.SEEK_END)
@@ -814,7 +814,7 @@ class BinaryManager(CleanupMixin):
                     if not line:
                         time.sleep(0.25)
                         continue
-                    console.print(line.rstrip("\n"))
+                    console.print(line.rstrip("\n"), markup=False)
 
         except KeyboardInterrupt:
             return True

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -10,6 +10,7 @@ import uuid
 from typing import Any, Optional
 
 import docker
+from rich.markup import escape
 from rich.progress import (
     BarColumn,
     Progress,
@@ -829,20 +830,24 @@ class WorkflowExecutor:
                 container.stop(timeout=5)
             except Exception as e:
                 console.print(
-                    f"[yellow]NAT teardown: failed to stop {client_name}: {e}[/yellow]"
+                    f"[yellow]NAT teardown: failed to stop {client_name}: "
+                    f"{escape(str(e))}[/yellow]"
                 )
             try:
                 container.remove(force=True)
             except Exception as e:
                 console.print(
-                    f"[yellow]NAT teardown: failed to remove {client_name}: {e}[/yellow]"
+                    f"[yellow]NAT teardown: failed to remove {client_name}: "
+                    f"{escape(str(e))}[/yellow]"
                 )
         try:
             from merobox.topology import teardown_nat_topology
 
             teardown_nat_topology(self.manager.client, self._nat_state)
         except Exception as e:
-            console.print(f"[yellow]NAT topology teardown raised: {e}[/yellow]")
+            console.print(
+                f"[yellow]NAT topology teardown raised: {escape(str(e))}[/yellow]"
+            )
         finally:
             self._nat_state = None
             # Drop the manager-side handle in lockstep so a
@@ -904,7 +909,8 @@ class WorkflowExecutor:
                             )
                     except Exception as e:
                         console.print(
-                            f"[red]Warning: force_pull_image failed for image: {image} - {e}[/red]"
+                            f"[red]Warning: force_pull_image failed for image: "
+                            f"{image} - {escape(str(e))}[/red]"
                         )
 
                 # Check for images in individual node configurations
@@ -924,7 +930,8 @@ class WorkflowExecutor:
                                 )
                         except Exception as e:
                             console.print(
-                                f"[red]Warning: force_pull_image failed for node {node_name}: {image} - {e}[/red]"
+                                f"[red]Warning: force_pull_image failed for node "
+                                f"{node_name}: {image} - {escape(str(e))}[/red]"
                             )
 
         except Exception as e:
@@ -1107,7 +1114,7 @@ class WorkflowExecutor:
                 boot_node_image_override=boot_node_image_override,
             )
         except Exception as e:
-            console.print(f"[red]❌ NAT topology setup failed: {e}[/red]")
+            console.print(f"[red]❌ NAT topology setup failed: {escape(str(e))}[/red]")
             return False
 
         # Expose the topology state on the manager so step
@@ -1258,7 +1265,7 @@ class WorkflowExecutor:
             except RuntimeError as e:
                 console.print(
                     f"[red]❌ Could not route {node_name} through the NAT "
-                    f"gateway: {e}[/red]"
+                    f"gateway: {escape(str(e))}[/red]"
                 )
                 self._teardown_nat_topology_if_present()
                 return False
@@ -1278,7 +1285,7 @@ class WorkflowExecutor:
             except RuntimeError as e:
                 console.print(
                     f"[red]❌ {node_name} cannot reach the boot-node via "
-                    f"the NAT gateway: {e}[/red]"
+                    f"the NAT gateway: {escape(str(e))}[/red]"
                 )
                 self._teardown_nat_topology_if_present()
                 return False
@@ -1529,7 +1536,7 @@ class WorkflowExecutor:
                             container.remove()
                     except Exception as e:
                         console.print(
-                            f"[yellow]Warning: Failed to stop node: {e}[/yellow]"
+                            f"[yellow]Warning: Failed to stop node: {escape(str(e))}[/yellow]"
                         )
 
                     console.print(f"Starting node '{node_name}'...")
@@ -1854,12 +1861,14 @@ class WorkflowExecutor:
 
             except AuthenticationError as e:
                 console.print(
-                    f"[red]  ✗ Failed to authenticate with {node_name}: {e}[/red]"
+                    f"[red]  ✗ Failed to authenticate with {node_name}: "
+                    f"{escape(str(e))}[/red]"
                 )
                 failed_nodes.append(node_name)
             except Exception as e:
                 console.print(
-                    f"[red]  ✗ Error authenticating with {node_name}: {e}[/red]"
+                    f"[red]  ✗ Error authenticating with {node_name}: "
+                    f"{escape(str(e))}[/red]"
                 )
                 failed_nodes.append(node_name)
 

--- a/merobox/commands/bootstrap/steps/account.py
+++ b/merobox/commands/bootstrap/steps/account.py
@@ -122,7 +122,7 @@ class AccountCreateStep(_AccountStepBase):
             client = self._client(node_name)
             result = ok(self._data(client.create_account(namespace_id)))
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
-            result = fail("account create failed", error=e)
+            result = fail(f"account create failed: {e}", error=e)
 
         if not result["success"]:
             console.print(
@@ -233,7 +233,7 @@ class AccountPairStep(_AccountStepBase):
                 )
             result = ok({**complete, "deviceId": init["deviceId"]})
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
-            result = fail("account pair failed", error=e)
+            result = fail(f"account pair failed: {e}", error=e)
 
         if not result["success"]:
             console.print(
@@ -320,7 +320,7 @@ class AccountRevokeStep(_AccountStepBase):
                 self._data(client.revoke_device(namespace_id, device_id, proof))
             )
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
-            result = fail("account revoke failed", error=e)
+            result = fail(f"account revoke failed: {e}", error=e)
 
         if not result["success"]:
             console.print(
@@ -373,7 +373,7 @@ class AccountShowStep(_AccountStepBase):
             client = self._client(node_name)
             result = ok(self._data(client.get_namespace_account(namespace_id)))
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
-            result = fail("account show failed", error=e)
+            result = fail(f"account show failed: {e}", error=e)
 
         if not result["success"]:
             console.print(

--- a/merobox/commands/bootstrap/steps/account.py
+++ b/merobox/commands/bootstrap/steps/account.py
@@ -21,6 +21,8 @@ error mapping and the connection handling this layer exists to provide.
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -127,7 +129,7 @@ class AccountCreateStep(_AccountStepBase):
         if not result["success"]:
             console.print(
                 f"[red]Failed to enrol an account on {node_name}: "
-                f"{result.get('error')}[/red]"
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -238,7 +240,7 @@ class AccountPairStep(_AccountStepBase):
         if not result["success"]:
             console.print(
                 f"[red]Failed to pair {node_name} onto the account held by "
-                f"{holder}: {result.get('error')}[/red]"
+                f"{holder}: {escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -325,7 +327,7 @@ class AccountRevokeStep(_AccountStepBase):
         if not result["success"]:
             console.print(
                 f"[red]Failed to revoke {device_id} via {node_name}: "
-                f"{result.get('error')}[/red]"
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -378,7 +380,7 @@ class AccountShowStep(_AccountStepBase):
         if not result["success"]:
             console.print(
                 f"[red]Failed to read {node_name}'s account: "
-                f"{result.get('error')}[/red]"
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/assert_log.py
+++ b/merobox/commands/bootstrap/steps/assert_log.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.utils import console
 
@@ -82,14 +84,16 @@ class _AssertLogStepBase(BaseStep):
             try:
                 listed = self.manager.list_nodes() or []
             except Exception as e:
-                console.print(f"[yellow]⚠️  manager.list_nodes() failed: {e}[/yellow]")
+                console.print(
+                    f"[yellow]⚠️  manager.list_nodes() failed: {escape(str(e))}[/yellow]"
+                )
                 return []
             return [n["name"] for n in listed if isinstance(n, dict) and "name" in n]
         try:
             return list(self.manager.get_running_nodes() or [])
         except Exception as e:
             console.print(
-                f"[yellow]⚠️  manager.get_running_nodes() failed: {e}[/yellow]"
+                f"[yellow]⚠️  manager.get_running_nodes() failed: {escape(str(e))}[/yellow]"
             )
             return []
 
@@ -103,7 +107,8 @@ class _AssertLogStepBase(BaseStep):
                 return self.manager.get_node_logs(node_name, lines=lines)
             except Exception as e:
                 console.print(
-                    f"[yellow]⚠️  Could not retrieve logs for {node_name}: {e}[/yellow]"
+                    f"[yellow]⚠️  Could not retrieve logs for {node_name}: "
+                    f"{escape(str(e))}[/yellow]"
                 )
                 return None
         # Docker mode
@@ -126,7 +131,8 @@ class _AssertLogStepBase(BaseStep):
             return str(raw)
         except Exception as e:
             console.print(
-                f"[yellow]⚠️  Could not retrieve logs for {node_name}: {e}[/yellow]"
+                f"[yellow]⚠️  Could not retrieve logs for {node_name}: "
+                f"{escape(str(e))}[/yellow]"
             )
             return None
 

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -712,8 +712,8 @@ class BaseStep:
                     raise Exception(f"Failed to resolve URL '{node_name}': {e}") from e
                 # Log the resolver error but try fallback for local nodes
                 console.print(
-                    f"[yellow]Warning: Resolver failed for {node_name}: {e}. "
-                    f"Trying legacy resolution...[/yellow]"
+                    f"[yellow]Warning: Resolver failed for {node_name}: "
+                    f"{escape(str(e))}. Trying legacy resolution...[/yellow]"
                 )
 
         # Fallback to legacy get_node_rpc_url (only for local nodes)

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -7,6 +7,8 @@ import json
 import re
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from rich.markup import escape
+
 from merobox.commands.utils import LOG_LEVEL_VERBOSE, console, get_node_rpc_url, vprint
 
 if TYPE_CHECKING:
@@ -1249,8 +1251,15 @@ class BaseStep:
         return value
 
     def _report_expected_failure(self, error_message: str) -> None:
-        """Log the standard yellow message when an expected failure occurred."""
-        console.print(f"[yellow]✓ Expected failure occurred: {error_message}[/yellow]")
+        """Log the standard yellow message when an expected failure occurred.
+
+        error_message may carry a raw exception's text, which can itself
+        contain square brackets (e.g. a multiaddr) that Rich would otherwise
+        try to parse as markup - escape it, keep the surrounding tag.
+        """
+        console.print(
+            f"[yellow]✓ Expected failure occurred: {escape(error_message)}[/yellow]"
+        )
 
     def _report_unexpected_success(self) -> None:
         """Log a warning when `expected_failure: true` was set but the step succeeded.

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -1361,7 +1361,9 @@ class BaseStep:
                 # Binary mode - use BinaryManager's get_node_logs
                 log_content = self.manager.get_node_logs(node_name, lines=lines)
                 if log_content:
-                    console.print(log_content)
+                    # Node output may contain literal square brackets (e.g. a
+                    # multiaddr list) that Rich would otherwise try to parse as markup.
+                    console.print(log_content, markup=False)
                 else:
                     console.print(f"[dim]No logs found for {node_name}[/dim]")
             else:
@@ -1376,7 +1378,7 @@ class BaseStep:
 
                     logs = container.logs(tail=lines, timestamps=True).decode("utf-8")
                     if logs:
-                        console.print(logs)
+                        console.print(logs, markup=False)
                     else:
                         console.print(f"[dim]No logs available for {node_name}[/dim]")
                 except Exception as e:

--- a/merobox/commands/bootstrap/steps/blob.py
+++ b/merobox/commands/bootstrap/steps/blob.py
@@ -5,6 +5,8 @@ Blob upload step executor.
 import os
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -97,7 +99,9 @@ class UploadBlobStep(BaseStep):
 
             return ok(result)
         except Exception as e:
-            console.print(f"[red]✗ Blob upload failed: {type(e).__name__}: {e}[/red]")
+            console.print(
+                f"[red]✗ Blob upload failed: {type(e).__name__}: {escape(str(e))}[/red]"
+            )
             return fail("upload_blob failed", error=e)
 
     async def execute(

--- a/merobox/commands/bootstrap/steps/context.py
+++ b/merobox/commands/bootstrap/steps/context.py
@@ -154,7 +154,7 @@ class CreateContextStep(BaseStep):
 
             result = ok(api_result)
         except Exception as e:
-            result = fail("create_context failed", error=e)
+            result = fail(f"create_context failed: {e}", error=e)
 
         # Log detailed API response
         import json as json_lib

--- a/merobox/commands/bootstrap/steps/context.py
+++ b/merobox/commands/bootstrap/steps/context.py
@@ -4,6 +4,8 @@ Create context step executor.
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -173,7 +175,7 @@ class CreateContextStep(BaseStep):
             console.print(f"  Data: {data}")
 
         if not result.get("success"):
-            console.print(f"  Error: {result.get('error')}")
+            console.print(f"  Error: {escape(str(result.get('error')))}")
             # Print exception details if available
             if "exception" in result:
                 exception = result["exception"]
@@ -254,7 +256,8 @@ class CreateContextStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]Context creation failed: {result.get('error', 'Unknown error')}[/red]"
+                f"[red]Context creation failed: "
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             # Print node logs to help with debugging
             self._print_node_logs_on_failure(node_name=node_name, lines=50)

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps._docker_utils import (
     is_binary_mode,
     resolve_container,
@@ -323,7 +325,8 @@ class DeleteBlobStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]delete_blob failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]delete_blob failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -316,7 +316,7 @@ class DeleteBlobStep(BaseStep):
                 if expected_failure:
                     self._report_unexpected_success()
                 return True
-            result = fail("delete_blob failed", error=e)
+            result = fail(f"delete_blob failed: {e}", error=e)
 
         if not result["success"]:
             if expected_failure:

--- a/merobox/commands/bootstrap/steps/download_blob.py
+++ b/merobox/commands/bootstrap/steps/download_blob.py
@@ -217,7 +217,7 @@ class DownloadBlobStep(BaseStep):
                 f"[red]✗ Blob download failed after retries: "
                 f"{type(e).__name__}: {e}[/red]"
             )
-            result = fail("download_blob failed", error=e)
+            result = fail(f"download_blob failed: {e}", error=e)
 
         if not result["success"]:
             return self._retrieval_failed(str(result.get("error", "Unknown error")))

--- a/merobox/commands/bootstrap/steps/download_blob.py
+++ b/merobox/commands/bootstrap/steps/download_blob.py
@@ -28,6 +28,8 @@ import hashlib
 import os
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -104,7 +106,7 @@ class DownloadBlobStep(BaseStep):
         if self._is_expected_failure():
             self._report_expected_failure(reason)
             return True
-        console.print(f"[red]✗ {reason}[/red]")
+        console.print(f"[red]✗ {escape(reason)}[/red]")
         return False
 
     def _assertion_failed(self, reason: str) -> bool:

--- a/merobox/commands/bootstrap/steps/download_blob.py
+++ b/merobox/commands/bootstrap/steps/download_blob.py
@@ -157,7 +157,9 @@ class DownloadBlobStep(BaseStep):
         except _RETRIEVAL_ERRORS as e:
             # A genuine "cannot retrieve" verdict. Anything outside this tuple is
             # deliberately left to propagate — see _RETRIEVAL_ERRORS.
-            console.print(f"[red]✗ Blob download failed: {type(e).__name__}: {e}[/red]")
+            console.print(
+                f"[red]✗ Blob download failed: {type(e).__name__}: {escape(str(e))}[/red]"
+            )
             return fail("download_blob failed", error=e)
         return ok(blob_data)
 
@@ -217,7 +219,7 @@ class DownloadBlobStep(BaseStep):
             # to keep travelling so it surfaces as the bug it is.
             console.print(
                 f"[red]✗ Blob download failed after retries: "
-                f"{type(e).__name__}: {e}[/red]"
+                f"{type(e).__name__}: {escape(str(e))}[/red]"
             )
             result = fail(f"download_blob failed: {e}", error=e)
 

--- a/merobox/commands/bootstrap/steps/fuzzy_test.py
+++ b/merobox/commands/bootstrap/steps/fuzzy_test.py
@@ -33,6 +33,8 @@ import time
 import uuid as uuid_module
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.assertion import (
     AssertStep,
     FuzzyTestResultsTracker,
@@ -533,7 +535,8 @@ class FuzzyTestStep(BaseStep):
                 except Exception as e:
                     # If generation fails, return original
                     console.print(
-                        f"[yellow]Warning: Failed to resolve {{{{{generator_name}}}}}: {e}[/yellow]"
+                        f"[yellow]Warning: Failed to resolve "
+                        f"{{{{{generator_name}}}}}: {escape(str(e))}[/yellow]"
                     )
                     return match.group(0)
 

--- a/merobox/commands/bootstrap/steps/get_application.py
+++ b/merobox/commands/bootstrap/steps/get_application.py
@@ -63,7 +63,7 @@ class GetApplicationStep(BaseStep):
             api_result = client.get_application(application_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("get_application failed", error=e)
+            result = fail(f"get_application failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/get_application.py
+++ b/merobox/commands/bootstrap/steps/get_application.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -72,7 +74,8 @@ class GetApplicationStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]get_application failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]get_application failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/group_create.py
+++ b/merobox/commands/bootstrap/steps/group_create.py
@@ -77,7 +77,7 @@ class CreateNamespaceStep(BaseStep):
                 api_result = client.create_group(application_id=application_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("create_namespace failed", error=e)
+            result = fail(f"create_namespace failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/group_create.py
+++ b/merobox/commands/bootstrap/steps/group_create.py
@@ -4,6 +4,8 @@ Create namespace step executor.
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -119,7 +121,7 @@ class CreateNamespaceStep(BaseStep):
                 return True
             console.print(
                 f"[red]Namespace creation failed on {node_name}: "
-                f"{result.get('error', 'Unknown error')}[/red]"
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False

--- a/merobox/commands/bootstrap/steps/group_invite.py
+++ b/merobox/commands/bootstrap/steps/group_invite.py
@@ -4,6 +4,8 @@ Create namespace invitation step executor.
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -126,7 +128,7 @@ class CreateNamespaceInvitationStep(BaseStep):
                 return True
             console.print(
                 f"[red]Namespace invitation creation failed on {node_name}: "
-                f"{result.get('error', 'Unknown error')}[/red]"
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False

--- a/merobox/commands/bootstrap/steps/group_invite.py
+++ b/merobox/commands/bootstrap/steps/group_invite.py
@@ -71,7 +71,7 @@ class CreateNamespaceInvitationStep(BaseStep):
                 api_result = client.create_group_invitation(namespace_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("create_namespace_invitation failed", error=e)
+            result = fail(f"create_namespace_invitation failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/group_join.py
+++ b/merobox/commands/bootstrap/steps/group_join.py
@@ -7,6 +7,8 @@ import os
 import shutil
 from typing import Any, Optional
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.constants import CONTAINER_DATA_DIR_PATTERNS, DEFAULT_METADATA
@@ -76,7 +78,7 @@ class JoinNamespaceStep(BaseStep):
             dynamic_values[f"app_path_{node_name}"] = app_path
         except Exception as e:
             console.print(
-                f"[yellow]⚠️  Auto-install on {node_name} failed: {e}[/yellow]"
+                f"[yellow]⚠️  Auto-install on {node_name} failed: {escape(str(e))}[/yellow]"
             )
 
     def _prepare_container_path(
@@ -142,7 +144,7 @@ class JoinNamespaceStep(BaseStep):
             except json_lib.JSONDecodeError as e:
                 console.print(
                     f"[red]Step 'join_namespace' on {node_name}: "
-                    f"'invitation' is not valid JSON: {e}[/red]"
+                    f"'invitation' is not valid JSON: {escape(str(e))}[/red]"
                 )
                 return False
         else:

--- a/merobox/commands/bootstrap/steps/group_management.py
+++ b/merobox/commands/bootstrap/steps/group_management.py
@@ -7,6 +7,8 @@ Steps for managing group membership, roles, capabilities, and lifecycle.
 import json
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -64,7 +66,8 @@ class RemoveGroupMembersStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]Failed to remove group members on {node_name}: {result.get('error')}[/red]"
+                f"[red]Failed to remove group members on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -120,7 +123,8 @@ class ListGroupMembersStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]list_group_members failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]list_group_members failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -182,7 +186,8 @@ class UpdateMemberRoleStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]update_member_role failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]update_member_role failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -244,7 +249,8 @@ class SetMemberCapabilitiesStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]set_member_capabilities failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]set_member_capabilities failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -352,7 +358,8 @@ class SetMemberAutoFollowStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]set_member_auto_follow failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]set_member_auto_follow failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -415,7 +422,8 @@ class GetMemberCapabilitiesStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]get_member_capabilities failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]get_member_capabilities failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -476,7 +484,8 @@ class SetDefaultCapabilitiesStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]set_default_capabilities failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]set_default_capabilities failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -544,7 +553,8 @@ class SetSubgroupVisibilityStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]set_subgroup_visibility failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]set_subgroup_visibility failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -605,7 +615,8 @@ class GetGroupInfoStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]get_group_info failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]get_group_info failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -660,7 +671,8 @@ class ListGroupContextsStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]list_group_contexts failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]list_group_contexts failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
@@ -1101,11 +1113,12 @@ class UninstallApplicationStep(BaseStep):
             api_result = client.uninstall_application(app_id=application_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("uninstall_application failed", error=e)
+            result = fail(f"uninstall_application failed: {e}", error=e)
 
         if not result["success"]:
             console.print(
-                f"[red]uninstall_application failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]uninstall_application failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):

--- a/merobox/commands/bootstrap/steps/group_management.py
+++ b/merobox/commands/bootstrap/steps/group_management.py
@@ -55,7 +55,7 @@ class RemoveGroupMembersStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("remove_group_members failed", error=e)
+            result = fail(f"remove_group_members failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -111,7 +111,7 @@ class ListGroupMembersStep(BaseStep):
             api_result = client.list_group_members(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("list_group_members failed", error=e)
+            result = fail(f"list_group_members failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -173,7 +173,7 @@ class UpdateMemberRoleStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("update_member_role failed", error=e)
+            result = fail(f"update_member_role failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -235,7 +235,7 @@ class SetMemberCapabilitiesStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("set_member_capabilities failed", error=e)
+            result = fail(f"set_member_capabilities failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -343,7 +343,7 @@ class SetMemberAutoFollowStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("set_member_auto_follow failed", error=e)
+            result = fail(f"set_member_auto_follow failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -406,7 +406,7 @@ class GetMemberCapabilitiesStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("get_member_capabilities failed", error=e)
+            result = fail(f"get_member_capabilities failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -467,7 +467,7 @@ class SetDefaultCapabilitiesStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("set_default_capabilities failed", error=e)
+            result = fail(f"set_default_capabilities failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -535,7 +535,7 @@ class SetSubgroupVisibilityStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("set_subgroup_visibility failed", error=e)
+            result = fail(f"set_subgroup_visibility failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -596,7 +596,7 @@ class GetGroupInfoStep(BaseStep):
             api_result = client.get_group_info(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("get_group_info failed", error=e)
+            result = fail(f"get_group_info failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -651,7 +651,7 @@ class ListGroupContextsStep(BaseStep):
             api_result = client.list_group_contexts(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("list_group_contexts failed", error=e)
+            result = fail(f"list_group_contexts failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/group_metadata.py
+++ b/merobox/commands/bootstrap/steps/group_metadata.py
@@ -8,6 +8,8 @@ and group-registered contexts via the admin API.
 import json
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -161,7 +163,8 @@ class _SetMetadataBase(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]{self._api_method} failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]{self._api_method} failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -272,7 +275,8 @@ class _GetMetadataBase(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]{self._api_method} failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]{self._api_method} failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):

--- a/merobox/commands/bootstrap/steps/group_metadata.py
+++ b/merobox/commands/bootstrap/steps/group_metadata.py
@@ -154,7 +154,7 @@ class _SetMetadataBase(BaseStep):
             api_result = method(group_id, *extra_args, body)
             result = ok(api_result)
         except Exception as e:
-            result = fail(f"{self._api_method} failed", error=e)
+            result = fail(f"{self._api_method} failed: {e}", error=e)
 
         if not result["success"]:
             if expected_failure:
@@ -265,7 +265,7 @@ class _GetMetadataBase(BaseStep):
             api_result = method(group_id, *extra_args)
             result = ok(api_result)
         except Exception as e:
-            result = fail(f"{self._api_method} failed", error=e)
+            result = fail(f"{self._api_method} failed: {e}", error=e)
 
         if not result["success"]:
             if expected_failure:

--- a/merobox/commands/bootstrap/steps/group_metadata.py
+++ b/merobox/commands/bootstrap/steps/group_metadata.py
@@ -137,7 +137,9 @@ class _SetMetadataBase(BaseStep):
             if expected_failure:
                 self._report_expected_failure(f"node resolution failed: {e}")
                 return True
-            console.print(f"[red]Failed to resolve node {node_name}: {e}[/red]")
+            console.print(
+                f"[red]Failed to resolve node {node_name}: {escape(str(e))}[/red]"
+            )
             return False
 
         try:
@@ -249,7 +251,9 @@ class _GetMetadataBase(BaseStep):
             if expected_failure:
                 self._report_expected_failure(f"node resolution failed: {e}")
                 return True
-            console.print(f"[red]Failed to resolve node {node_name}: {e}[/red]")
+            console.print(
+                f"[red]Failed to resolve node {node_name}: {escape(str(e))}[/red]"
+            )
             return False
 
         try:

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -360,7 +360,7 @@ class UpgradeGroupStep(BaseStep):
             api_result = client.upgrade_group(**upgrade_kwargs)
             result = ok(api_result)
         except Exception as e:
-            result = fail("upgrade_group failed", error=e)
+            result = fail(f"upgrade_group failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -488,7 +488,7 @@ class CascadeNamespaceApplicationStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("cascade_namespace_application failed", error=e)
+            result = fail(f"cascade_namespace_application failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -559,7 +559,7 @@ class GetGroupUpgradeStatusStep(BaseStep):
             api_result = client.get_group_upgrade_status(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("get_group_upgrade_status failed", error=e)
+            result = fail(f"get_group_upgrade_status failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -619,7 +619,7 @@ class RetryGroupUpgradeStep(BaseStep):
             api_result = client.retry_group_upgrade(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("retry_group_upgrade failed", error=e)
+            result = fail(f"retry_group_upgrade failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -706,7 +706,7 @@ class GetCascadeStatusStep(BaseStep):
             api_result = client.get_cascade_status(namespace_id=namespace_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("get_cascade_status failed", error=e)
+            result = fail(f"get_cascade_status failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -995,7 +995,7 @@ class AbortMigrationStep(BaseStep):
             api_result = client.abort_migration(namespace_id=namespace_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("abort_migration failed", error=e)
+            result = fail(f"abort_migration failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -1090,7 +1090,7 @@ class GetMigrationStatusStep(BaseStep):
             api_result = client.get_migration_status(namespace_id=namespace_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("get_migration_status failed", error=e)
+            result = fail(f"get_migration_status failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -1396,7 +1396,7 @@ class ResyncContextStep(BaseStep):
             api_result = client.resync_context(context_id=context_id, force=force)
             result = ok(api_result)
         except Exception as e:
-            result = fail("resync_context failed", error=e)
+            result = fail(f"resync_context failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -1498,7 +1498,7 @@ class ListApplicationVersionsStep(BaseStep):
             api_result = client.list_application_versions(application_id=application_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("list_application_versions failed", error=e)
+            result = fail(f"list_application_versions failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -19,6 +19,8 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -369,7 +371,8 @@ class UpgradeGroupStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]upgrade_group failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]upgrade_group failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -497,7 +500,8 @@ class CascadeNamespaceApplicationStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]cascade_namespace_application failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]cascade_namespace_application failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -568,7 +572,8 @@ class GetGroupUpgradeStatusStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]get_group_upgrade_status failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]get_group_upgrade_status failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -628,7 +633,8 @@ class RetryGroupUpgradeStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]retry_group_upgrade failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]retry_group_upgrade failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -715,7 +721,8 @@ class GetCascadeStatusStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]get_cascade_status failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]get_cascade_status failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -1004,7 +1011,8 @@ class AbortMigrationStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]abort_migration failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]abort_migration failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -1099,7 +1107,8 @@ class GetMigrationStatusStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]get_migration_status failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]get_migration_status failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -1405,7 +1414,8 @@ class ResyncContextStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]resync_context failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]resync_context failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -1507,7 +1517,8 @@ class ListApplicationVersionsStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]list_application_versions failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]list_application_versions failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -852,7 +852,8 @@ class AssertCascadeCompleteStep(BaseStep):
                 self._report_expected_failure(str(e))
                 return True
             console.print(
-                f"[red]assert_cascade_complete: failed to reach {node_name}: {e}[/red]"
+                f"[red]assert_cascade_complete: failed to reach {node_name}: "
+                f"{escape(str(e))}[/red]"
             )
             return False
 
@@ -1233,7 +1234,8 @@ class AssertMigrationCompleteStep(BaseStep):
                 self._report_expected_failure(str(e))
                 return True
             console.print(
-                f"[red]assert_migration_complete: failed to reach {node_name}: {e}[/red]"
+                f"[red]assert_migration_complete: failed to reach {node_name}: "
+                f"{escape(str(e))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/install.py
+++ b/merobox/commands/bootstrap/steps/install.py
@@ -6,6 +6,8 @@ import os
 import shutil
 from typing import Any, Optional
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.constants import CONTAINER_DATA_DIR_PATTERNS, DEFAULT_METADATA
@@ -209,9 +211,10 @@ class InstallApplicationStep(BaseStep):
             import traceback
 
             console.print(
-                f"[red]Exception during install_application: {type(e).__name__}: {e}[/red]"
+                f"[red]Exception during install_application: "
+                f"{type(e).__name__}: {escape(str(e))}[/red]"
             )
-            console.print(f"[dim]{traceback.format_exc()}[/dim]")
+            console.print(f"[dim]{escape(traceback.format_exc())}[/dim]")
             result = fail(f"install_application failed: {e}", error=e)
 
         # Log detailed API response

--- a/merobox/commands/bootstrap/steps/invite_open.py
+++ b/merobox/commands/bootstrap/steps/invite_open.py
@@ -8,6 +8,8 @@ Step types 'invite', 'invite_open', and 'invite_identity' all route here.
 import json as json_lib
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.identity import create_namespace_invitation_via_admin_api
 from merobox.commands.utils import console
@@ -99,9 +101,10 @@ class InviteOpenStep(BaseStep):
             if expected_failure:
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
-            console.print(f"  Error: {result.get('error')}")
+            console.print(f"  Error: {escape(str(result.get('error')))}")
             console.print(
-                f"[red]Namespace invitation creation failed: {result.get('error', 'Unknown error')}[/red]"
+                f"[red]Namespace invitation creation failed: "
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/join.py
+++ b/merobox/commands/bootstrap/steps/join.py
@@ -8,6 +8,8 @@ Step types 'join' and 'join_open' route here as deprecated aliases.
 import json as json_lib
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.join import join_namespace_via_admin_api
 from merobox.commands.utils import console
@@ -106,7 +108,9 @@ class JoinNamespaceStep(BaseStep):
             invitation_json,
             node_name=client_node_name,
         )
-        console.print(f"[blue]Join namespace function returned: {result}[/blue]")
+        console.print(
+            f"[blue]Join namespace function returned: {escape(str(result))}[/blue]"
+        )
 
         console.print(f"[cyan]🔍 Join Namespace API Response for {node_name}:[/cyan]")
         console.print(f"  Success: {result.get('success')}")
@@ -122,7 +126,7 @@ class JoinNamespaceStep(BaseStep):
             console.print(f"  Data: {data}")
 
         if not result.get("success"):
-            console.print(f"  Error: {result.get('error')}")
+            console.print(f"  Error: {escape(str(result.get('error')))}")
 
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
@@ -136,7 +140,8 @@ class JoinNamespaceStep(BaseStep):
             return True
         else:
             console.print(
-                f"[red]Join namespace failed: {result.get('error', 'Unknown error')}[/red]"
+                f"[red]Join namespace failed: "
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/join_context.py
+++ b/merobox/commands/bootstrap/steps/join_context.py
@@ -57,7 +57,7 @@ class JoinContextStep(BaseStep):
             api_result = client.join_context(context_id=context_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("join_context failed", error=e)
+            result = fail(f"join_context failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/join_context.py
+++ b/merobox/commands/bootstrap/steps/join_context.py
@@ -4,6 +4,8 @@ Join context step executor (via group membership).
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -99,7 +101,7 @@ class JoinContextStep(BaseStep):
                 return True
             console.print(
                 f"[red]Join context failed on {node_name}: "
-                f"{result.get('error', 'Unknown error')}[/red]"
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False

--- a/merobox/commands/bootstrap/steps/join_subgroup_inheritance.py
+++ b/merobox/commands/bootstrap/steps/join_subgroup_inheritance.py
@@ -11,6 +11,8 @@ context — the workflow-level equivalent of the explicit-invite
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -132,7 +134,7 @@ class JoinSubgroupInheritanceStep(BaseStep):
                 return True
             console.print(
                 f"[red]join_subgroup_inheritance failed on {node_name}: "
-                f"{result.get('error', 'Unknown error')}[/red]"
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False

--- a/merobox/commands/bootstrap/steps/join_subgroup_inheritance.py
+++ b/merobox/commands/bootstrap/steps/join_subgroup_inheritance.py
@@ -83,7 +83,7 @@ class JoinSubgroupInheritanceStep(BaseStep):
             api_result = method(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("join_subgroup_inheritance failed", error=e)
+            result = fail(f"join_subgroup_inheritance failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/login.py
+++ b/merobox/commands/bootstrap/steps/login.py
@@ -13,6 +13,8 @@ with no chicken-and-egg.
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.auth import AuthenticationError, AuthManager
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.utils import console
@@ -83,17 +85,21 @@ class LoginStep(BaseStep):
                 if self._is_connectivity_error(str(e)):
                     console.print(
                         f"[red]❌ Expected an auth rejection but hit a "
-                        f"connectivity error for {node_name}: {e}[/red]"
+                        f"connectivity error for {node_name}: {escape(str(e))}[/red]"
                     )
                     return False
                 self._report_expected_failure(str(e))
                 return True
-            console.print(f"[red]❌ Login failed for {node_name}: {e}[/red]")
+            console.print(
+                f"[red]❌ Login failed for {node_name}: {escape(str(e))}[/red]"
+            )
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False
         except Exception as e:
             # An unexpected exception is never proof of an auth rejection.
-            console.print(f"[red]❌ Login error for {node_name}: {e}[/red]")
+            console.print(
+                f"[red]❌ Login error for {node_name}: {escape(str(e))}[/red]"
+            )
             return False
 
         if expected_failure:

--- a/merobox/commands/bootstrap/steps/mesh.py
+++ b/merobox/commands/bootstrap/steps/mesh.py
@@ -14,6 +14,8 @@ import os
 import shutil
 from typing import Any, Optional
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.constants import CONTAINER_DATA_DIR_PATTERNS, DEFAULT_METADATA
@@ -241,7 +243,8 @@ class CreateMeshStep(BaseStep):
 
         if not namespace_result.get("success"):
             console.print(
-                f"[red]Namespace creation failed: {namespace_result.get('error', 'Unknown error')}[/red]"
+                f"[red]Namespace creation failed: "
+                f"{escape(str(namespace_result.get('error', 'Unknown error')))}[/red]"
             )
             return False
 
@@ -273,7 +276,8 @@ class CreateMeshStep(BaseStep):
 
         if not context_result.get("success"):
             console.print(
-                f"[red]Context creation failed: {context_result.get('error', 'Unknown error')}[/red]"
+                f"[red]Context creation failed: "
+                f"{escape(str(context_result.get('error', 'Unknown error')))}[/red]"
             )
             return False
 
@@ -394,7 +398,8 @@ class CreateMeshStep(BaseStep):
 
             if not identity_result.get("success"):
                 console.print(
-                    f"[red]Identity creation failed for {node_name}: {identity_result.get('error', 'Unknown error')}[/red]"
+                    f"[red]Identity creation failed for {node_name}: "
+                    f"{escape(str(identity_result.get('error', 'Unknown error')))}[/red]"
                 )
                 return False
 
@@ -464,7 +469,8 @@ class CreateMeshStep(BaseStep):
 
             if not invite_result.get("success"):
                 console.print(
-                    f"[red]Namespace invitation failed for {node_name}: {invite_result.get('error', 'Unknown error')}[/red]"
+                    f"[red]Namespace invitation failed for {node_name}: "
+                    f"{escape(str(invite_result.get('error', 'Unknown error')))}[/red]"
                 )
                 return False
 
@@ -505,7 +511,8 @@ class CreateMeshStep(BaseStep):
 
             if not join_result.get("success"):
                 console.print(
-                    f"[red]Join namespace failed for {node_name}: {join_result.get('error', 'Unknown error')}[/red]"
+                    f"[red]Join namespace failed for {node_name}: "
+                    f"{escape(str(join_result.get('error', 'Unknown error')))}[/red]"
                 )
                 return False
 

--- a/merobox/commands/bootstrap/steps/mesh.py
+++ b/merobox/commands/bootstrap/steps/mesh.py
@@ -180,7 +180,8 @@ class CreateMeshStep(BaseStep):
             return True
         except Exception as e:
             console.print(
-                f"  [yellow]\u26a0\ufe0f Failed to pre-install app on {node_name}: {e}[/yellow]"
+                f"  [yellow]\u26a0\ufe0f Failed to pre-install app on {node_name}: "
+                f"{escape(str(e))}[/yellow]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/mesh.py
+++ b/merobox/commands/bootstrap/steps/mesh.py
@@ -237,7 +237,7 @@ class CreateMeshStep(BaseStep):
                     )
                 )
         except Exception as e:
-            namespace_result = fail("create_namespace failed", error=e)
+            namespace_result = fail(f"create_namespace failed: {e}", error=e)
 
         if not namespace_result.get("success"):
             console.print(
@@ -269,7 +269,7 @@ class CreateMeshStep(BaseStep):
             api_result = client.create_context(**context_kwargs)
             context_result = ok(api_result)
         except Exception as e:
-            context_result = fail("create_context failed", error=e)
+            context_result = fail(f"create_context failed: {e}", error=e)
 
         if not context_result.get("success"):
             console.print(

--- a/merobox/commands/bootstrap/steps/namespace.py
+++ b/merobox/commands/bootstrap/steps/namespace.py
@@ -43,7 +43,7 @@ class ListNamespacesStep(BaseStep):
                 # Backward compatibility for older client versions.
                 result = ok(client.list_groups())
         except Exception as e:
-            result = fail("list_namespaces failed", error=e)
+            result = fail(f"list_namespaces failed: {e}", error=e)
 
         if not result["success"]:
             console.print(
@@ -104,7 +104,7 @@ class GetNamespaceIdentityStep(BaseStep):
                     "get_namespace_identity is not available in current client"
                 )
         except Exception as e:
-            result = fail("get_namespace_identity failed", error=e)
+            result = fail(f"get_namespace_identity failed: {e}", error=e)
 
         if not result["success"]:
             console.print(
@@ -227,7 +227,7 @@ class CreateGroupInNamespaceStep(BaseStep):
                         "create_group_in_namespace is not available in current client"
                     )
         except Exception as e:
-            result = fail("create_group_in_namespace failed", error=e)
+            result = fail(f"create_group_in_namespace failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -284,7 +284,7 @@ class ListNamespaceGroupsStep(BaseStep):
                 # Backward compatibility: best-effort fallback to generic group listing.
                 result = ok(client.list_groups())
         except Exception as e:
-            result = fail("list_namespace_groups failed", error=e)
+            result = fail(f"list_namespace_groups failed: {e}", error=e)
 
         if not result["success"]:
             console.print(

--- a/merobox/commands/bootstrap/steps/namespace.py
+++ b/merobox/commands/bootstrap/steps/namespace.py
@@ -5,6 +5,7 @@ Namespace-related workflow step executors.
 from typing import Any
 
 import requests
+from rich.markup import escape
 
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
@@ -47,7 +48,8 @@ class ListNamespacesStep(BaseStep):
 
         if not result["success"]:
             console.print(
-                f"[red]Failed to list namespaces on {node_name}: {result.get('error')}[/red]"
+                f"[red]Failed to list namespaces on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -108,7 +110,8 @@ class GetNamespaceIdentityStep(BaseStep):
 
         if not result["success"]:
             console.print(
-                f"[red]Failed to get namespace identity on {node_name}: {result.get('error')}[/red]"
+                f"[red]Failed to get namespace identity on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -236,7 +239,8 @@ class CreateGroupInNamespaceStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]Failed to create group in namespace on {node_name}: {result.get('error')}[/red]"
+                f"[red]Failed to create group in namespace on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -288,7 +292,8 @@ class ListNamespaceGroupsStep(BaseStep):
 
         if not result["success"]:
             console.print(
-                f"[red]Failed to list namespace groups on {node_name}: {result.get('error')}[/red]"
+                f"[red]Failed to list namespace groups on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/refresh.py
+++ b/merobox/commands/bootstrap/steps/refresh.py
@@ -9,6 +9,8 @@ working access token.
 
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.auth import AuthenticationError, AuthManager
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.utils import console
@@ -73,16 +75,20 @@ class RefreshStep(BaseStep):
                 if self._is_connectivity_error(str(e)):
                     console.print(
                         f"[red]❌ Expected a refresh rejection but hit a "
-                        f"connectivity error for {node_name}: {e}[/red]"
+                        f"connectivity error for {node_name}: {escape(str(e))}[/red]"
                     )
                     return False
                 self._report_expected_failure(str(e))
                 return True
-            console.print(f"[red]❌ Token refresh failed for {node_name}: {e}[/red]")
+            console.print(
+                f"[red]❌ Token refresh failed for {node_name}: {escape(str(e))}[/red]"
+            )
             return False
         except Exception as e:
             # An unexpected exception is never proof of a refresh rejection.
-            console.print(f"[red]❌ Token refresh error for {node_name}: {e}[/red]")
+            console.print(
+                f"[red]❌ Token refresh error for {node_name}: {escape(str(e))}[/red]"
+            )
             return False
 
         if expected_failure:

--- a/merobox/commands/bootstrap/steps/script.py
+++ b/merobox/commands/bootstrap/steps/script.py
@@ -289,7 +289,7 @@ class ScriptStep(BaseStep):
 
             if output.strip():
                 console.print("[cyan]Local script output:[/cyan]")
-                console.print(output)
+                console.print(output, markup=False)
 
             if completed.returncode != 0:
                 console.print(
@@ -484,7 +484,7 @@ class ScriptStep(BaseStep):
                 output = result.output.decode("utf-8", errors="replace")
                 if output.strip():
                     console.print("[cyan]Script output:[/cyan]")
-                    console.print(output)
+                    console.print(output, markup=False)
 
                 if result.exit_code != 0:
                     console.print(
@@ -612,7 +612,7 @@ class ScriptStep(BaseStep):
                             console.print(
                                 f"[cyan]Script output from {node_name}:[/cyan]"
                             )
-                            console.print(output)
+                            console.print(output, markup=False)
 
                         # Check exit code
                         if result.exit_code != 0:

--- a/merobox/commands/bootstrap/steps/subgroup.py
+++ b/merobox/commands/bootstrap/steps/subgroup.py
@@ -49,7 +49,7 @@ class ReparentGroupStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("reparent_group failed", error=e)
+            result = fail(f"reparent_group failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -107,7 +107,7 @@ class ListSubgroupsStep(BaseStep):
             api_result = client.list_subgroups(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
-            result = fail("list_subgroups failed", error=e)
+            result = fail(f"list_subgroups failed: {e}", error=e)
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
                 return False
@@ -173,7 +173,7 @@ class AddGroupMembersStep(BaseStep):
             )
             result = ok(api_result)
         except Exception as e:
-            result = fail("add_group_members failed", error=e)
+            result = fail(f"add_group_members failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/subgroup.py
+++ b/merobox/commands/bootstrap/steps/subgroup.py
@@ -5,6 +5,8 @@ Subgroup workflow step executors.
 import json
 from typing import Any
 
+from rich.markup import escape
+
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
@@ -58,7 +60,8 @@ class ReparentGroupStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]reparent_group failed on {node_name}: {result.get('error', 'Unknown error')}[/red]"
+                f"[red]reparent_group failed on {node_name}: "
+                f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
             )
             return False
 
@@ -118,7 +121,8 @@ class ListSubgroupsStep(BaseStep):
             )
             return True
         console.print(
-            f"[red]list_subgroups failed on {node_name}: {result.get('error', 'Unknown error')}[/red]"
+            f"[red]list_subgroups failed on {node_name}: "
+            f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
         )
         return False
 
@@ -182,7 +186,8 @@ class AddGroupMembersStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]Failed to add group members on {node_name}: {result.get('error')}[/red]"
+                f"[red]Failed to add group members on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/tee.py
+++ b/merobox/commands/bootstrap/steps/tee.py
@@ -24,6 +24,7 @@ import json
 from typing import Any
 
 import requests
+from rich.markup import escape
 
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.constants import (
@@ -162,7 +163,7 @@ class SetTeeAdmissionPolicyStep(BaseStep):
                 return True
             console.print(
                 f"[red]set_tee_admission_policy failed on {node_name}: "
-                f"{result.get('error')}[/red]"
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 
@@ -245,7 +246,8 @@ class TeeFleetJoinStep(BaseStep):
                 self._report_expected_failure(str(result.get("error", "Unknown error")))
                 return True
             console.print(
-                f"[red]tee_fleet_join failed on {node_name}: {result.get('error')}[/red]"
+                f"[red]tee_fleet_join failed on {node_name}: "
+                f"{escape(str(result.get('error')))}[/red]"
             )
             return False
 

--- a/merobox/commands/bootstrap/steps/tee.py
+++ b/merobox/commands/bootstrap/steps/tee.py
@@ -152,7 +152,7 @@ class SetTeeAdmissionPolicyStep(BaseStep):
                 # readers always get a dict, not None.
                 result = ok(self._parse_json(response.text) or {})
         except Exception as e:
-            result = fail("set_tee_admission_policy failed", error=e)
+            result = fail(f"set_tee_admission_policy failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 
@@ -236,7 +236,7 @@ class TeeFleetJoinStep(BaseStep):
                 else:
                     result = ok(payload)
         except Exception as e:
-            result = fail("tee_fleet_join failed", error=e)
+            result = fail(f"tee_fleet_join failed: {e}", error=e)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -18,6 +18,7 @@ import asyncio
 from typing import Any, Optional
 
 import aiohttp
+from rich.markup import escape
 
 from merobox.commands.auth import AuthManager
 from merobox.commands.bootstrap.steps.base import BaseStep
@@ -122,12 +123,16 @@ class WebSocketConnectStep(BaseStep):
                     f"{node_name} handshake returned HTTP {e.status}[/red]"
                 )
                 return False
-            console.print(f"[red]❌ WebSocket connect to {node_name} failed: {e}[/red]")
+            console.print(
+                f"[red]❌ WebSocket connect to {node_name} failed: {escape(str(e))}[/red]"
+            )
             return False
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             # Connection refused / reset / timeout doesn't prove an auth
             # rejection, so it never satisfies expected_failure.
-            console.print(f"[red]❌ WebSocket connect to {node_name} error: {e}[/red]")
+            console.print(
+                f"[red]❌ WebSocket connect to {node_name} error: {escape(str(e))}[/red]"
+            )
             return False
 
         if expected_failure:

--- a/merobox/commands/identity.py
+++ b/merobox/commands/identity.py
@@ -6,6 +6,7 @@ import sys
 
 import click
 from rich import box
+from rich.markup import escape
 from rich.table import Table
 
 from merobox.commands.client import get_client_for_rpc_url
@@ -64,7 +65,7 @@ async def list_identities_via_admin_api(
         result = client.list_identities(context_id)
         return ok(result)
     except Exception as e:
-        return fail("list_identities failed", error=e)
+        return fail(f"list_identities failed: {e}", error=e)
 
 
 @with_retry(config=NETWORK_RETRY_CONFIG)
@@ -118,7 +119,7 @@ async def create_namespace_invitation_via_admin_api(
             result = client.create_group_invitation(namespace_id)
         return ok(result)
     except Exception as e:
-        return fail("create_namespace_invitation failed", error=e)
+        return fail(f"create_namespace_invitation failed: {e}", error=e)
 
 
 # Deprecated alias kept for backward compatibility.
@@ -160,7 +161,7 @@ def list_identities(node, context_id, verbose):
             )
             if verbose:
                 console.print("\n[bold]Response structure:[/bold]")
-                console.print(f"{result}")
+                console.print(f"{escape(str(result))}")
             return
 
         console.print(f"\n[green]Found {len(identities_data)} identity(ies):[/green]")
@@ -171,11 +172,13 @@ def list_identities(node, context_id, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
     else:
         console.print("\n[red]✗ Failed to list identities[/red]")
-        console.print(f"[red]Error: {result.get('error', 'Unknown error')}[/red]")
+        console.print(
+            f"[red]Error: {escape(str(result.get('error', 'Unknown error')))}[/red]"
+        )
         sys.exit(1)
 
 
@@ -281,11 +284,13 @@ def invite_group(node, group_id, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
     else:
         console.print("\n[red]✗ Failed to create group invitation[/red]")
-        console.print(f"[red]Error: {result.get('error', 'Unknown error')}[/red]")
+        console.print(
+            f"[red]Error: {escape(str(result.get('error', 'Unknown error')))}[/red]"
+        )
 
         if "errors" in result:
             console.print("\n[yellow]Detailed errors:[/yellow]")
@@ -294,7 +299,7 @@ def invite_group(node, group_id, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
         sys.exit(1)
 

--- a/merobox/commands/identity.py
+++ b/merobox/commands/identity.py
@@ -84,9 +84,9 @@ async def generate_identity_via_admin_api(rpc_url: str, node_name: str = None) -
         import traceback
 
         console.print(
-            f"[red]Exception in generate_identity: {type(e).__name__}: {e}[/red]"
+            f"[red]Exception in generate_identity: {type(e).__name__}: {escape(str(e))}[/red]"
         )
-        console.print(f"[dim]{traceback.format_exc()}[/dim]")
+        console.print(f"[dim]{escape(traceback.format_exc())}[/dim]")
         return fail(f"generate_context_identity failed: {e}", error=e)
 
 

--- a/merobox/commands/join.py
+++ b/merobox/commands/join.py
@@ -10,6 +10,7 @@ import sys
 
 import click
 from rich import box
+from rich.markup import escape
 from rich.table import Table
 
 from merobox.commands.client import get_client_for_rpc_url
@@ -78,7 +79,7 @@ async def join_namespace_via_admin_api(
             result = client.join_group(invitation_json=invitation_json)
         return ok(result)
     except Exception as e:
-        return fail("join_namespace failed", error=e)
+        return fail(f"join_namespace failed: {e}", error=e)
 
 
 # Deprecated alias kept for backward compatibility.
@@ -103,7 +104,7 @@ async def join_context_via_admin_api(
         result = client.join_context(context_id=context_id)
         return ok(result)
     except Exception as e:
-        return fail("join_context failed", error=e)
+        return fail(f"join_context failed: {e}", error=e)
 
 
 @click.group()
@@ -156,11 +157,13 @@ def join_namespace_cmd(node, namespace_id, invitation, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
     else:
         console.print("\n[red]✗ Failed to join namespace[/red]")
-        console.print(f"[red]Error: {result.get('error', 'Unknown error')}[/red]")
+        console.print(
+            f"[red]Error: {escape(str(result.get('error', 'Unknown error')))}[/red]"
+        )
 
         if "errors" in result:
             console.print("\n[yellow]Detailed errors:[/yellow]")
@@ -169,7 +172,7 @@ def join_namespace_cmd(node, namespace_id, invitation, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
         sys.exit(1)
 
@@ -211,11 +214,13 @@ def join_context_cmd(node, context_id, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
     else:
         console.print("\n[red]✗ Failed to join context[/red]")
-        console.print(f"[red]Error: {result.get('error', 'Unknown error')}[/red]")
+        console.print(
+            f"[red]Error: {escape(str(result.get('error', 'Unknown error')))}[/red]"
+        )
 
         if "errors" in result:
             console.print("\n[yellow]Detailed errors:[/yellow]")
@@ -224,7 +229,7 @@ def join_context_cmd(node, context_id, verbose):
 
         if verbose:
             console.print("\n[bold]Full response:[/bold]")
-            console.print(f"{result}")
+            console.print(f"{escape(str(result))}")
 
         sys.exit(1)
 

--- a/merobox/commands/logs.py
+++ b/merobox/commands/logs.py
@@ -36,7 +36,7 @@ def logs(node_name, tail, follow, no_docker):
                 )
                 return
             console.print(f"\n[bold]Logs for {node_name}:[/bold]")
-            console.print(content)
+            console.print(content, markup=False)
     else:
         calimero_manager = DockerManager()
         calimero_manager.get_node_logs(node_name, tail)

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -877,7 +877,7 @@ class DockerManager(CleanupMixin):
                 container.remove()
                 console.print(f"[red]✗ Node {node_name} failed to start[/red]")
                 console.print("[yellow]Container logs:[/yellow]")
-                console.print(logs)
+                console.print(logs, markup=False)
 
                 # Check for common issues
                 if "GLIBC" in logs:
@@ -2237,7 +2237,7 @@ class DockerManager(CleanupMixin):
 
             logs = container.logs(tail=tail, timestamps=True).decode("utf-8")
             console.print(f"\n[bold]Logs for {node_name}:[/bold]")
-            console.print(logs)
+            console.print(logs, markup=False)
 
         except Exception as e:
             console.print(f"[red]Failed to get logs for {node_name}: {str(e)}[/red]")

--- a/merobox/tests/unit/test_error_reporting_defects.py
+++ b/merobox/tests/unit/test_error_reporting_defects.py
@@ -1,0 +1,121 @@
+"""Regression tests for two error-reporting defects fixed on this branch.
+
+Defect 1: step failure handlers folded a fixed string like "X failed" into
+fail(), discarding the real exception text that fail() had already captured
+in result["exception"]. Fixed by folding the exception message into the
+fail() call itself, so it reaches console output instead of a generic label.
+
+Defect 2: raw node/log output and error-message interpolations reached
+console.print() calls wrapped in Rich markup tags without escaping. Text
+containing square brackets (a multiaddr list is the common case) made Rich
+raise MarkupError instead of printing the diagnosis. Fixed by markup=False
+at raw-output sites and rich.markup.escape() at interpolation sites.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.bootstrap.steps.group_create import CreateNamespaceStep
+
+MULTIADDR_LIST = "[/ip4/127.0.0.1/tcp/2428, /ip4/10.0.0.5/tcp/2428]"
+
+
+def _unwrapped(captured_out: str) -> str:
+    """Undo Rich's terminal-width line wrapping so substring checks don't
+    depend on the console width the test happens to run under."""
+    return captured_out.replace("\n", "")
+
+
+def _run(coro):
+    # See test_assert_log_step.py: asyncio.run() clears the event loop on
+    # exit, which breaks other test files' asyncio.get_event_loop() usage.
+    try:
+        return asyncio.run(coro)
+    finally:
+        try:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+        except Exception:
+            pass
+
+
+def _exec_create_namespace(exc):
+    """Drive CreateNamespaceStep through a failing create_namespace call."""
+    step = CreateNamespaceStep(
+        {
+            "type": "create_namespace",
+            "name": "t",
+            "node": "n1",
+            "application_id": "app",
+        }
+    )
+    mock_client = MagicMock()
+    mock_client.create_namespace.side_effect = exc
+    with (
+        patch.object(
+            step,
+            "_resolve_node_for_client",
+            return_value=("http://localhost:1234", "n1"),
+        ),
+        patch(
+            "merobox.commands.bootstrap.steps.group_create.get_client_for_rpc_url",
+            return_value=mock_client,
+        ),
+        patch.object(step, "_print_node_logs_on_failure"),
+    ):
+        return _run(step.execute({}, {}))
+
+
+class TestExceptionSurfacing:
+    """A step's failure handler must print the real exception message, not
+    a fixed label. Reverting the fix (fail("create_namespace failed", ...)
+    instead of fail(f"create_namespace failed: {e}", ...)) drops the
+    distinctive message from result["error"] and from the printed line."""
+
+    def test_real_exception_message_reaches_output(self, capsys):
+        result = _exec_create_namespace(RuntimeError("distinctive_boom_xyz_789"))
+        assert result is False
+        combined = _unwrapped(capsys.readouterr().out)
+        assert "distinctive_boom_xyz_789" in combined
+
+
+class TestMarkupSafety:
+    """Text containing square brackets must reach the terminal unmangled
+    instead of crashing Rich's markup parser."""
+
+    def test_exception_message_with_multiaddr_list_does_not_crash(self, capsys):
+        """Covers the escape()-wrapped interpolation site in
+        CreateNamespaceStep's failure branch (defect 2, escaped-interpolation
+        shape)."""
+        result = _exec_create_namespace(
+            RuntimeError(f"connection failed: {MULTIADDR_LIST}")
+        )
+        assert result is False
+        combined = _unwrapped(capsys.readouterr().out)
+        assert MULTIADDR_LIST in combined
+
+    def test_raw_node_log_output_with_brackets_does_not_crash(self, capsys):
+        """Covers the raw console.print(..., markup=False) site in
+        BaseStep._print_node_logs_on_failure (defect 2, raw-output shape)."""
+        manager = MagicMock()
+        manager.binary_path = "/usr/local/bin/merod"
+        manager.get_node_logs.return_value = f"listening on {MULTIADDR_LIST}\n"
+        step = BaseStep({"name": "t"}, manager=manager)
+
+        step._print_node_logs_on_failure(node_name="node-1", lines=10)
+
+        combined = _unwrapped(capsys.readouterr().out)
+        assert MULTIADDR_LIST in combined
+
+
+class TestReportExpectedFailureEscaping:
+    """base.py's _report_expected_failure() is the single choke point every
+    step inherits its markup-safety from on the expected-failure path - the
+    widest-surface fix on this branch."""
+
+    def test_message_with_brackets_prints_intact(self, capsys):
+        step = BaseStep({"name": "t"})
+        step._report_expected_failure(f"context does not belong: {MULTIADDR_LIST}")
+
+        combined = _unwrapped(capsys.readouterr().out)
+        assert MULTIADDR_LIST in combined


### PR DESCRIPTION
## Summary

Two error-reporting defects made a recent CI failure take far longer to diagnose than it should have.

- **Discarded exceptions**: step failure handlers called `fail("X failed", error=e)` and then only ever printed the fixed `"X failed"` string, even though `fail()` had already captured the real exception text in `result["exception"]`. Fixed by folding the exception message into the `fail()` call (`fail(f"X failed: {e}", error=e)`) at every bootstrap step site with this shape, so the actual cause reaches console output instead of a generic label. This also covers admin-API helper functions one layer below the steps - `create_namespace_invitation_via_admin_api` and `list_identities_via_admin_api` in `commands/identity.py`, and `join_namespace_via_admin_api` and `join_context_via_admin_api` in `commands/join.py` - which several steps (`invite_open`, `join`, `mesh`) and CLI commands route through. Left untouched on purpose: `register_group_signing_key` redacts exception details deliberately (the message can contain key material), and several `group_management.py` steps already resolved the real exception message at print time through a different but equivalent pattern.
- **Rich markup crash on untrusted text**: many places passed raw, untrusted text - node log tails, script/command output, and (once the fix above stopped discarding it) exception and traceback text - straight into `console.print()` with Rich markup parsing left on. Text containing square brackets, such as a multiaddr list or an error message that quotes one, gets parsed as a malformed markup tag and crashes with `closing tag '[...]' doesn't match any open tag`, replacing a real diagnosis with a traceback. Raw log/output dumps are now printed with `markup=False`. Exception text and tracebacks that get interpolated into `[red]...[/red]` / `[yellow]...[/yellow]` messages throughout `bootstrap/` are now escaped with `rich.markup.escape()` at the point of interpolation, keeping the surrounding color tags intact. `_report_expected_failure()` in `base.py` escapes once, covering the "expected failure" branch for every step that calls it. CLI-only, filesystem and config-path messages outside `bootstrap/` (`config_utils.py`, `auth.py`, `binary_manager.py`, `remote.py`, `remote_nodes.py`, `node_resolver.py`) were left alone - they don't carry node or API output.

## Test plan

- `make format-check` (black --check, ruff check) - passed
- `pytest merobox/tests/unit` (1192 tests) - all passed
- Added `merobox/tests/unit/test_error_reporting_defects.py` with regression tests that fail if either fix is reverted:
  - Exception surfacing: drives `CreateNamespaceStep.execute()` through a mocked client call raising an exception with a distinctive message and asserts that message reaches the printed output, not a fixed label.
  - Markup safety (raw output): feeds a multiaddr-bearing log tail through `BaseStep._print_node_logs_on_failure()`'s `console.print(..., markup=False)` site and asserts it prints intact instead of raising Rich's `MarkupError`.
  - Markup safety (escaped interpolation): exercises both `CreateNamespaceStep`'s failure branch and `base.py`'s `_report_expected_failure()` - the shared helper every step's expected-failure path routes through - with a bracket-bearing message and asserts it prints intact.
  - Each test was confirmed to fail with the pre-fix behavior (fixed-string `fail()`, missing `markup=False`, missing `escape()`) before being checked in against the fixed code.
- Verified completeness with `grep -rn 'console\.print(f"\[' merobox/commands/bootstrap/**/*.py merobox/commands/bootstrap/*.py | grep -E '\{e\}|format_exc\(\)' | grep -v "escape("` and a multi-line-aware equivalent scan, both returning 0 matches across `bootstrap/`.
