### PR TITLE
feat(bootstrap): assert WebSocket events with assert_ws_event

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -579,8 +579,8 @@ snake_case, so paths read `data.toVersion`, not `data.to_version`.
     data.toVersion: "2.0.0"
 ```
 
-`absent: true` inverts the verdict, for the guarantees that are about an event
-firing at most once or never:
+`absent: true` inverts the verdict, and `count: n` demands exactly `n`, for the
+guarantees that are about an event firing a fixed number of times or never:
 
 ```yaml
 - type: assert_ws_event
@@ -589,7 +589,21 @@ firing at most once or never:
   event: MigrationCompleted
   absent: true
   timeout_seconds: 15
+
+# Convergence announces itself once, and a duplicate is a regression.
+- type: assert_ws_event
+  node: calimero-node-2
+  group_id: "{{namespace_id}}"
+  event: MigrationCompleted
+  count: 1
+  timeout_seconds: 30
 ```
+
+`count` is counted over the bounded window, so it proves the event did not fire
+more than `count` times within `timeout_seconds`, not that it never fires again
+afterwards. It also always costs the whole window, since ruling out a further
+arrival means watching for one. `absent: true` is the same assertion as
+`count: 0`, and the two cannot be combined.
 
 A failure prints every event that did arrive, plus the per-path mismatch for
 any event of the right type that missed on a `match` value, so CI output alone

--- a/LLM.md
+++ b/LLM.md
@@ -550,6 +550,58 @@ Validate execution results.
     - 'json_subset({{result}}, {"key": "value"})'
 ```
 
+#### 9a. WebSocket Event Assertion Step (`assert_ws_event`)
+
+Subscribe to a group or namespace over `/ws` and gate on what the node pushes,
+rather than grepping logs for a line that a wrong answer never writes.
+
+The step watches for `timeout_seconds` and passes as soon as an event of type
+`event` satisfying `match` arrives.
+
+```yaml
+- type: assert_ws_event
+  node: calimero-node-2
+  group_id: "{{namespace_id}}"
+  event: MigrationStarted
+  timeout_seconds: 60
+```
+
+`match` is a subset test: unlisted fields are ignored, and each key is a dotted
+path into the delivered frame. The wire form is camelCase where the Rust is
+snake_case, so paths read `data.toVersion`, not `data.to_version`.
+
+```yaml
+- type: assert_ws_event
+  node: calimero-node-2
+  group_id: "{{namespace_id}}"
+  event: MigrationCompleted
+  match:
+    data.toVersion: "2.0.0"
+```
+
+`absent: true` inverts the verdict, for the guarantees that are about an event
+firing at most once or never:
+
+```yaml
+- type: assert_ws_event
+  node: calimero-node-2
+  group_id: "{{namespace_id}}"
+  event: MigrationCompleted
+  absent: true
+  timeout_seconds: 15
+```
+
+A failure prints every event that did arrive, plus the per-path mismatch for
+any event of the right type that missed on a `match` value, so CI output alone
+is enough to tell "nothing happened" from "the wrong thing happened".
+
+Two properties of the transport to plan around. A subscription observes only
+events emitted after it lands and the stream has no replay, so point the step
+at a node that learns of the change through sync rather than the one whose own
+step triggered it. And `CascadeProgress` is admin-gated at subscribe time while
+the other migration events are member-visible, so a non-admin subscriber never
+receives it and `absent: true` on it would pass for the wrong reason.
+
 #### 10. Proposals
 
 Create and vote on proposals in a context.

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -131,6 +131,7 @@ VALID_STEP_TYPES = frozenset(
         "refresh",
         "ws_connect",
         "ws_subscribe",
+        "assert_ws_event",
     }
 )
 
@@ -399,6 +400,30 @@ class WebSocketConnectStepConfig(BaseStepConfig):
     )
     timeout: Optional[float] = Field(
         None, gt=0, description="Handshake timeout in seconds"
+    )
+
+
+class WebSocketEventAssertStepConfig(BaseStepConfig):
+    """Configuration for assert_ws_event step (WebSocket event assertion)."""
+
+    type: Literal["assert_ws_event"] = "assert_ws_event"
+    node: str = Field(..., description="Node whose event stream is watched")
+    group_id: str = Field(..., description="Hex group or namespace id to subscribe to")
+    event: str = Field(
+        ..., description="Event type tag to wait for, e.g. MigrationStarted"
+    )
+    match: Optional[dict[str, Any]] = Field(
+        None,
+        description="Dotted paths into the event frame mapped to expected values",
+    )
+    absent: Optional[bool] = Field(
+        False, description="Assert the event must NOT arrive within the window"
+    )
+    timeout_seconds: Optional[float] = Field(
+        None, gt=0, description="Length of the watch window in seconds"
+    )
+    token: Optional[str] = Field(
+        None, description="Explicit JWT to attach (overrides the cached token)"
     )
 
 
@@ -1658,6 +1683,7 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "refresh": RefreshStepConfig,
     "ws_connect": WebSocketConnectStepConfig,
     "ws_subscribe": WebSocketConnectStepConfig,
+    "assert_ws_event": WebSocketEventAssertStepConfig,
     "wait": WaitStep,
     "wait_for_sync": WaitForSyncStep,
     "repeat": RepeatStep,

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -419,6 +419,11 @@ class WebSocketEventAssertStepConfig(BaseStepConfig):
     absent: Optional[bool] = Field(
         False, description="Assert the event must NOT arrive within the window"
     )
+    count: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Assert exactly this many arrive (mutually exclusive with absent)",
+    )
     timeout_seconds: Optional[float] = Field(
         None, gt=0, description="Length of the watch window in seconds"
     )

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -2166,6 +2166,12 @@ class WorkflowExecutor:
             )
 
             return WebSocketConnectStep(step_config, **common_kwargs)
+        elif step_type == "assert_ws_event":
+            from merobox.commands.bootstrap.steps.websocket import (
+                WebSocketEventAssertStep,
+            )
+
+            return WebSocketEventAssertStep(step_config, **common_kwargs)
         elif step_type == "wait":
             return WaitStep(step_config, **common_kwargs)
         elif step_type == "wait_for_sync":

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -146,10 +146,25 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     documented fail-fast would silently degrade to a poll-to-timeout. `total`
     falls back to the member count only when the rollup omits it entirely (an
     explicit `0` cohort is preserved).
+
+    `fleet_completed_at` and `cohort_pinned_at_hlc` are the two top-level
+    optionals, passed through as `None` when the response omits them.
+    `fleet_completed_at` is the durable answer to "did this fleet ever
+    converge": `all_migrated` is recomputed from in-TTL heartbeats and lapses
+    when a converged member goes quiet, while the timestamp does not follow it
+    back down. Absent must therefore stay distinguishable from `0`, so neither
+    goes through `_as_int`.
+
+    The summary is an allowlist, which silently drops anything core adds later.
+    The per-member rows are deliberately narrowed to `peer`, `state`, and
+    `migration_failed`; the rest of each member's report (`schema_version`,
+    `residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`) is
+    reachable only by widening that loop.
     """
-    rollup = response.get("rollup") if isinstance(response, dict) else None
+    source = response if isinstance(response, dict) else {}
+    rollup = source.get("rollup")
     rollup = rollup if isinstance(rollup, dict) else {}
-    raw_members = response.get("members") if isinstance(response, dict) else None
+    raw_members = source.get("members")
     raw_members = raw_members if isinstance(raw_members, list) else []
 
     members: list[dict[str, Any]] = []
@@ -187,12 +202,15 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     failed = max(_as_int(rollup.get("failed")), members_failed)
 
     return {
-        "target_version": (
-            response.get("targetVersion") if isinstance(response, dict) else None
-        ),
-        "expected_members": (
-            response.get("expectedMembers") if isinstance(response, dict) else None
-        ),
+        "target_version": source.get("targetVersion"),
+        "expected_members": source.get("expectedMembers"),
+        # Both are omitted from the response rather than sent null, and both
+        # have a meaningful zero, so they pass through untouched: coercing an
+        # absent key to 0 would claim the fleet converged at the epoch, and
+        # coercing it to a falsy default would lose the difference from a
+        # namespace that genuinely has not converged.
+        "fleet_completed_at": source.get("fleetCompletedAt"),
+        "cohort_pinned_at_hlc": source.get("cohortPinnedAtHlc"),
         "total": total,
         "migrated": _as_int(rollup.get("migrated")),
         "in_progress": _as_int(rollup.get("inProgress")),

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -185,9 +185,10 @@ class WebSocketConnectStep(_WebSocketStepBase):
 class WebSocketEventAssertStep(_WebSocketStepBase):
     """Subscribe to a group's event stream and assert what arrives on it.
 
-    Watches the stream for ``timeout_seconds``. The positive form passes as soon
-    as an event of type ``event`` satisfying ``match`` arrives; ``absent: true``
-    inverts the verdict, passing only if the window elapses without one.
+    Watches the stream for ``timeout_seconds``. The default form passes as soon
+    as an event of type ``event`` satisfying ``match`` arrives. ``absent: true``
+    inverts the verdict, passing only if the window elapses without one, and
+    ``count: n`` demands exactly ``n``.
 
     Required fields: ``node``, ``group_id``, ``event``.
 
@@ -197,10 +198,17 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
       wire frame, which is camelCase where the Rust is snake_case:
       ``groupId``, ``data.toVersion``, ``data.toStateVersion``.
     - ``absent`` (bool): assert the event must NOT arrive.
+    - ``count`` (int): assert exactly this many arrive. Mutually exclusive with
+      ``absent``, which is the same assertion for ``count: 0``.
     - ``timeout_seconds`` (number): window length, default ``30``.
     - ``token`` (str): explicit JWT (supports ``{{placeholders}}``); otherwise
       the token a prior ``login`` cached for the node, or none at all on a node
       running without auth.
+
+    ``count`` is counted over the bounded window, so it proves the event did not
+    fire more than ``count`` times within ``timeout_seconds``, not that it never
+    fires again afterwards. Establishing the count also costs the whole window,
+    since a further arrival can only be ruled out by watching for one.
 
     Two properties of the transport a workflow author has to plan around:
 
@@ -225,6 +233,14 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         self._validate_string_field("event")
         self._validate_string_field("token", required=False)
         self._validate_boolean_field("absent", required=False)
+        self._validate_integer_field("count", required=False, non_negative=True)
+        # Both express an expected number of arrivals, so a config carrying two
+        # of them has no single answer to honour.
+        if self.config.get("count") is not None and self.config.get("absent"):
+            raise ValueError(
+                f"Step '{self._get_step_name()}': 'count' and 'absent' are "
+                f"mutually exclusive ('absent: true' is 'count: 0')"
+            )
         self._validate_number_field("timeout_seconds", required=False, positive=True)
         timeout = self.config.get("timeout_seconds")
         # NaN/inf survive the positive check but leave the deadline non-finite,
@@ -252,7 +268,14 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         event_type = self._resolve_dynamic_value(
             self.config["event"], workflow_results, dynamic_values
         )
-        absent = bool(self.config.get("absent", False))
+        # How many matches the window must hold. `None` means "at least one",
+        # the default, which is also the only form that can stop at the first
+        # arrival; an exact count is only knowable at the end of the window.
+        required: int | None = None
+        if self.config.get("absent"):
+            required = 0
+        elif self.config.get("count") is not None:
+            required = int(self.config["count"])
         # `.get(key, default)` returns the default only when the key is ABSENT;
         # an explicit `timeout_seconds: null` yields a present key with value
         # None, which float() would crash on.
@@ -281,59 +304,62 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         token = self._resolve_token(cache_node_name, workflow_results, dynamic_values)
         ws_url = self._build_ws_url(rpc_url, token)
 
+        wanted = (
+            f"at least one '{event_type}'"
+            if required is None
+            else f"exactly {required} '{event_type}'"
+        )
         console.print(
-            f"[blue]⏳ Watching {node_name} for {'no ' if absent else ''}"
-            f"'{event_type}' on group {group_id} "
+            f"[blue]⏳ Watching {node_name} for {wanted} on group {group_id} "
             f"(timeout {timeout_seconds:g}s)[/blue]"
         )
 
-        matched, received, blocker = await self._watch(
-            ws_url, group_id, event_type, match_spec, timeout_seconds
+        matches, received, blocker = await self._watch(
+            ws_url, group_id, event_type, match_spec, timeout_seconds, required
         )
 
         if blocker is not None:
-            # The window was never observed, so neither verdict was tested. An
-            # unobserved window is not an absent event, so `absent` fails here
-            # too rather than passing vacuously.
+            # The window was never observed, so no verdict was tested. An
+            # unobserved window is not an absent event, so the `absent` and
+            # `count` forms fail here too rather than passing vacuously.
             console.print(
                 f"✗ assert_ws_event on {node_name}: {blocker}",
                 style="red",
                 markup=False,
             )
-            self._report_received(received, event_type, match_spec)
+            self._report_received(received, event_type, match_spec, matches)
             return False
 
-        if absent:
-            if matched is None:
+        satisfied = len(matches) >= 1 if required is None else len(matches) == required
+        if satisfied:
+            if matches:
+                workflow_results[f"ws_event_{node_name}"] = matches[0]
+            if required == 0:
                 console.print(
                     f"[green]✓ assert_ws_event: no '{event_type}' reached "
                     f"{node_name} for group {group_id} in {timeout_seconds:g}s "
                     f"({len(received)} other event(s) observed)[/green]"
                 )
-                return True
-            console.print(
-                f"✗ assert_ws_event on {node_name}: '{event_type}' was asserted "
-                f"absent but arrived: {json.dumps(matched, sort_keys=True)}",
-                style="red",
-                markup=False,
-            )
-            return False
-
-        if matched is not None:
-            workflow_results[f"ws_event_{node_name}"] = matched
-            console.print(
-                f"[green]✓ assert_ws_event: '{event_type}' arrived on {node_name} "
-                f"for group {group_id}[/green]"
-            )
+            elif required is None:
+                console.print(
+                    f"[green]✓ assert_ws_event: '{event_type}' arrived on "
+                    f"{node_name} for group {group_id}[/green]"
+                )
+            else:
+                console.print(
+                    f"[green]✓ assert_ws_event: exactly {required} "
+                    f"'{event_type}' arrived on {node_name} for group "
+                    f"{group_id} in {timeout_seconds:g}s[/green]"
+                )
             return True
 
         console.print(
-            f"✗ assert_ws_event on {node_name}: no '{event_type}' on group "
-            f"{group_id} matched within {timeout_seconds:g}s",
+            f"✗ assert_ws_event on {node_name}: expected {wanted} on group "
+            f"{group_id} within {timeout_seconds:g}s, but {len(matches)} arrived",
             style="red",
             markup=False,
         )
-        self._report_received(received, event_type, match_spec)
+        self._report_received(received, event_type, match_spec, matches)
         return False
 
     async def _watch(
@@ -343,16 +369,24 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         event_type: str,
         match_spec: dict[str, Any],
         timeout_seconds: float,
-    ) -> tuple[dict[str, Any] | None, list[dict[str, Any]], str | None]:
-        """Subscribe and collect frames until a match or the deadline.
+        required: int | None,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
+        """Subscribe and collect frames until the verdict is settled or the deadline.
 
-        Returns ``(matched_frame, received_frames, blocker)``. ``blocker`` is set
-        when the window could not be observed at all (a refused handshake, a
-        denied subscription, an early close) and invalidates both verdicts.
+        Returns ``(matching_frames, received_frames, blocker)``. ``blocker`` is
+        set when the window could not be observed at all (a refused handshake, a
+        denied subscription, an early close) and invalidates every verdict.
         The received frames come back on every path so a caller can report what
         actually arrived instead of only that the expectation went unmet.
+
+        One arrival past the ceiling settles the run early: for the default
+        "at least one" that is the success, and for an exact ``required`` it is
+        a failure no further watching can undo. An exact count that is still
+        reachable has to watch the whole window.
         """
         received: list[dict[str, Any]] = []
+        matches: list[dict[str, Any]] = []
+        stop_after = required if required is not None else 0
         deadline = time.monotonic() + timeout_seconds
 
         try:
@@ -365,7 +399,7 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                     )
                 except asyncio.TimeoutError:
                     return (
-                        None,
+                        matches,
                         received,
                         f"the handshake did not complete within {timeout_seconds:g}s",
                     )
@@ -394,7 +428,7 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                             break  # the window elapsed, the normal end
                         if msg.type is not aiohttp.WSMsgType.TEXT:
                             return (
-                                None,
+                                matches,
                                 received,
                                 f"the connection ended after "
                                 f"{timeout_seconds - max(remaining, 0.0):.1f}s "
@@ -415,7 +449,7 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                                 "groupIds"
                             ):
                                 return (
-                                    None,
+                                    matches,
                                     received,
                                     f"the node refused a subscription to group "
                                     f"{group_id} (not a member of it, or the id "
@@ -430,12 +464,15 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                         received.append(result)
                         if result.get("type") != event_type:
                             continue
-                        if not self._match_failures(result, match_spec):
-                            return result, received, None
+                        if self._match_failures(result, match_spec):
+                            continue
+                        matches.append(result)
+                        if len(matches) > stop_after:
+                            return matches, received, None
 
                     if not subscribed:
                         return (
-                            None,
+                            matches,
                             received,
                             "the subscription was never acknowledged, so the "
                             "window was not observed",
@@ -443,11 +480,11 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                 finally:
                     await ws.close()
         except (aiohttp.ClientError, OSError) as e:
-            return None, received, f"WebSocket error: {e}"
+            return matches, received, f"WebSocket error: {e}"
         except json.JSONDecodeError as e:
-            return None, received, f"the node sent a frame that is not JSON: {e}"
+            return matches, received, f"the node sent a frame that is not JSON: {e}"
 
-        return None, received, None
+        return matches, received, None
 
     def _match_failures(
         self, frame: dict[str, Any], match_spec: dict[str, Any]
@@ -465,11 +502,14 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         received: list[dict[str, Any]],
         event_type: str,
         match_spec: dict[str, Any],
+        matches: list[dict[str, Any]],
     ) -> None:
-        """Replay what actually arrived, with per-path mismatches for near misses.
+        """Replay what actually arrived, marking matches and near misses.
 
-        markup=False so event payloads containing ``[..]`` are not eaten as Rich
-        console tags.
+        Matching frames are marked rather than replayed separately, so a count
+        mismatch shows which arrivals were counted without printing the stream
+        twice. markup=False so event payloads containing ``[..]`` are not eaten
+        as Rich console tags.
         """
         if not received:
             console.print(
@@ -477,17 +517,24 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
             )
             return
         console.print(
-            f"  {len(received)} event(s) arrived on the subscription:",
+            f"  {len(received)} event(s) arrived on the subscription, "
+            f"{len(matches)} of them matching:",
             style="red",
             markup=False,
         )
+        # Identity, not equality: two matches can be equal frames, and each
+        # arrival counted separately toward `count`.
+        matched_ids = {id(frame) for frame in matches}
         for frame in received[:_MAX_REPORTED_FRAMES]:
+            marker = "match >" if id(frame) in matched_ids else "      "
             console.print(
-                f"    {json.dumps(frame, sort_keys=True)}", style="red", markup=False
+                f"    {marker} {json.dumps(frame, sort_keys=True)}",
+                style="red",
+                markup=False,
             )
             if match_spec and frame.get("type") == event_type:
                 for failure in self._match_failures(frame, match_spec):
-                    console.print(f"      match {failure}", style="red", markup=False)
+                    console.print(f"      {failure}", style="red", markup=False)
         if len(received) > _MAX_REPORTED_FRAMES:
             console.print(
                 f"    ... and {len(received) - _MAX_REPORTED_FRAMES} more",

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -405,19 +405,18 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         a failure no further watching can undo. An exact count that is still
         reachable has to watch the whole window.
 
-        The window starts when the subscription is acknowledged, not when the
-        step does: the stream delivers nothing before that, so counting the
-        handshake against ``timeout_seconds`` would hand `absent` a shorter
-        window than it asked for and call the shortfall evidence of absence.
-        The handshake is bounded separately by the same number, so the step
-        still terminates.
+        Each of the three phases gets ``timeout_seconds`` of its own: the
+        handshake, then the wait for the acknowledgement, then the watch. The
+        stream delivers nothing until the subscription lands, so charging the
+        handshake to the window would hand `absent` less time than it asked
+        for and count the shortfall as evidence of absence - and charging it to
+        the acknowledgement would report a slow connect as a node that never
+        acknowledged. Every phase is bounded, so the step still terminates.
         """
         received: list[dict[str, Any]] = []
         matches: list[dict[str, Any]] = []
         stop_after = required if required is not None else 0
-        # Bounds the wait for the acknowledgement; reset to the full window
-        # once it lands (see docstring).
-        deadline = time.monotonic() + timeout_seconds
+        deadline = 0.0
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -433,6 +432,11 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                         received,
                         f"the handshake did not complete within {timeout_seconds:g}s",
                     )
+                # Set here, not before the connect: a slow handshake would
+                # otherwise leave the acknowledgement no time to arrive and be
+                # reported as a node that never acknowledged. Reset again when
+                # it lands (see docstring).
+                deadline = time.monotonic() + timeout_seconds
 
                 try:
                     await ws.send_str(

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -404,10 +404,19 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         "at least one" that is the success, and for an exact ``required`` it is
         a failure no further watching can undo. An exact count that is still
         reachable has to watch the whole window.
+
+        The window starts when the subscription is acknowledged, not when the
+        step does: the stream delivers nothing before that, so counting the
+        handshake against ``timeout_seconds`` would hand `absent` a shorter
+        window than it asked for and call the shortfall evidence of absence.
+        The handshake is bounded separately by the same number, so the step
+        still terminates.
         """
         received: list[dict[str, Any]] = []
         matches: list[dict[str, Any]] = []
         stop_after = required if required is not None else 0
+        # Bounds the wait for the acknowledgement; reset to the full window
+        # once it lands (see docstring).
         deadline = time.monotonic() + timeout_seconds
 
         try:
@@ -484,6 +493,7 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                                     f"is wrong): {msg.data}",
                                 )
                             subscribed = True
+                            deadline = time.monotonic() + timeout_seconds
                             continue
 
                         result = frame.get("result")

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -1,21 +1,23 @@
 """
-WebSocket connect step executor for embedded-auth nodes.
+WebSocket step executors: handshake assertion and event assertion.
 
-Opens a WebSocket subscription against a node's ``/ws`` endpoint and asserts the
-handshake outcome. WebSocket clients cannot set custom headers, so the JWT is
-passed via the ``?token=<jwt>`` query param (mirroring
+Both talk to a node's ``/ws`` endpoint. WebSocket clients cannot set custom
+headers, so the JWT is passed via the ``?token=<jwt>`` query param (mirroring
 ``core/scripts/test-websocket-auth.sh``).
 
-Use it two ways:
-- Positive: with a valid cached token (seeded by a prior ``login`` step) the
-  connect must succeed.
-- Negative: ``unauthenticated: true`` forces a no-token connect; combine with
-  ``expected_failure: true`` to assert the server rejects it (HTTP 401 on the
-  upgrade handshake).
+``ws_connect`` asserts only the handshake outcome. ``assert_ws_event``
+subscribes to a group's event stream and asserts what does (or does not) arrive
+on it, which is the only way to gate on an event whose absence writes no log
+line to grep for.
 """
 
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Optional
+import json
+import math
+import time
+from typing import Any
 
 import aiohttp
 
@@ -26,8 +28,54 @@ from merobox.commands.utils import console
 
 WS_ENDPOINT = "/ws"
 
+# Correlates the subscribe request with its acknowledgement. Event pushes carry
+# a null id, so the ack is the only frame that echoes this back.
+_SUBSCRIBE_REQUEST_ID = 1
 
-class WebSocketConnectStep(BaseStep):
+# Cap on frames replayed in a failure report, so a long window of progress
+# frames cannot bury the assertion that failed.
+_MAX_REPORTED_FRAMES = 20
+
+
+class _WebSocketStepBase(BaseStep):
+    """Shared node/token/URL resolution for the WebSocket steps."""
+
+    def _resolve_ws_target(self, node_name: str) -> tuple[str, str]:
+        """Resolve a node to its RPC URL and the name its token is cached under."""
+        resolved = self._resolve_node(node_name)
+        if resolved:
+            return resolved.url, resolved.node_name
+        return self._get_node_rpc_url(node_name), node_name
+
+    def _resolve_token(
+        self,
+        cache_node_name: str,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> str | None:
+        """Resolve the JWT to attach: explicit ``token`` field wins, else cache."""
+        explicit = self.config.get("token")
+        if explicit:
+            return self._resolve_dynamic_value(
+                explicit, workflow_results, dynamic_values
+            )
+        cached = AuthManager().get_cached_token(cache_node_name)
+        return cached.access_token if cached else None
+
+    def _build_ws_url(self, rpc_url: str, token: str | None) -> str:
+        """Build the ``ws(s)://host:port/ws[?token=...]`` URL from the RPC URL."""
+        base = rpc_url.rstrip("/")
+        if base.startswith("https://"):
+            base = "wss://" + base[len("https://") :]
+        elif base.startswith("http://"):
+            base = "ws://" + base[len("http://") :]
+        url = f"{base}{WS_ENDPOINT}"
+        if token:
+            url = f"{url}?token={token}"
+        return url
+
+
+class WebSocketConnectStep(_WebSocketStepBase):
     """Open a WebSocket subscription and assert the handshake outcome.
 
     Required fields: ``node``.
@@ -70,16 +118,12 @@ class WebSocketConnectStep(BaseStep):
         )
 
         try:
-            resolved = self._resolve_node(node_name)
-            if resolved:
-                rpc_url, cache_node_name = resolved.url, resolved.node_name
-            else:
-                rpc_url, cache_node_name = self._get_node_rpc_url(node_name), node_name
+            rpc_url, cache_node_name = self._resolve_ws_target(node_name)
         except Exception as e:
             console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
             return False
 
-        token = None
+        token: str | None = None
         if not unauthenticated:
             token = self._resolve_token(
                 cache_node_name, workflow_results, dynamic_values
@@ -137,29 +181,316 @@ class WebSocketConnectStep(BaseStep):
         console.print(f"[green]✓ WebSocket connected to {node_name}[/green]")
         return True
 
-    def _resolve_token(
-        self,
-        cache_node_name: str,
-        workflow_results: dict[str, Any],
-        dynamic_values: dict[str, Any],
-    ) -> Optional[str]:
-        """Resolve the JWT to attach: explicit ``token`` field wins, else cache."""
-        explicit = self.config.get("token")
-        if explicit:
-            return self._resolve_dynamic_value(
-                explicit, workflow_results, dynamic_values
-            )
-        cached = AuthManager().get_cached_token(cache_node_name)
-        return cached.access_token if cached else None
 
-    def _build_ws_url(self, rpc_url: str, token: Optional[str]) -> str:
-        """Build the ``ws(s)://host:port/ws[?token=...]`` URL from the RPC URL."""
-        base = rpc_url.rstrip("/")
-        if base.startswith("https://"):
-            base = "wss://" + base[len("https://") :]
-        elif base.startswith("http://"):
-            base = "ws://" + base[len("http://") :]
-        url = f"{base}{WS_ENDPOINT}"
-        if token:
-            url = f"{url}?token={token}"
-        return url
+class WebSocketEventAssertStep(_WebSocketStepBase):
+    """Subscribe to a group's event stream and assert what arrives on it.
+
+    Watches the stream for ``timeout_seconds``. The positive form passes as soon
+    as an event of type ``event`` satisfying ``match`` arrives; ``absent: true``
+    inverts the verdict, passing only if the window elapses without one.
+
+    Required fields: ``node``, ``group_id``, ``event``.
+
+    Optional fields:
+    - ``match`` (dict): dotted paths into the delivered frame mapped to expected
+      values. A subset test, so unlisted fields are ignored. Paths address the
+      wire frame, which is camelCase where the Rust is snake_case:
+      ``groupId``, ``data.toVersion``, ``data.toStateVersion``.
+    - ``absent`` (bool): assert the event must NOT arrive.
+    - ``timeout_seconds`` (number): window length, default ``30``.
+    - ``token`` (str): explicit JWT (supports ``{{placeholders}}``); otherwise
+      the token a prior ``login`` cached for the node, or none at all on a node
+      running without auth.
+
+    Two properties of the transport a workflow author has to plan around:
+
+    A subscription observes only events emitted after it lands, and the stream
+    has no replay, so an event the triggering step already emitted on the same
+    node cannot be caught by a later step. Assert against a node that learns of
+    the change through sync.
+
+    ``CascadeProgress`` is admin-gated at subscribe time while the other
+    migration variants are member-visible, so a non-admin subscriber never
+    receives it and ``absent: true`` on it would pass for the wrong reason.
+    """
+
+    _DEFAULT_TIMEOUT_SECONDS = 30.0
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "group_id", "event"]
+
+    def _validate_field_types(self) -> None:
+        self._validate_string_field("node")
+        self._validate_string_field("group_id")
+        self._validate_string_field("event")
+        self._validate_string_field("token", required=False)
+        self._validate_boolean_field("absent", required=False)
+        self._validate_number_field("timeout_seconds", required=False, positive=True)
+        timeout = self.config.get("timeout_seconds")
+        # NaN/inf survive the positive check but leave the deadline non-finite,
+        # so the watch loop would never end.
+        if timeout is not None and not math.isfinite(timeout):
+            raise ValueError(
+                f"Step '{self._get_step_name()}': 'timeout_seconds' must be a "
+                f"finite number"
+            )
+        self._validate_dict_field("match", required=False)
+        for path in self.config.get("match") or {}:
+            if not isinstance(path, str) or not path:
+                raise ValueError(
+                    f"Step '{self._get_step_name()}': 'match' keys must be "
+                    f"non-empty dotted paths into the event frame"
+                )
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        group_id = self._resolve_dynamic_value(
+            self.config["group_id"], workflow_results, dynamic_values
+        )
+        event_type = self._resolve_dynamic_value(
+            self.config["event"], workflow_results, dynamic_values
+        )
+        absent = bool(self.config.get("absent", False))
+        # `.get(key, default)` returns the default only when the key is ABSENT;
+        # an explicit `timeout_seconds: null` yields a present key with value
+        # None, which float() would crash on.
+        timeout_raw = self.config.get("timeout_seconds")
+        timeout_seconds = float(
+            self._DEFAULT_TIMEOUT_SECONDS if timeout_raw is None else timeout_raw
+        )
+        match_spec = {
+            path: (
+                self._resolve_dynamic_value(expected, workflow_results, dynamic_values)
+                if isinstance(expected, str)
+                else expected
+            )
+            for path, expected in (self.config.get("match") or {}).items()
+        }
+
+        try:
+            rpc_url, cache_node_name = self._resolve_ws_target(node_name)
+        except Exception as e:
+            console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
+            return False
+
+        # A node running without auth issues no token, and its WS treats every
+        # connection as node owner, so a missing token is not an error here.
+        # The subscribe acknowledgement below is the real authorization signal.
+        token = self._resolve_token(cache_node_name, workflow_results, dynamic_values)
+        ws_url = self._build_ws_url(rpc_url, token)
+
+        console.print(
+            f"[blue]⏳ Watching {node_name} for {'no ' if absent else ''}"
+            f"'{event_type}' on group {group_id} "
+            f"(timeout {timeout_seconds:g}s)[/blue]"
+        )
+
+        matched, received, blocker = await self._watch(
+            ws_url, group_id, event_type, match_spec, timeout_seconds
+        )
+
+        if blocker is not None:
+            # The window was never observed, so neither verdict was tested. An
+            # unobserved window is not an absent event, so `absent` fails here
+            # too rather than passing vacuously.
+            console.print(
+                f"✗ assert_ws_event on {node_name}: {blocker}",
+                style="red",
+                markup=False,
+            )
+            self._report_received(received, event_type, match_spec)
+            return False
+
+        if absent:
+            if matched is None:
+                console.print(
+                    f"[green]✓ assert_ws_event: no '{event_type}' reached "
+                    f"{node_name} for group {group_id} in {timeout_seconds:g}s "
+                    f"({len(received)} other event(s) observed)[/green]"
+                )
+                return True
+            console.print(
+                f"✗ assert_ws_event on {node_name}: '{event_type}' was asserted "
+                f"absent but arrived: {json.dumps(matched, sort_keys=True)}",
+                style="red",
+                markup=False,
+            )
+            return False
+
+        if matched is not None:
+            workflow_results[f"ws_event_{node_name}"] = matched
+            console.print(
+                f"[green]✓ assert_ws_event: '{event_type}' arrived on {node_name} "
+                f"for group {group_id}[/green]"
+            )
+            return True
+
+        console.print(
+            f"✗ assert_ws_event on {node_name}: no '{event_type}' on group "
+            f"{group_id} matched within {timeout_seconds:g}s",
+            style="red",
+            markup=False,
+        )
+        self._report_received(received, event_type, match_spec)
+        return False
+
+    async def _watch(
+        self,
+        ws_url: str,
+        group_id: str,
+        event_type: str,
+        match_spec: dict[str, Any],
+        timeout_seconds: float,
+    ) -> tuple[dict[str, Any] | None, list[dict[str, Any]], str | None]:
+        """Subscribe and collect frames until a match or the deadline.
+
+        Returns ``(matched_frame, received_frames, blocker)``. ``blocker`` is set
+        when the window could not be observed at all (a refused handshake, a
+        denied subscription, an early close) and invalidates both verdicts.
+        The received frames come back on every path so a caller can report what
+        actually arrived instead of only that the expectation went unmet.
+        """
+        received: list[dict[str, Any]] = []
+        deadline = time.monotonic() + timeout_seconds
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                # asyncio.wait_for rather than ws_connect's own timeout kwarg,
+                # whose shape changed in aiohttp 3.11.
+                try:
+                    ws = await asyncio.wait_for(
+                        session.ws_connect(ws_url), timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    return (
+                        None,
+                        received,
+                        f"the handshake did not complete within {timeout_seconds:g}s",
+                    )
+
+                try:
+                    await ws.send_str(
+                        json.dumps(
+                            {
+                                "id": _SUBSCRIBE_REQUEST_ID,
+                                "method": "subscribe",
+                                # Hex ids, the representation the group and
+                                # namespace admin APIs hand out.
+                                "params": {"groupIds": [group_id]},
+                            }
+                        )
+                    )
+                    subscribed = False
+
+                    while True:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        try:
+                            msg = await asyncio.wait_for(ws.receive(), remaining)
+                        except asyncio.TimeoutError:
+                            break  # the window elapsed, the normal end
+                        if msg.type is not aiohttp.WSMsgType.TEXT:
+                            return (
+                                None,
+                                received,
+                                f"the connection ended after "
+                                f"{timeout_seconds - max(remaining, 0.0):.1f}s "
+                                f"({msg.type.name}), so the window was not observed",
+                            )
+
+                        frame = json.loads(msg.data)
+                        if not isinstance(frame, dict):
+                            continue
+
+                        if frame.get("id") == _SUBSCRIBE_REQUEST_ID:
+                            result = frame.get("result")
+                            # The server answers with the ids it actually
+                            # subscribed, dropping any the caller may not
+                            # observe, so an empty (or absent) list is a denial
+                            # and not something to wait out.
+                            if not isinstance(result, dict) or not result.get(
+                                "groupIds"
+                            ):
+                                return (
+                                    None,
+                                    received,
+                                    f"the node refused a subscription to group "
+                                    f"{group_id} (not a member of it, or the id "
+                                    f"is wrong): {msg.data}",
+                                )
+                            subscribed = True
+                            continue
+
+                        result = frame.get("result")
+                        if not isinstance(result, dict):
+                            continue
+                        received.append(result)
+                        if result.get("type") != event_type:
+                            continue
+                        if not self._match_failures(result, match_spec):
+                            return result, received, None
+
+                    if not subscribed:
+                        return (
+                            None,
+                            received,
+                            "the subscription was never acknowledged, so the "
+                            "window was not observed",
+                        )
+                finally:
+                    await ws.close()
+        except (aiohttp.ClientError, OSError) as e:
+            return None, received, f"WebSocket error: {e}"
+        except json.JSONDecodeError as e:
+            return None, received, f"the node sent a frame that is not JSON: {e}"
+
+        return None, received, None
+
+    def _match_failures(
+        self, frame: dict[str, Any], match_spec: dict[str, Any]
+    ) -> list[str]:
+        """Per-path mismatches; empty means the frame satisfies ``match``."""
+        failures = []
+        for path, expected in match_spec.items():
+            actual = self._get_value(frame, path)
+            if actual != expected:
+                failures.append(f"{path}: expected {expected!r}, got {actual!r}")
+        return failures
+
+    def _report_received(
+        self,
+        received: list[dict[str, Any]],
+        event_type: str,
+        match_spec: dict[str, Any],
+    ) -> None:
+        """Replay what actually arrived, with per-path mismatches for near misses.
+
+        markup=False so event payloads containing ``[..]`` are not eaten as Rich
+        console tags.
+        """
+        if not received:
+            console.print(
+                "  no events arrived on the subscription", style="red", markup=False
+            )
+            return
+        console.print(
+            f"  {len(received)} event(s) arrived on the subscription:",
+            style="red",
+            markup=False,
+        )
+        for frame in received[:_MAX_REPORTED_FRAMES]:
+            console.print(
+                f"    {json.dumps(frame, sort_keys=True)}", style="red", markup=False
+            )
+            if match_spec and frame.get("type") == event_type:
+                for failure in self._match_failures(frame, match_spec):
+                    console.print(f"      match {failure}", style="red", markup=False)
+        if len(received) > _MAX_REPORTED_FRAMES:
+            console.print(
+                f"    ... and {len(received) - _MAX_REPORTED_FRAMES} more",
+                style="red",
+                markup=False,
+            )

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -36,6 +36,9 @@ _SUBSCRIBE_REQUEST_ID = 1
 # frames cannot bury the assertion that failed.
 _MAX_REPORTED_FRAMES = 20
 
+# Stands in for the JWT wherever a URL reaches the console.
+_REDACTED = "***"
+
 
 class _WebSocketStepBase(BaseStep):
     """Shared node/token/URL resolution for the WebSocket steps."""
@@ -73,6 +76,15 @@ class _WebSocketStepBase(BaseStep):
         if token:
             url = f"{url}?token={token}"
         return url
+
+    def _redact(self, text: str, token: str | None) -> str:
+        """Mask a token anywhere in text bound for the console.
+
+        aiohttp errors stringify the request URL, and the JWT rides in that
+        URL's query string, so every error path can otherwise print the token
+        into a CI log that outlives the node.
+        """
+        return text.replace(token, _REDACTED) if token else text
 
 
 class WebSocketConnectStep(_WebSocketStepBase):
@@ -136,8 +148,9 @@ class WebSocketConnectStep(_WebSocketStepBase):
                 return False
 
         ws_url = self._build_ws_url(rpc_url, token)
-        display_url = self._build_ws_url(rpc_url, "***" if token else None)
-        console.print(f"[cyan]Opening WebSocket to {display_url}[/cyan]")
+        console.print(
+            f"[cyan]Opening WebSocket to {self._redact(ws_url, token)}[/cyan]"
+        )
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -157,21 +170,27 @@ class WebSocketConnectStep(_WebSocketStepBase):
             # The server rejected the upgrade handshake — the genuine auth signal.
             # Only an auth status (401/403) proves a rejected-without-token test;
             # other statuses are a real failure even under expected_failure.
+            detail = self._redact(str(e), token)
             if expected_failure:
                 if e.status in (401, 403):
-                    self._report_expected_failure(str(e))
+                    self._report_expected_failure(detail)
                     return True
                 console.print(
                     f"[red]❌ Expected a 401/403 auth rejection but the "
                     f"{node_name} handshake returned HTTP {e.status}[/red]"
                 )
                 return False
-            console.print(f"[red]❌ WebSocket connect to {node_name} failed: {e}[/red]")
+            console.print(
+                f"[red]❌ WebSocket connect to {node_name} failed: {detail}[/red]"
+            )
             return False
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             # Connection refused / reset / timeout doesn't prove an auth
             # rejection, so it never satisfies expected_failure.
-            console.print(f"[red]❌ WebSocket connect to {node_name} error: {e}[/red]")
+            console.print(
+                f"[red]❌ WebSocket connect to {node_name} error: "
+                f"{self._redact(str(e), token)}[/red]"
+            )
             return False
 
         if expected_failure:
@@ -322,8 +341,10 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
             # The window was never observed, so no verdict was tested. An
             # unobserved window is not an absent event, so the `absent` and
             # `count` forms fail here too rather than passing vacuously.
+            # A transport blocker quotes the exception, which quotes the URL the
+            # token rides in, so redact here rather than at each raising site.
             console.print(
-                f"✗ assert_ws_event on {node_name}: {blocker}",
+                f"✗ assert_ws_event on {node_name}: {self._redact(blocker, token)}",
                 style="red",
                 markup=False,
             )
@@ -443,11 +464,18 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
                             result = frame.get("result")
                             # The server answers with the ids it actually
                             # subscribed, dropping any the caller may not
-                            # observe, so an empty (or absent) list is a denial
-                            # and not something to wait out.
-                            if not isinstance(result, dict) or not result.get(
-                                "groupIds"
-                            ):
+                            # observe, so the requested id missing from the ack
+                            # is a denial and not something to wait out. A
+                            # non-empty list is not enough: an ack naming only
+                            # other groups leaves this one unwatched, and
+                            # `absent` would then pass without observing
+                            # anything.
+                            acked = (
+                                result.get("groupIds")
+                                if isinstance(result, dict)
+                                else None
+                            )
+                            if not isinstance(acked, list) or group_id not in acked:
                                 return (
                                     matches,
                                     received,

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -132,7 +132,10 @@ from merobox.commands.bootstrap.steps.tee import (
 )
 from merobox.commands.bootstrap.steps.wait import WaitStep
 from merobox.commands.bootstrap.steps.wait_for_sync import WaitForSyncStep
-from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
+from merobox.commands.bootstrap.steps.websocket import (
+    WebSocketConnectStep,
+    WebSocketEventAssertStep,
+)
 from merobox.commands.constants import RESERVED_NODE_CONFIG_KEYS
 
 
@@ -415,6 +418,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = RefreshStep
         elif step_type in ("ws_connect", "ws_subscribe"):
             step_class = WebSocketConnectStep
+        elif step_type == "assert_ws_event":
+            step_class = WebSocketEventAssertStep
         elif step_type == "set_tee_admission_policy":
             step_class = SetTeeAdmissionPolicyStep
         elif step_type == "tee_fleet_join":

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -19,6 +19,17 @@ from merobox.commands.bootstrap.steps.refresh import RefreshStep
 from merobox.commands.bootstrap.steps.websocket import WebSocketConnectStep
 
 
+@pytest.fixture(autouse=True)
+def _wide_console():
+    """Rich soft-wraps at terminal width, splitting the strings asserted on."""
+    from merobox.commands.utils import console
+
+    original = console.width
+    console.width = 400
+    yield
+    console.width = original
+
+
 def _run(coro):
     """Run a coroutine on a dedicated loop, leaving a fresh current loop behind.
 
@@ -337,17 +348,20 @@ class _FakeHandshakeError(aiohttp.WSServerHandshakeError):
     versions. We skip the base ``__init__`` and override ``__str__`` so the
     fixture is version-proof; it still matches ``except
     aiohttp.WSServerHandshakeError`` (the step only reads ``.status``).
+    ``url`` reproduces the real ``__str__``, which echoes the request URL.
     """
 
-    def __init__(self, status):
+    def __init__(self, status, url=""):
         self.status = status
+        self._url = url
 
     def __str__(self):
-        return f"handshake rejected with {self.status}"
+        echoed = f", url={self._url!r}" if self._url else ""
+        return f"handshake rejected with {self.status}{echoed}"
 
 
-def _handshake_error(status):
-    return _FakeHandshakeError(status)
+def _handshake_error(status, url=""):
+    return _FakeHandshakeError(status, url)
 
 
 class TestWebSocketConnectStep:
@@ -478,6 +492,73 @@ class TestWebSocketConnectStep:
 
         # Asserted rejection but the connection succeeded -> step fails.
         assert result is False
+
+
+class TestWebSocketTokenRedaction:
+    """No console path may echo the JWT the URL carries in its query string."""
+
+    def _step(self, **extra):
+        config = {
+            "type": "ws_connect",
+            "name": "ws",
+            "node": "calimero-node-1",
+            **extra,
+        }
+        return WebSocketConnectStep(config, manager=_manager())
+
+    def _run_with(self, step, ws_connect, capsys):
+        fake_auth = MagicMock()
+        fake_auth.get_cached_token.return_value = _token()
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.AuthManager",
+                return_value=fake_auth,
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+                return_value=_FakeSession(ws_connect),
+            ),
+        ):
+            result = _run(step.execute({}, {}))
+        return result, capsys.readouterr().out
+
+    def test_the_opened_url_is_masked(self, capsys):
+        async def ws_connect(url):
+            return _FakeWS()
+
+        result, out = self._run_with(self._step(), ws_connect, capsys)
+        assert result is True
+        assert "acc.jwt.tok" not in out
+
+    def test_a_handshake_error_echoing_the_url_is_masked(self, capsys):
+        # ClientResponseError (which WSServerHandshakeError subclasses)
+        # stringifies the request URL, query string included.
+        async def ws_connect(url):
+            raise _handshake_error(500, url)
+
+        result, out = self._run_with(self._step(), ws_connect, capsys)
+        assert result is False
+        assert "acc.jwt.tok" not in out
+        assert "token=***" in out
+
+    def test_a_rejection_reported_as_expected_is_masked(self, capsys):
+        async def ws_connect(url):
+            raise _handshake_error(401, url)
+
+        result, out = self._run_with(
+            self._step(expected_failure=True), ws_connect, capsys
+        )
+        assert result is True
+        assert "acc.jwt.tok" not in out
+
+    def test_a_transport_error_echoing_the_url_is_masked(self, capsys):
+        async def ws_connect(url):
+            raise aiohttp.ClientError(f"Cannot connect to {url}")
+
+        result, out = self._run_with(self._step(), ws_connect, capsys)
+        assert result is False
+        assert "acc.jwt.tok" not in out
+        assert "token=***" in out
 
 
 if __name__ == "__main__":

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -560,6 +560,26 @@ class TestWebSocketTokenRedaction:
         assert "acc.jwt.tok" not in out
         assert "token=***" in out
 
+    # Masking is not enough on its own: both paths interpolate into [red] tags,
+    # so a bracketed message (a multiaddr is the common case) must also be
+    # escaped or Rich parses it as a malformed tag and raises instead of
+    # reporting.
+    def test_a_bracketed_handshake_error_is_reported_not_parsed(self, capsys):
+        async def ws_connect(url):
+            raise _handshake_error(500, "[/ip4/127.0.0.1/tcp/2428]")
+
+        result, out = self._run_with(self._step(), ws_connect, capsys)
+        assert result is False
+        assert "/ip4/127.0.0.1/tcp/2428" in out
+
+    def test_a_bracketed_transport_error_is_reported_not_parsed(self, capsys):
+        async def ws_connect(url):
+            raise aiohttp.ClientError("no route to [/ip4/127.0.0.1/tcp/2428]")
+
+        result, out = self._run_with(self._step(), ws_connect, capsys)
+        assert result is False
+        assert "/ip4/127.0.0.1/tcp/2428" in out
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -106,6 +106,46 @@ class TestSummarizeMigrationStatus:
         assert s["total"] == 0
         assert s["all_migrated"] is False
         assert s["members"] == []
+        assert s["fleet_completed_at"] is None
+        assert s["cohort_pinned_at_hlc"] is None
+
+    def test_fleet_completed_at_is_surfaced(self):
+        # The durable evidence that convergence happened, which allMigrated
+        # cannot provide: it is TTL-derived and lapses when a member goes quiet.
+        s = _summarize_migration_status(
+            {
+                "fleetCompletedAt": 1_700_002_000,
+                "cohortPinnedAtHlc": "hlc-abc",
+                "rollup": _rollup(total=1),
+            }
+        )
+        assert s["fleet_completed_at"] == 1_700_002_000
+        assert s["cohort_pinned_at_hlc"] == "hlc-abc"
+
+    def test_fleet_completed_at_outlives_a_lapsed_all_migrated(self):
+        # A converged fleet whose members went quiet: allMigrated is back to
+        # false, and the timestamp is the only remaining evidence.
+        s = _summarize_migration_status(
+            {
+                "fleetCompletedAt": 1_700_002_000,
+                "rollup": _rollup(unknown=2, total=2, allMigrated=False),
+            }
+        )
+        assert s["all_migrated"] is False
+        assert s["fleet_completed_at"] == 1_700_002_000
+
+    def test_an_unconverged_namespace_reports_none_not_zero(self):
+        # Core omits the key entirely rather than sending 0, and 0 is a valid
+        # unix timestamp, so absent must not collapse into it.
+        s = _summarize_migration_status({"rollup": _rollup(total=2)})
+        assert s["fleet_completed_at"] is None
+        assert s["cohort_pinned_at_hlc"] is None
+
+    def test_a_zero_fleet_timestamp_is_preserved(self):
+        s = _summarize_migration_status(
+            {"fleetCompletedAt": 0, "rollup": _rollup(total=1)}
+        )
+        assert s["fleet_completed_at"] == 0
 
     def test_bool_counters_coerced_to_zero(self):
         # A bool is an int subclass — it must NOT be treated as a count.

--- a/merobox/tests/unit/test_node_resolver.py
+++ b/merobox/tests/unit/test_node_resolver.py
@@ -46,22 +46,35 @@ _mock_constants.DEFAULT_RPC_PORT = 2528
 
 _mock_remote_nodes = MagicMock()
 
-# Install mocks
-sys.modules["merobox.commands.auth"] = _mock_auth
-sys.modules["merobox.commands.constants"] = _mock_constants
-sys.modules["merobox.commands.remote_nodes"] = _mock_remote_nodes
-sys.modules["aiohttp"] = MagicMock()
-sys.modules["rich"] = MagicMock()
-sys.modules["rich.console"] = MagicMock()
-sys.modules["rich.prompt"] = MagicMock()
+_STUBS = {
+    "merobox.commands.auth": _mock_auth,
+    "merobox.commands.constants": _mock_constants,
+    "merobox.commands.remote_nodes": _mock_remote_nodes,
+    "aiohttp": MagicMock(),
+    "rich": MagicMock(),
+    "rich.console": MagicMock(),
+    "rich.prompt": MagicMock(),
+}
 
-# Load node_resolver directly
+# Load node_resolver directly, with its dependencies stubbed only for the
+# duration of the exec. Leaving the stubs installed hands every test module
+# imported later a MagicMock in place of the real aiohttp and rich, which
+# silently breaks any assertion those modules' real values take part in.
 _workspace = Path(__file__).parent.parent.parent.parent
 _node_resolver_path = _workspace / "merobox" / "commands" / "node_resolver.py"
-_module, _spec = _load_module_directly(
-    "merobox.commands.node_resolver", str(_node_resolver_path)
-)
-_spec.loader.exec_module(_module)
+_saved = {name: sys.modules.get(name) for name in _STUBS}
+sys.modules.update(_STUBS)
+try:
+    _module, _spec = _load_module_directly(
+        "merobox.commands.node_resolver", str(_node_resolver_path)
+    )
+    _spec.loader.exec_module(_module)
+finally:
+    for name, original in _saved.items():
+        if original is None:
+            del sys.modules[name]
+        else:
+            sys.modules[name] = original
 
 NodeResolver = _module.NodeResolver
 

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -162,19 +162,25 @@ def _step(**extra):
     return WebSocketEventAssertStep(config, manager=_manager())
 
 
-def _execute(step, frames, workflow_results=None):
-    """Run the step against a socket replaying `frames`, returning (result, ws)."""
+def _execute(step, frames, workflow_results=None, session=None, token=None):
+    """Run the step against a socket replaying `frames`, returning (result, ws).
+
+    `session` overrides the transport for the tests that need a slow or
+    refusing connect; `token` seeds the auth cache for the redaction tests.
+    """
     ws = _ScriptedWS(frames)
-    no_token = MagicMock()
-    no_token.get_cached_token.return_value = None
+    auth = MagicMock()
+    auth.get_cached_token.return_value = (
+        MagicMock(access_token=token) if token else None
+    )
     with (
         patch(
             "merobox.commands.bootstrap.steps.websocket.AuthManager",
-            return_value=no_token,
+            return_value=auth,
         ),
         patch(
             "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
-            return_value=_FakeSession(ws),
+            return_value=session if session is not None else _FakeSession(ws),
         ),
     ):
         return (
@@ -185,6 +191,18 @@ def _execute(step, frames, workflow_results=None):
             ),
             ws,
         )
+
+
+class _SlowHandshake(_FakeSession):
+    """A session whose connect takes `delay` seconds to complete."""
+
+    def __init__(self, ws, delay):
+        super().__init__(ws)
+        self._delay = delay
+
+    async def ws_connect(self, url):
+        await asyncio.sleep(self._delay)
+        return self._ws
 
 
 class TestPositiveAssertion:
@@ -390,41 +408,23 @@ class TestUnobservedWindow:
 class TestTokenRedaction:
     """The JWT rides in the URL's query string, which aiohttp errors echo."""
 
-    def _execute_against(self, session, capsys):
-        step = _step()
-        cached = MagicMock()
-        cached.access_token = "acc.jwt.tok"
-        auth = MagicMock()
-        auth.get_cached_token.return_value = cached
-        with (
-            patch(
-                "merobox.commands.bootstrap.steps.websocket.AuthManager",
-                return_value=auth,
-            ),
-            patch(
-                "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
-                return_value=session,
-            ),
-        ):
-            result = _run(step.execute({}, {}))
-        return result, capsys.readouterr().out
-
     def test_a_transport_error_echoing_the_url_is_masked(self, capsys):
         class _Refusing(_FakeSession):
             async def ws_connect(self, url):
                 raise aiohttp.ClientError(f"Cannot connect to {url}")
 
-        result, out = self._execute_against(_Refusing(None), capsys)
+        result, _ = _execute(_step(), [], session=_Refusing(None), token="acc.jwt.tok")
         assert result is False
+        out = capsys.readouterr().out
         assert "acc.jwt.tok" not in out
         assert "token=***" in out
 
     def test_the_watched_url_is_never_printed_in_full(self, capsys):
-        result, out = self._execute_against(
-            _FakeSession(_ScriptedWS([_ack(), _migration_started()])), capsys
+        result, _ = _execute(
+            _step(), [_ack(), _migration_started()], token="acc.jwt.tok"
         )
         assert result is True
-        assert "acc.jwt.tok" not in out
+        assert "acc.jwt.tok" not in capsys.readouterr().out
 
 
 class TestWatchWindow:
@@ -432,27 +432,21 @@ class TestWatchWindow:
         # A slow handshake must not eat the window: `absent` would then call
         # the shortfall evidence of absence, and a positive assertion would
         # time out for a reason that has nothing to do with the stream.
-        step = _step(timeout_seconds=1.0)
         ws = _ScriptedWS([_ack(), _delayed(0.6, _migration_started())])
-        no_token = MagicMock()
-        no_token.get_cached_token.return_value = None
+        result, _ = _execute(
+            _step(timeout_seconds=1.0), [], session=_SlowHandshake(ws, 0.6)
+        )
+        assert result is True
 
-        class _SlowHandshake(_FakeSession):
-            async def ws_connect(self, url):
-                await asyncio.sleep(0.6)
-                return self._ws
-
-        with (
-            patch(
-                "merobox.commands.bootstrap.steps.websocket.AuthManager",
-                return_value=no_token,
-            ),
-            patch(
-                "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
-                return_value=_SlowHandshake(ws),
-            ),
-        ):
-            assert _run(step.execute({}, {})) is True
+    def test_a_slow_handshake_is_not_reported_as_an_unacknowledged_one(self, capsys):
+        # The acknowledgement gets its own window too: charging the handshake
+        # to it would blame the node for a connect merobox waited out.
+        ws = _ScriptedWS([_delayed(0.4, _ack()), _migration_started()])
+        result, _ = _execute(
+            _step(timeout_seconds=1.0), [], session=_SlowHandshake(ws, 0.8)
+        )
+        assert result is True
+        assert "never acknowledged" not in capsys.readouterr().out
 
 
 class TestValidation:

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -255,7 +255,8 @@ class TestNegativeAssertion:
         result, _ = _execute(step, [_ack(), cascade])
         assert result is False
         combined = capsys.readouterr().out
-        assert "asserted absent but arrived" in combined
+        assert "expected exactly 0 'CascadeProgress'" in combined
+        assert "but 1 arrived" in combined
         assert _SUBGROUP in combined, "the offending frame must be printed"
 
     def test_absent_respects_match_so_a_different_payload_is_not_a_violation(self):
@@ -264,6 +265,57 @@ class TestNegativeAssertion:
             event="MigrationCompleted", match={"data.toVersion": "3.0.0"}, absent=True
         )
         result, _ = _execute(step, [_ack(), _migration_completed(to_version="2.0.0")])
+        assert result is True
+
+
+class TestExactCount:
+    def test_exactly_one_passes_when_exactly_one_arrives(self):
+        step = _step(event="MigrationCompleted", count=1)
+        result, _ = _execute(step, [_ack(), _migration_completed()])
+        assert result is True
+
+    def test_a_second_arrival_fails_the_exactly_one_assertion(self, capsys):
+        # The guarantee core holds is that convergence fires MigrationCompleted
+        # once; a duplicate is the regression this catches.
+        step = _step(event="MigrationCompleted", count=1)
+        result, _ = _execute(
+            step, [_ack(), _migration_completed(), _migration_completed()]
+        )
+        assert result is False
+        combined = capsys.readouterr().out
+        assert "expected exactly 1 'MigrationCompleted'" in combined
+        assert "but 2 arrived" in combined
+        # Both arrivals are replayed and marked as the ones that were counted.
+        assert combined.count("match >") == 2
+
+    def test_no_arrival_fails_the_exactly_one_assertion(self, capsys):
+        step = _step(event="MigrationCompleted", count=1)
+        result, _ = _execute(step, [_ack(), _migration_progress()])
+        assert result is False
+        combined = capsys.readouterr().out
+        assert "but 0 arrived" in combined
+        # The non-matching event still has to be replayed, unmarked.
+        assert "MigrationProgress" in combined
+        assert combined.count("match >") == 0
+
+    def test_count_two_passes_on_two_arrivals(self):
+        step = _step(event="MigrationProgress", count=2)
+        result, _ = _execute(
+            step, [_ack(), _migration_progress(), _migration_progress()]
+        )
+        assert result is True
+
+    def test_count_zero_is_the_same_assertion_as_absent(self):
+        step = _step(event="CascadeProgress", count=0)
+        result, _ = _execute(step, [_ack(), _migration_progress()])
+        assert result is True
+
+    def test_the_default_form_tolerates_a_second_arrival(self):
+        # Without `count`, "at least one" stays the default and stops early, so
+        # a repeat must not turn a passing assertion red.
+        result, _ = _execute(
+            _step(), [_ack(), _migration_started(), _migration_started()]
+        )
         assert result is True
 
 
@@ -314,6 +366,14 @@ class TestValidation:
     def test_match_must_be_a_dict_of_paths(self):
         with pytest.raises(ValueError):
             _step(match={"": "x"})
+
+    def test_count_and_absent_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _step(count=1, absent=True)
+
+    def test_a_negative_count_is_rejected(self):
+        with pytest.raises(ValueError):
+            _step(count=-1)
 
 
 if __name__ == "__main__":

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -72,7 +72,11 @@ class _ScriptedWS:
 
     async def receive(self):
         if self._frames:
-            return self._frames.pop(0)
+            frame = self._frames.pop(0)
+            if isinstance(frame, _Delayed):
+                await asyncio.sleep(frame.after)
+                return frame.frame
+            return frame
         await asyncio.sleep(3600)
 
     async def close(self):
@@ -98,6 +102,18 @@ def _ack(group_ids=(_GROUP,)):
     return _FakeMsg(
         json.dumps({"id": 1, "result": {"contextIds": [], "groupIds": list(group_ids)}})
     )
+
+
+class _Delayed:
+    """A scripted frame that only arrives after `after` seconds."""
+
+    def __init__(self, after, frame):
+        self.after = after
+        self.frame = frame
+
+
+def _delayed(after, frame):
+    return _Delayed(after, frame)
 
 
 def _event(event_type, data, group=_GROUP):
@@ -409,6 +425,34 @@ class TestTokenRedaction:
         )
         assert result is True
         assert "acc.jwt.tok" not in out
+
+
+class TestWatchWindow:
+    def test_the_window_is_measured_from_the_acknowledgement(self):
+        # A slow handshake must not eat the window: `absent` would then call
+        # the shortfall evidence of absence, and a positive assertion would
+        # time out for a reason that has nothing to do with the stream.
+        step = _step(timeout_seconds=1.0)
+        ws = _ScriptedWS([_ack(), _delayed(0.6, _migration_started())])
+        no_token = MagicMock()
+        no_token.get_cached_token.return_value = None
+
+        class _SlowHandshake(_FakeSession):
+            async def ws_connect(self, url):
+                await asyncio.sleep(0.6)
+                return self._ws
+
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.AuthManager",
+                return_value=no_token,
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+                return_value=_SlowHandshake(ws),
+            ),
+        ):
+            assert _run(step.execute({}, {})) is True
 
 
 class TestValidation:

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -1,0 +1,320 @@
+"""
+Unit tests for the assert_ws_event workflow step.
+
+The aiohttp layer is mocked with a socket that replays a scripted frame
+sequence and then blocks, so the watch window really ends on the step's own
+deadline rather than on the fixture running out. Frame shapes are the wire form
+of calimero's GroupMigration events: a PascalCase `type` tag beside the hex
+`groupId`, with camelCase fields under `data`.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+import pytest
+
+from merobox.commands.bootstrap.steps.websocket import WebSocketEventAssertStep
+
+# Long enough to let the scripted frames land, short enough that the tests
+# exercising the timeout path stay fast.
+_WINDOW = 0.3
+
+_GROUP = "21" * 32
+_SUBGROUP = "31" * 32
+
+
+@pytest.fixture(autouse=True)
+def _wide_console():
+    """Rich soft-wraps at terminal width, splitting the strings asserted on."""
+    from merobox.commands.utils import console
+
+    original = console.width
+    console.width = 400
+    yield
+    console.width = original
+
+
+def _run(coro):
+    """Run a coroutine on a dedicated loop, leaving a fresh current loop behind."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def _manager():
+    manager = MagicMock()
+    manager.get_node_rpc_port.return_value = 2528
+    return manager
+
+
+class _FakeMsg:
+    def __init__(self, data, type_=aiohttp.WSMsgType.TEXT):
+        self.type = type_
+        self.data = data
+
+
+class _ScriptedWS:
+    """Replays scripted frames, then blocks so the step's deadline ends the window."""
+
+    def __init__(self, frames):
+        self._frames = list(frames)
+        self.sent = []
+        self.closed = False
+
+    async def send_str(self, message):
+        self.sent.append(message)
+
+    async def receive(self):
+        if self._frames:
+            return self._frames.pop(0)
+        await asyncio.sleep(3600)
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeSession:
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def ws_connect(self, url):
+        return self._ws
+
+
+def _ack(group_ids=(_GROUP,)):
+    """The subscribe acknowledgement: the ids the node actually subscribed."""
+    return _FakeMsg(
+        json.dumps({"id": 1, "result": {"contextIds": [], "groupIds": list(group_ids)}})
+    )
+
+
+def _event(event_type, data, group=_GROUP):
+    return _FakeMsg(
+        json.dumps(
+            {"id": None, "result": {"groupId": group, "type": event_type, "data": data}}
+        )
+    )
+
+
+def _migration_started(from_version="1.0.0", to_version="2.0.0", to_state_version=2):
+    return _event(
+        "MigrationStarted",
+        {
+            "fromVersion": from_version,
+            "toVersion": to_version,
+            "toStateVersion": to_state_version,
+            "localContextsTotal": 7,
+        },
+    )
+
+
+def _migration_completed(to_version="2.0.0"):
+    return _event(
+        "MigrationCompleted", {"toVersion": to_version, "completedAt": 1_700_000_000}
+    )
+
+
+def _migration_progress():
+    return _event(
+        "MigrationProgress",
+        {"migrated": 1, "inProgress": 1, "unknown": 0, "failed": 0, "total": 2},
+    )
+
+
+def _step(**extra):
+    config = {
+        "type": "assert_ws_event",
+        "name": "ws-event",
+        "node": "calimero-node-2",
+        "group_id": _GROUP,
+        "event": "MigrationStarted",
+        "timeout_seconds": _WINDOW,
+        **extra,
+    }
+    return WebSocketEventAssertStep(config, manager=_manager())
+
+
+def _execute(step, frames, workflow_results=None):
+    """Run the step against a socket replaying `frames`, returning (result, ws)."""
+    ws = _ScriptedWS(frames)
+    no_token = MagicMock()
+    no_token.get_cached_token.return_value = None
+    with (
+        patch(
+            "merobox.commands.bootstrap.steps.websocket.AuthManager",
+            return_value=no_token,
+        ),
+        patch(
+            "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+            return_value=_FakeSession(ws),
+        ),
+    ):
+        return (
+            _run(
+                step.execute(
+                    workflow_results if workflow_results is not None else {}, {}
+                )
+            ),
+            ws,
+        )
+
+
+class TestPositiveAssertion:
+    def test_matching_event_satisfies_the_step(self):
+        result, ws = _execute(_step(), [_ack(), _migration_started()])
+        assert result is True
+        # The subscription rides groupIds, hex-encoded like the admin API.
+        assert json.loads(ws.sent[0]) == {
+            "id": 1,
+            "method": "subscribe",
+            "params": {"groupIds": [_GROUP]},
+        }
+
+    def test_event_of_another_type_does_not_satisfy_it(self, capsys):
+        result, _ = _execute(
+            _step(), [_ack(), _migration_progress(), _migration_completed()]
+        )
+        assert result is False
+        combined = capsys.readouterr().out
+        # The two events that did arrive have to be in the report.
+        assert "MigrationProgress" in combined
+        assert "MigrationCompleted" in combined
+
+    def test_nested_payload_field_is_matched(self):
+        step = _step(event="MigrationCompleted", match={"data.toVersion": "2.0.0"})
+        result, _ = _execute(step, [_ack(), _migration_completed(to_version="2.0.0")])
+        assert result is True
+
+    def test_a_wrong_nested_field_value_does_not_match(self, capsys):
+        step = _step(event="MigrationCompleted", match={"data.toVersion": "2.0.0"})
+        result, _ = _execute(step, [_ack(), _migration_completed(to_version="1.9.0")])
+        assert result is False
+        combined = capsys.readouterr().out
+        # The near miss must name the path, what was wanted, and what came.
+        assert "data.toVersion" in combined
+        assert "'2.0.0'" in combined
+        assert "'1.9.0'" in combined
+
+    def test_matching_is_a_subset_so_unlisted_fields_are_ignored(self):
+        # Only toStateVersion is asserted; the frame carries three more fields.
+        step = _step(match={"data.toStateVersion": 2})
+        result, _ = _execute(step, [_ack(), _migration_started(to_state_version=2)])
+        assert result is True
+
+    def test_the_matched_event_is_stored_for_later_steps(self):
+        results = {}
+        _execute(_step(), [_ack(), _migration_started()], workflow_results=results)
+        assert results["ws_event_calimero-node-2"]["type"] == "MigrationStarted"
+
+
+class TestTimeoutReporting:
+    def test_timeout_names_what_actually_arrived(self, capsys):
+        result, _ = _execute(_step(), [_ack(), _migration_progress()])
+        assert result is False
+        combined = capsys.readouterr().out
+        assert "MigrationStarted" in combined, "the expectation should be named"
+        assert "1 event(s) arrived" in combined
+        # The whole frame is replayed, not just the type, so a mismatch is
+        # diagnosable from CI output alone.
+        assert "inProgress" in combined
+
+    def test_timeout_with_an_empty_stream_says_so(self, capsys):
+        result, _ = _execute(_step(), [_ack()])
+        assert result is False
+        assert "no events arrived on the subscription" in capsys.readouterr().out
+
+
+class TestNegativeAssertion:
+    def test_absent_passes_when_the_event_never_arrives(self):
+        step = _step(event="CascadeProgress", absent=True)
+        result, _ = _execute(step, [_ack(), _migration_progress()])
+        assert result is True
+
+    def test_absent_fails_when_the_event_does_arrive(self, capsys):
+        step = _step(event="CascadeProgress", absent=True)
+        cascade = _event(
+            "CascadeProgress",
+            {
+                "subgroupId": _SUBGROUP,
+                "localContextsSwapped": 1,
+                "localContextsTotal": 2,
+            },
+        )
+        result, _ = _execute(step, [_ack(), cascade])
+        assert result is False
+        combined = capsys.readouterr().out
+        assert "asserted absent but arrived" in combined
+        assert _SUBGROUP in combined, "the offending frame must be printed"
+
+    def test_absent_respects_match_so_a_different_payload_is_not_a_violation(self):
+        # "no MigrationCompleted to 3.0.0" must not trip on a completion to 2.0.0.
+        step = _step(
+            event="MigrationCompleted", match={"data.toVersion": "3.0.0"}, absent=True
+        )
+        result, _ = _execute(step, [_ack(), _migration_completed(to_version="2.0.0")])
+        assert result is True
+
+
+class TestUnobservedWindow:
+    """A window that was never watched must fail both directions, not pass one."""
+
+    def test_denied_subscription_fails_the_positive_assertion(self, capsys):
+        # The node drops ids the caller may not observe, so the ack comes back
+        # with no groupIds at all.
+        result, _ = _execute(_step(), [_ack(group_ids=())])
+        assert result is False
+        assert "refused a subscription" in capsys.readouterr().out
+
+    def test_denied_subscription_fails_the_negative_assertion_too(self, capsys):
+        step = _step(event="CascadeProgress", absent=True)
+        result, _ = _execute(step, [_ack(group_ids=())])
+        assert result is False
+        combined = capsys.readouterr().out
+        assert "refused a subscription" in combined
+
+    def test_an_unacknowledged_subscription_fails(self, capsys):
+        step = _step(absent=True)
+        result, _ = _execute(step, [])
+        assert result is False
+        assert "never acknowledged" in capsys.readouterr().out
+
+    def test_an_early_close_fails_the_negative_assertion(self, capsys):
+        step = _step(event="CascadeProgress", absent=True)
+        closed = _FakeMsg(None, type_=aiohttp.WSMsgType.CLOSED)
+        result, _ = _execute(step, [_ack(), closed])
+        assert result is False
+        assert "the connection ended" in capsys.readouterr().out
+
+
+class TestValidation:
+    def test_group_id_and_event_are_required(self):
+        with pytest.raises(ValueError):
+            WebSocketEventAssertStep(
+                {"type": "assert_ws_event", "node": "calimero-node-1"},
+                manager=_manager(),
+            )
+
+    def test_a_non_finite_timeout_is_rejected(self):
+        # inf survives the positive check but leaves the deadline unreachable.
+        with pytest.raises(ValueError):
+            _step(timeout_seconds=float("inf"))
+
+    def test_match_must_be_a_dict_of_paths(self):
+        with pytest.raises(ValueError):
+            _step(match={"": "x"})
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -329,6 +329,27 @@ class TestUnobservedWindow:
         assert result is False
         assert "refused a subscription" in capsys.readouterr().out
 
+    def test_an_ack_naming_only_another_group_is_a_denial(self, capsys):
+        # A non-empty ack is not proof: this group stays unwatched, so the
+        # window was never observed.
+        result, _ = _execute(_step(), [_ack(group_ids=(_SUBGROUP,))])
+        assert result is False
+        assert "refused a subscription" in capsys.readouterr().out
+
+    def test_an_ack_naming_only_another_group_fails_absent_too(self, capsys):
+        # The vacuous pass this guards: nothing arrives because nothing is
+        # being watched, which is not evidence of absence.
+        step = _step(event="CascadeProgress", absent=True)
+        result, _ = _execute(step, [_ack(group_ids=(_SUBGROUP,))])
+        assert result is False
+        assert "refused a subscription" in capsys.readouterr().out
+
+    def test_an_ack_listing_the_group_among_others_is_accepted(self):
+        result, _ = _execute(
+            _step(), [_ack(group_ids=(_SUBGROUP, _GROUP)), _migration_started()]
+        )
+        assert result is True
+
     def test_denied_subscription_fails_the_negative_assertion_too(self, capsys):
         step = _step(event="CascadeProgress", absent=True)
         result, _ = _execute(step, [_ack(group_ids=())])
@@ -348,6 +369,46 @@ class TestUnobservedWindow:
         result, _ = _execute(step, [_ack(), closed])
         assert result is False
         assert "the connection ended" in capsys.readouterr().out
+
+
+class TestTokenRedaction:
+    """The JWT rides in the URL's query string, which aiohttp errors echo."""
+
+    def _execute_against(self, session, capsys):
+        step = _step()
+        cached = MagicMock()
+        cached.access_token = "acc.jwt.tok"
+        auth = MagicMock()
+        auth.get_cached_token.return_value = cached
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.AuthManager",
+                return_value=auth,
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.websocket.aiohttp.ClientSession",
+                return_value=session,
+            ),
+        ):
+            result = _run(step.execute({}, {}))
+        return result, capsys.readouterr().out
+
+    def test_a_transport_error_echoing_the_url_is_masked(self, capsys):
+        class _Refusing(_FakeSession):
+            async def ws_connect(self, url):
+                raise aiohttp.ClientError(f"Cannot connect to {url}")
+
+        result, out = self._execute_against(_Refusing(None), capsys)
+        assert result is False
+        assert "acc.jwt.tok" not in out
+        assert "token=***" in out
+
+    def test_the_watched_url_is_never_printed_in_full(self, capsys):
+        result, out = self._execute_against(
+            _FakeSession(_ScriptedWS([_ack(), _migration_started()])), capsys
+        )
+        assert result is True
+        assert "acc.jwt.tok" not in out
 
 
 class TestValidation:


### PR DESCRIPTION
## Summary

merobox can drive a namespace migration but has no way to observe one. The only
gate available today is grepping node logs, which cannot catch a wrong
\"everything migrated\" answer, because that answer writes no log line to grep
for. The existing `ws_connect` step only asserts the handshake outcome; there is
no subscribe-and-match capability at all.

This adds `assert_ws_event`, which subscribes to a group or namespace over `/ws`
and gates on what the node actually pushes.

```yaml
- name: Migration starts on node 2
  type: assert_ws_event
  node: calimero-node-2
  group_id: "{{namespace_id}}"
  event: MigrationStarted
  timeout_seconds: 60

- name: Completed at the target version
  type: assert_ws_event
  node: calimero-node-2
  group_id: "{{namespace_id}}"
  event: MigrationCompleted
  match:
    data.toVersion: "2.0.0"

- name: Convergence announces itself exactly once
  type: assert_ws_event
  node: calimero-node-2
  group_id: "{{namespace_id}}"
  event: MigrationCompleted
  count: 1

- name: No cascade detail reaches a plain member
  type: assert_ws_event
  node: calimero-node-2
  group_id: "{{namespace_id}}"
  event: CascadeProgress
  absent: true
  timeout_seconds: 10
```

Design notes, and why:

- **One expected-count behind three spellings.** The default is "at least one"
  and stops at the first arrival. `count: n` demands exactly `n`, and
  `absent: true` is the same assertion as `count: 0`; the two are rejected
  together rather than silently resolved. The watch loop collects matches and
  settles early only when an arrival puts the tally past the ceiling, which is
  the success for the default form and a failure no further watching can undo
  for an exact count. An exact count that is still reachable watches the whole
  window, because ruling out a further arrival means watching for one.
- **`count` is honest about its scope.** It is counted over the bounded window,
  so it proves the event did not fire more than `count` times within
  `timeout_seconds`, not that it never fires again. The step docstring and
  `LLM.md` say so rather than letting an author read it as stronger.
- **`expected_failure` is deliberately not overloaded.** It has to keep meaning
  \"the step could not do its job\", which must stay distinguishable from \"the
  subscription worked and the event correctly never came\".
- **Subset matching over dotted paths.** Exact-field matching would force a
  caller to spell out every field of a payload that core is free to extend.
  `match` keys are dotted paths resolved by the same `_get_value` helper the
  other steps use, and they address the wire frame, which is camelCase where the
  Rust is snake_case (`data.toVersion`, not `data.to_version`).
- **A failure prints what did arrive.** One shared failure path states the
  expectation, says how many matched, and replays every event observed on the
  subscription with the counted arrivals marked, plus a per-path
  `expected X, got Y` for any event of the right type that missed on a `match`
  value. CI output alone distinguishes \"nothing happened\", \"the wrong thing
  happened\", and \"the right thing happened twice\".
- **An unobserved window fails every direction.** A refused subscription, a
  subscription that is never acknowledged, and a connection that closes early
  are reported as blockers rather than being counted as an absent event. Without
  this, `absent: true` would pass vacuously for a caller who is not a member of
  the group it named.

Two transport properties are documented on the step and in `LLM.md`, because a
test author will otherwise hit them: a subscription observes only events emitted
after it lands and the stream has no replay, so the step must target a node that
learns of the change through sync; and `CascadeProgress` is admin-gated at
subscribe time while the other migration events are member-visible, so a
non-admin subscriber never receives it and `absent: true` on it would pass for
the wrong reason.

The step is registered in all four places a step type must be declared:
`VALID_STEP_TYPES` and `STEP_TYPE_MODELS` in `config.py`, the dispatch chain in
`validate/validator.py`, and the executor factory in `run/executor.py`.

### `_summarize_migration_status` was dropping fields core returns

That summarizer builds an allowlist, so every field added upstream is silently
lost. Two top-level fields were being dropped:

- `fleetCompletedAt`, the durable record of when the fleet converged. It matters
  because `allMigrated` is recomputed from in-TTL heartbeats and lapses when a
  converged member goes quiet, which leaves this timestamp as the only
  persistent evidence convergence ever happened.
- `cohortPinnedAtHlc`, the governance HLC the cohort was pinned at.

Both are omitted from the response rather than sent null, and both have a
meaningful zero, so they pass through untouched. Routing them through the
existing counter coercion would report an unconverged namespace as having
converged at the epoch, which is the same class of mistake the existing
`total_raw is not None` handling avoids for an explicit `total: 0`.

The per-member rows stay narrowed to `peer`, `state`, and `migration_failed`.
That narrowing is deliberate rather than accidental, so it is left alone, but
the docstring now names the report fields it leaves behind (`schema_version`,
`residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`) so the
next reader does not have to diff against core to find out.

### Supporting fix

`test_node_resolver` installed MagicMocks for `aiohttp` and `rich` into
`sys.modules` at import time and never restored them, so every test module
imported after it received a mock in place of the real enum values its
assertions compare against. The new tests cannot pass in a full suite run
without this. The stubs now live only for the duration of the module load they
exist for.

## Test plan

- `make format-check`: black and ruff both clean over 133 files.
- `pytest merobox/tests/unit`: 1219 passed. Before the `sys.modules` restore,
  the same run was 12 failed / 1195 passed while the new WebSocket file passed
  in isolation, which is what identified the leak.
- 26 tests in `merobox/tests/unit/test_ws_event_assertion.py`, driving the step
  against a socket that replays scripted frames and then blocks, so the watch
  window really ends on the step's own deadline. Frame shapes are the wire form
  of the `GroupMigration` events.
- 5 added tests in `merobox/tests/unit/test_migrations_v2_steps.py` covering the
  two recovered fields, including that a lapsed `allMigrated` does not take the
  timestamp with it, that an unconverged namespace reports `None` rather than
  `0`, and that a genuine `0` timestamp survives.
- Every test was proven to be a gate by breaking the behaviour it covers and
  confirming it goes red. All sixteen mutations were detected, none silent:

  | Behaviour broken | Tests that caught it |
  | --- | --- |
  | `match` made a no-op | 2 |
  | event type tag ignored | 3 |
  | failure report drops what arrived | 4 |
  | denied subscription treated as subscribed | 2 |
  | unacknowledged subscription treated as observed | 1 |
  | early close treated as a normal end of window | 1 |
  | `absent` always passes | 1 |
  | `count` ignored | 5 |
  | watch stops at first match despite an exact count | 2 |
  | failure report drops the arrival tally | 1 |
  | matching frames no longer marked in the replay | 1 |
  | `count` and `absent` allowed together | 1 |
  | negative `count` accepted | 1 |
  | `fleetCompletedAt` dropped again | 3 |
  | `cohortPinnedAtHlc` dropped again | 1 |
  | fleet timestamp coerced so absent collapses to `0` | 2 |

- The registration is covered end to end by the existing
  `test_validator_step_type_coverage` parametrisation, and by running the real
  CLI: `merobox bootstrap validate` accepts workflows using every form above,
  and rejects both a step with `event` removed and a step combining `count` with
  `absent`, naming the problem in each case.