### PR TITLE
fix(bootstrap): make dropped status fields and upstream image drift visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,9 +385,11 @@ jobs:
           path: workflow-examples/res/
 
       - name: Run ${{ matrix.name }}
+        env:
+          WORKFLOW_FILE: ${{ matrix.file }}
         run: |
           chmod +x workflow-examples/scripts/run_with_retry.sh
-          ./workflow-examples/scripts/run_with_retry.sh "${{ matrix.file }}" --no-docker
+          ./workflow-examples/scripts/run_with_retry.sh "$WORKFLOW_FILE" --no-docker
 
   # ── Test phase (TEE): mock-TEE scenarios, native, feature-enabled merod ──
   # These are excluded from the binary+docker matrices and run only here, on the
@@ -446,9 +448,11 @@ jobs:
           echo "✓ meroctl $TAG installed"
 
       - name: Run ${{ matrix.name }}
+        env:
+          WORKFLOW_FILE: ${{ matrix.file }}
         run: |
           chmod +x workflow-examples/scripts/run_with_retry.sh
-          ./workflow-examples/scripts/run_with_retry.sh "${{ matrix.file }}" --no-docker
+          ./workflow-examples/scripts/run_with_retry.sh "$WORKFLOW_FILE" --no-docker
 
       - name: Upload node logs
         if: always()
@@ -533,17 +537,23 @@ jobs:
           .github/scripts/capture-node-logs.sh start "$GITHUB_WORKSPACE/node-logs" /tmp/node-log-capture.state
 
       - name: Run ${{ matrix.name }}
+        env:
+          WORKFLOW_FILE: ${{ matrix.file }}
         run: |
           chmod +x workflow-examples/scripts/run_with_retry.sh
-          ./workflow-examples/scripts/run_with_retry.sh "${{ matrix.file }}"
+          ./workflow-examples/scripts/run_with_retry.sh "$WORKFLOW_FILE"
 
       # The PR run is green whatever happens here, so say what failed and how to
       # tell drift from a defect where the reader will actually see it.
       - name: Report canary failure
         if: failure()
+        # Through the environment, not interpolated into the script: an
+        # expression expanded into `run:` is executed as shell.
+        env:
+          WORKFLOW_NAME: ${{ matrix.name }}
         run: |
           {
-            echo "### Docker canary failed: ${{ matrix.name }}"
+            echo "### Docker canary failed: $WORKFLOW_NAME"
             echo
             echo "This lane runs against the rolling \`ghcr.io/calimero-network/merod:edge\` image, so the failure is either a merobox defect or an upstream core change."
             echo "Check the same workflow on master: still failing there means core moved, and fixing it is not this PR's job."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,10 +462,15 @@ jobs:
           if-no-files-found: ignore
 
   # ── Test phase (Docker): run each workflow in parallel ──
+  # Canary lane: `merod:edge` + force_pull_image means an upstream core change
+  # reddens it with no merobox commit involved, and ghcr keeps no immutable edge
+  # build to pin to (untagged versions are deleted after 2 days). So it reports
+  # on PRs instead of gating them, and stays a hard failure on master pushes.
   test-merobox-docker:
-    name: Docker (${{ matrix.name }})
+    name: Docker canary (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: [list-workflows]
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -531,6 +536,18 @@ jobs:
         run: |
           chmod +x workflow-examples/scripts/run_with_retry.sh
           ./workflow-examples/scripts/run_with_retry.sh "${{ matrix.file }}"
+
+      # The PR run is green whatever happens here, so say what failed and how to
+      # tell drift from a defect where the reader will actually see it.
+      - name: Report canary failure
+        if: failure()
+        run: |
+          {
+            echo "### Docker canary failed: ${{ matrix.name }}"
+            echo
+            echo "This lane runs against the rolling \`ghcr.io/calimero-network/merod:edge\` image, so the failure is either a merobox defect or an upstream core change."
+            echo "Check the same workflow on master: still failing there means core moved, and fixing it is not this PR's job."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stop node log capture
         if: always()

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -16,6 +16,7 @@ import asyncio
 import math
 import time
 from collections import Counter
+from functools import cache
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Any
@@ -87,6 +88,45 @@ def _drop_absent(summary: dict[str, Any]) -> dict[str, Any]:
     `_export_custom_outputs` applies to a raw response.
     """
     return {key: value for key, value in summary.items() if value is not _MISSING}
+# Response keys the summarizers below map into their curated summaries. Both
+# summaries are hand-picked allowlists (a raw passthrough would break `outputs:`
+# addressing), so a field core adds upstream is dropped; these sets are what
+# `_warn_unmapped_keys` diffs against to make that drop visible.
+_CASCADE_STATUS_MAPPED_KEYS = frozenset({"data"})
+_MIGRATION_STATUS_MAPPED_KEYS = frozenset(
+    {"targetVersion", "expectedMembers", "rollup", "members"}
+)
+_MIGRATION_ROLLUP_MAPPED_KEYS = frozenset(
+    {
+        "migrated",
+        "inProgress",
+        "unknown",
+        "failed",
+        "total",
+        "allMigrated",
+        "membersPendingSignature",
+    }
+)
+
+
+@cache
+def _warn_once(message: str) -> None:
+    # Cached on the message: the assert_* steps re-summarize on every poll, and
+    # the same drift warning repeated once per poll is one nobody reads.
+    console.print(message)
+
+
+def _warn_unmapped_keys(source: Any, mapped: frozenset[str], rpc: str) -> None:
+    """Warn when a response carries keys the summary silently drops."""
+    if not isinstance(source, dict):
+        return
+    unmapped = sorted(set(source) - mapped)
+    if unmapped:
+        _warn_once(
+            f"[yellow]⚠️  {rpc}: response field(s) {', '.join(unmapped)} are not "
+            f"mapped by merobox's summary and are unreachable from `outputs:`; "
+            f"this merod is newer than merobox.[/yellow]"
+        )
 
 
 def _summarize_cascade_status(response: Any) -> dict[str, Any]:
@@ -116,6 +156,11 @@ def _summarize_cascade_status(response: Any) -> dict[str, Any]:
     """
     raw_entries = response.get("data") if isinstance(response, dict) else None
     entries: list[Any] = raw_entries if isinstance(raw_entries, list) else []
+    _warn_unmapped_keys(response, _CASCADE_STATUS_MAPPED_KEYS, "get_cascade_status")
+
+    entries: list[Any] = []
+    if isinstance(response, dict) and isinstance(response.get("data"), list):
+        entries = response["data"]
 
     completed = 0
     failed = 0
@@ -213,12 +258,33 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     The summary is an allowlist, which silently drops anything core adds later.
     `members` itself mirrors core's list and is omitted when the response
     carried none, so an empty cohort stays distinct from an unanswered one.
+    `failed` is reconciled against the per-member states (`max` of the rollup
+    counter and the count of members in `state:"failed"`) so the
+    `assert_migration_complete` fast-exit still honours a failed member even
+    when the rollup is missing or carries a non-int counter — without it the
+    documented fail-fast would silently degrade to a poll-to-timeout. `total`
+    falls back to the member count only when the rollup omits it entirely (an
+    explicit `0` cohort is preserved).
+
+    Response and rollup keys outside the mapped sets are warned about rather
+    than dropped silently. Each member's report stays deliberately narrowed to
+    `migration_failed`: its other fields (`schemaVersion`, `residueAuto`,
+    `syncedUpToHlc`, `reportedAt`, `authoredRemaining`) are not surfaced and
+    never warn.
     """
     source = response if isinstance(response, dict) else {}
     rollup = source.get("rollup")
     rollup = rollup if isinstance(rollup, dict) else {}
     raw_members = source.get("members")
     member_entries = raw_members if isinstance(raw_members, list) else []
+
+    _warn_unmapped_keys(response, _MIGRATION_STATUS_MAPPED_KEYS, "get_migration_status")
+    _warn_unmapped_keys(
+        rollup, _MIGRATION_ROLLUP_MAPPED_KEYS, "get_migration_status.rollup"
+    )
+
+    raw_members = response.get("members") if isinstance(response, dict) else None
+    raw_members = raw_members if isinstance(raw_members, list) else []
 
     members: list[dict[str, Any]] = []
     member_states: Counter = Counter()

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -88,6 +88,8 @@ def _drop_absent(summary: dict[str, Any]) -> dict[str, Any]:
     `_export_custom_outputs` applies to a raw response.
     """
     return {key: value for key, value in summary.items() if value is not _MISSING}
+
+
 # Response keys the summarizers below map into their curated summaries. Both
 # summaries are hand-picked allowlists (a raw passthrough would break `outputs:`
 # addressing), so a field core adds upstream is dropped; these sets are what
@@ -282,9 +284,6 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     _warn_unmapped_keys(
         rollup, _MIGRATION_ROLLUP_MAPPED_KEYS, "get_migration_status.rollup"
     )
-
-    raw_members = response.get("members") if isinstance(response, dict) else None
-    raw_members = raw_members if isinstance(raw_members, list) else []
 
     members: list[dict[str, Any]] = []
     member_states: Counter = Counter()

--- a/merobox/tests/unit/test_ci_workflow_hygiene.py
+++ b/merobox/tests/unit/test_ci_workflow_hygiene.py
@@ -1,0 +1,27 @@
+"""CI's own workflow must not expand an expression into a shell script.
+
+`ci.yml` triggers on `pull_request`, so the checkout is the PR's own tree and
+the matrix is built by `ls workflow-examples/*.yml`. A `${{ }}` expanded inside
+`run:` is spliced into the script before bash sees it, so a PR adding a file
+whose name contains a command substitution would run it on the runner. Passing
+the value through `env:` leaves it a string.
+"""
+
+import pathlib
+import re
+
+import yaml
+
+_CI = pathlib.Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+
+
+def test_no_expression_is_interpolated_into_a_run_block():
+    jobs = yaml.safe_load(_CI.read_text())["jobs"]
+    offenders = [
+        (job_name, step.get("name"), expression)
+        for job_name, job in jobs.items()
+        for step in job.get("steps") or []
+        if isinstance(step.get("run"), str)
+        for expression in re.findall(r"\$\{\{[^}]*\}\}", step["run"])
+    ]
+    assert offenders == []

--- a/merobox/tests/unit/test_summary_drift_warning.py
+++ b/merobox/tests/unit/test_summary_drift_warning.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for drift detection on the group-upgrade status summarizers.
+
+`_summarize_cascade_status` and `_summarize_migration_status` flatten core's
+JSON into curated allowlists, so any field core adds upstream is dropped. These
+tests pin the mapped-key sets (a core-side addition has to be reviewed here
+rather than discovered weeks later in a workflow whose `outputs:` resolved to
+nothing) and cover the runtime warning that makes the drop visible on the first
+run against a newer merod.
+"""
+
+import pytest
+
+from merobox.commands.bootstrap.steps.group_upgrade import (
+    _CASCADE_STATUS_MAPPED_KEYS,
+    _MIGRATION_ROLLUP_MAPPED_KEYS,
+    _MIGRATION_STATUS_MAPPED_KEYS,
+    _summarize_cascade_status,
+    _summarize_migration_status,
+    _warn_once,
+)
+from merobox.commands.utils import console
+
+# Substring every drift warning carries, and nothing else prints.
+_MARKER = "not mapped by merobox's summary"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_console():
+    # `_warn_once` dedupes for the life of the process, so each test needs a
+    # clean cache; the wide console keeps rich from wrapping a key name across
+    # lines and breaking the substring assertions.
+    original_width = console.width
+    console.width = 400
+    _warn_once.cache_clear()
+    yield
+    console.width = original_width
+    _warn_once.cache_clear()
+
+
+def _rollup(**overrides):
+    base = {
+        "migrated": 1,
+        "inProgress": 0,
+        "unknown": 0,
+        "failed": 0,
+        "total": 1,
+        "allMigrated": True,
+        "membersPendingSignature": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+# =============================================================================
+# The pinned allowlists
+# =============================================================================
+
+
+class TestMappedKeysArePinned:
+    """Change these together with the summary that surfaces the new field.
+
+    The sets are the summarizers' contract with core's response shape: this is
+    the checkpoint where a core-side addition has to be either mapped into the
+    summary or consciously left out.
+    """
+
+    def test_cascade_status_mapped_keys(self):
+        assert set(_CASCADE_STATUS_MAPPED_KEYS) == {"data"}
+
+    def test_migration_status_mapped_keys(self):
+        assert set(_MIGRATION_STATUS_MAPPED_KEYS) == {
+            "targetVersion",
+            "expectedMembers",
+            "rollup",
+            "members",
+        }
+
+    def test_migration_rollup_mapped_keys(self):
+        assert set(_MIGRATION_ROLLUP_MAPPED_KEYS) == {
+            "migrated",
+            "inProgress",
+            "unknown",
+            "failed",
+            "total",
+            "allMigrated",
+            "membersPendingSignature",
+        }
+
+
+# =============================================================================
+# The runtime warning
+# =============================================================================
+
+
+class TestDriftWarning:
+    def test_cascade_unmapped_key_warns(self, capsys):
+        summary = _summarize_cascade_status({"data": [], "cursor": "abc"})
+        out = capsys.readouterr().out
+        assert _MARKER in out
+        assert "get_cascade_status" in out and "cursor" in out
+        # The summary itself is unaffected: the warning is the only new output.
+        assert summary["total"] == 0
+
+    def test_migration_unmapped_top_level_key_warns(self, capsys):
+        _summarize_migration_status(
+            {"rollup": _rollup(), "members": [], "fleetCompletedAt": 1_700_002_000}
+        )
+        out = capsys.readouterr().out
+        assert _MARKER in out
+        assert "get_migration_status" in out and "fleetCompletedAt" in out
+
+    def test_migration_unmapped_rollup_counter_warns(self, capsys):
+        # The rollup counters are lifted to the top level of the summary, so a
+        # counter core adds there is dropped exactly like a top-level field.
+        _summarize_migration_status({"rollup": _rollup(membersPendingProof=2)})
+        out = capsys.readouterr().out
+        assert _MARKER in out
+        assert "get_migration_status.rollup" in out and "membersPendingProof" in out
+
+    def test_fully_mapped_responses_are_silent(self, capsys):
+        _summarize_cascade_status({"data": [{"groupId": "g0"}]})
+        _summarize_migration_status(
+            {
+                "targetVersion": 3,
+                "expectedMembers": 1,
+                "rollup": _rollup(),
+                "members": [{"peer": "p", "state": "migrated"}],
+            }
+        )
+        assert _MARKER not in capsys.readouterr().out
+
+    def test_deliberately_omitted_member_report_fields_do_not_warn(self, capsys):
+        # Only `migrationFailed` is surfaced per member; the rest of the report
+        # is left out on purpose, and a warning about it would be pure noise.
+        _summarize_migration_status(
+            {
+                "rollup": _rollup(),
+                "members": [
+                    {
+                        "peer": "p",
+                        "state": "migrated",
+                        "report": {
+                            "schemaVersion": 3,
+                            "residueAuto": 0,
+                            "syncedUpToHlc": "hlc-1",
+                            "reportedAt": 1_700_000_000,
+                            "authoredRemaining": 0,
+                            "migrationFailed": None,
+                        },
+                    }
+                ],
+            }
+        )
+        assert _MARKER not in capsys.readouterr().out
+
+    def test_garbage_response_does_not_warn(self, capsys):
+        # A non-dict body is already handled (and warned about) by the steps;
+        # the summarizers stay silent rather than blaming core for it.
+        for bad in (None, "not-a-dict", []):
+            _summarize_cascade_status(bad)
+            _summarize_migration_status(bad)
+        assert _MARKER not in capsys.readouterr().out
+
+    def test_repeated_drift_warns_once(self, capsys):
+        # assert_migration_complete re-summarizes on every poll; one warning per
+        # poll is one nobody reads.
+        for _ in range(3):
+            _summarize_migration_status({"rollup": _rollup(), "cohortPinnedAtHlc": "x"})
+        assert capsys.readouterr().out.count(_MARKER) == 1


### PR DESCRIPTION
## Summary

Two things that made merobox quietly lie about what it tests.

**Silent field loss in the status summarizers.** `_summarize_cascade_status` and
`_summarize_migration_status` flatten core's JSON into curated key allowlists, so
anything core adds upstream vanishes from `outputs:` with no signal at all;
`fleetCompletedAt` and `cohortPinnedAtHlc` were both found by hand, and the class
stayed open. The curated shape has to stay - a raw passthrough would break
`outputs:` addressing and reintroduce the `data`-key unwrap trap the helper
docstrings warn about - so the allowlists are now explicit sets that every
response is diffed against, warning once per distinct drift through the same
`console` yellow warning the rest of the steps use. Deduping matters because the
`assert_*` steps re-summarize on every poll, and one warning per poll is one
nobody reads.

Coverage is the top-level response keys plus the rollup counters, which are the
parts lifted into the summary. Each member's report stays deliberately narrowed
to `migration_failed`, so `schemaVersion`, `residueAuto`, `syncedUpToHlc`,
`reportedAt` and `authoredRemaining` never warn. A unit test pins the three
mapped sets, so mapping a new core field - or widening a set without mapping it -
is a deliberate edit reviewed at that test rather than a surprise weeks later.

Worth knowing: current core sends `cohortPinnedAtHlc`, which master does not map,
so this warning fires on the first real migration-status run. That is the
detector working, not a defect it introduces.

**The docker lane.** Every workflow in that matrix pulls
`ghcr.io/calimero-network/merod:edge` fresh, so an upstream core change fails the
job with no merobox commit involved, and a red job there tells a reviewer nothing
about the PR under it. Pinning the image was the alternative and it does not
hold: ghcr keeps only `edge`, `latest` and release tags, and core's tidy-docker
job deletes untagged versions after two days, so a digest pin evaporates two days
after edge moves. Pinning to a release tag instead would put this lane on the
same core the binary lane already tests, dropping the master-only coverage it
exists for - cascade-namespace is excluded from binary mode precisely because the
release lags master. So the lane keeps running edge on PRs but no longer gates
them, and a failure writes a step summary saying how to tell drift from a defect.
Master pushes still fail hard, which is where drift has to be noticed and fixed.

The tradeoff is deliberate and worth stating: a PR that genuinely breaks
docker-only behaviour (fault injection, NAT topology, cascade-namespace) now
reports instead of blocking, so those failures have to be read rather than
enforced.

## Test plan

- `merobox/tests/unit/test_summary_drift_warning.py`, 10 new tests: the three
  pinned allowlists, a warning for an unmapped top-level key on each summarizer,
  a warning for an unmapped rollup counter, silence for fully mapped responses,
  silence for the deliberately omitted per-member report fields, silence for
  garbage bodies, and one warning across three repeated summarizations.
- Each behaviour was proven to be a gate by breaking it and watching the right
  test fail: dropping the cascade warn call, dropping the rollup warn call,
  widening `_MIGRATION_STATUS_MAPPED_KEYS` without mapping the field (fails both
  the pin and the warning test), replacing `_warn_once` with a bare
  `console.print` (3 warnings instead of 1), and extending the warning over the
  per-member report (fails the deliberate-omission test).
- `pytest merobox/tests/unit`: 1198 passed, up from 1188 on master.
- `make format-check`: black and ruff clean.
- `actionlint .github/workflows/ci.yml`: 12 findings, identical to master's 12,
  none in the changed lines. Verified actionlint type-checks the new
  `continue-on-error` expression by misspelling `github.event_name` and watching
  it fail.
