### PR TITLE
feat(bootstrap): surface per-member migration reports, and make expected_failure able to fail

### DIFF
--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -169,7 +169,7 @@ Every step is a mapping with a `type`. These keys are available on all steps:
 | `name` | no | string | Human-readable label shown in output. |
 | `outputs` | no | map | Capture response values into workflow variables — see [capturing outputs](/workflows/engine/#capturing-outputs). |
 | `expected_failure` | no | bool (`false`) | Pass only if the operation is refused. A step that unexpectedly **succeeds** fails. |
-| `expected_error` | no | string | Pass only if the recorded error contains this substring (case-sensitive). Requires `expected_failure: true`. |
+| `expected_error` | no | string | Pass only if the recorded error contains this substring (case-sensitive), `{{placeholders}}` resolved first. Requires `expected_failure: true`. |
 
 Without `expected_error`, `expected_failure: true` accepts any error at all,
 including the node being unreachable standing in for the refusal under test.

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1093,7 +1093,7 @@ Poll until a namespace migration finishes, or fail. Same fields as
 `residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`,
 `migration_failed`).
 
-Alongside those, merobox recomputes six aggregates from the raw member reports
+Alongside those, merobox recomputes these aggregates from the raw member reports
 rather than reading core's rollup, so an assertion on them can falsify the
 rollup rather than confirm it against itself:
 
@@ -1105,6 +1105,7 @@ rollup rather than confirm it against itself:
 | `min_reported_schema_version` | Lowest reported state version, or `None`. |
 | `residue_total` | Sum of `residue_auto` across members. |
 | `failure_reasons` | Sorted list of the members' `migration_failed` reasons. |
+| `stuck_members` | Sorted peers behind those reasons. |
 
 `report.schema_version` is a **u32 ABI state version**, unlike an application's
 own `schema_info`, which is a semver string compiled into the binary and reports

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -168,6 +168,25 @@ Every step is a mapping with a `type`. These keys are available on all steps:
 | `type` | yes | string | The step type (one of the catalogue below). |
 | `name` | no | string | Human-readable label shown in output. |
 | `outputs` | no | map | Capture response values into workflow variables — see [capturing outputs](/workflows/engine/#capturing-outputs). |
+| `expected_failure` | no | bool (`false`) | Pass only if the operation is refused. A step that unexpectedly **succeeds** fails. |
+| `expected_error` | no | string | Pass only if the recorded error contains this substring (case-sensitive). Requires `expected_failure: true`. |
+
+Without `expected_error`, `expected_failure: true` accepts any error at all,
+including the node being unreachable standing in for the refusal under test.
+Pin the reason whenever the workflow is gating a specific refusal:
+
+```yaml
+- type: upgrade_group
+  node: calimero-node-1
+  group_id: '{{group_id}}'
+  target_application_id: '{{app_v2}}'
+  expected_failure: true
+  expected_error: 'identity downgrade forbidden'
+```
+
+The `call` step is the one exception to the unexpected-success rule: it keeps
+warning and passing, because workflows use `expected_failure` on a read as a
+soft "may not have propagated yet" probe and rely on its `None` error exports.
 
 Fields specific to each step are documented per type. Placeholder references
 (`{{var}}`, `{{env.VAR}}`) and `${ENV}` expansion are described in the
@@ -1065,6 +1084,37 @@ Poll until a namespace migration finishes, or fail. Same fields as
   context_id: '{{context_id}}'
   force: true
 ```
+
+`get_migration_status` and `assert_migration_complete` flatten the response into
+`target_version`, `expected_members`, `fleet_completed_at`,
+`cohort_pinned_at_hlc`, the rollup counters (`total`, `migrated`, `in_progress`,
+`unknown`, `failed`, `all_migrated`, `members_pending_signature`), and one
+`members` row per cohort member carrying its whole report (`schema_version`,
+`residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`,
+`migration_failed`).
+
+Alongside those, merobox recomputes six aggregates from the raw member reports
+rather than reading core's rollup, so an assertion on them can falsify the
+rollup rather than confirm it against itself:
+
+| Output | Meaning |
+| --- | --- |
+| `reported_at_target` | Members whose reported ABI state version is at or above `target_version`. |
+| `reported_below_target` | Members that reported a version *below* the target. |
+| `reported_missing` | Members that reported no usable state version at all. |
+| `min_reported_schema_version` | Lowest reported state version, or `None`. |
+| `residue_total` | Sum of `residue_auto` across members. |
+| `failure_reasons` | Sorted list of the members' `migration_failed` reasons. |
+
+`report.schema_version` is a **u32 ABI state version**, unlike an application's
+own `schema_info`, which is a semver string compiled into the binary and reports
+which WASM is loaded rather than whether the state was migrated. Assert
+`reported_below_target` to check the latter.
+
+The two target-relative counters are `None` when the response carries no
+`target_version` (a namespace with no upgrade record): defaulting the target to
+`0` would classify every member as at-target and report green for a namespace
+that never migrated.
 
 ---
 

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -2082,6 +2082,9 @@ class WorkflowExecutor:
                     return False
 
                 # Execute the step
+                step_executor.bind_expected_error(
+                    self.workflow_results, self.dynamic_values
+                )
                 success = await step_executor.execute(
                     self.workflow_results, self.dynamic_values
                 )

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -37,6 +37,9 @@ class BaseStep:
         self._validate_required_fields()
         # Validate field types
         self._validate_field_types()
+        # Validated here rather than in _validate_field_types() so a subclass
+        # override cannot drop it.
+        self._validate_expected_error()
 
     def _get_exportable_variables(self) -> list[tuple[str, str, str]]:
         """
@@ -1250,27 +1253,86 @@ class BaseStep:
             )
         return value
 
-    def _report_expected_failure(self, error_message: str) -> None:
-        """Log the standard yellow message when an expected failure occurred.
+    def _validate_expected_error(self) -> None:
+        """Validate `expected_error`, the optional reason pin on a negative test.
 
-        error_message may carry a raw exception's text, which can itself
-        contain square brackets (e.g. a multiaddr) that Rich would otherwise
-        try to parse as markup - escape it, keep the surrounding tag.
+        `expected_error` without `expected_failure` can never assert anything,
+        and silently asserting nothing is the exact failure mode it exists to
+        close, so that pairing is a hard config error.
         """
+        if self.config.get("expected_error") is None:
+            return
+        self._validate_string_field("expected_error", required=False)
+        if not self._is_expected_failure():
+            raise ValueError(
+                f"Step '{self._get_step_name()}': 'expected_error' requires "
+                f"'expected_failure: true' - on its own it never asserts anything"
+            )
+
+    def _failure_detail(self, result: dict[str, Any]) -> str:
+        """The most specific error text a `fail()` result carries.
+
+        `fail()` records the step's own message under `error` and the
+        underlying cause under `exception.message`. `expected_error` has to
+        match the cause, so report both rather than the generic message alone.
+        """
+        message = str(result.get("error", "Unknown error"))
+        exception = result.get("exception")
+        cause = exception.get("message") if isinstance(exception, dict) else None
+        return f"{message}: {cause}" if cause else message
+
+    def _jsonrpc_error_detail(self, result_data: Any) -> str:
+        """Flatten a JSON-RPC error envelope onto one line for `expected_error`.
+
+        merod puts the refusal reason in `error.data` for some routes and
+        `error.type` for others, so both are included verbatim.
+        """
+        error = result_data.get("error") if isinstance(result_data, dict) else None
+        if isinstance(error, dict):
+            return (
+                f"JSON-RPC error returned: {error.get('type', 'Unknown')} - "
+                f"{error.get('data', 'No details')}"
+            )
+        if error is not None:
+            return f"JSON-RPC error returned: {error}"
+        return "JSON-RPC error returned"
+
+    def _report_expected_failure(self, error_message: str) -> bool:
+        """Report an expected failure, returning whether it was the RIGHT one.
+
+        With no `expected_error` configured any failure satisfies the step, so
+        this returns True. With one configured the step passes only if the
+        recorded message contains that substring (case-sensitive) - otherwise
+        `expected_failure: true` would green-light a refusal that never
+        happened, e.g. an unreachable node standing in for a rejected upgrade.
+        """
+        expected = self.config.get("expected_error")
+        if expected is not None and expected not in error_message:
+            # markup=False so an error body containing brackets survives Rich.
+            console.print(
+                f"✗ expected the failure to mention {expected!r}, "
+                f"but it was: {error_message}",
+                style="red",
+                markup=False,
+                highlight=False,
+            )
+            return False
+        # error_message may carry raw exception text whose brackets (e.g. a
+        # multiaddr) Rich would otherwise parse as markup.
         console.print(
             f"[yellow]✓ Expected failure occurred: {escape(error_message)}[/yellow]"
         )
+        return True
 
-    def _report_unexpected_success(self) -> None:
-        """Log a warning when `expected_failure: true` was set but the step succeeded.
+    def _report_unexpected_success(self) -> bool:
+        """Fail the step when `expected_failure: true` was set but it succeeded.
 
-        Matches the semantic of the `call` step: we warn rather than flip the
-        step to a hard failure, so an over-eager `expected_failure` flag never
-        silently turns a passing workflow into a failing one on refactor.
+        A negative test whose subject succeeds has not been proven - it has
+        been disproven, so returning True here would make every gate the flag
+        guards unable to fail.
         """
-        console.print(
-            "[yellow]⚠️  Warning: expected_failure was set but the step succeeded[/yellow]"
-        )
+        console.print("[red]✗ expected_failure was set but the step succeeded[/red]")
+        return False
 
     def _is_connectivity_error(self, error_message: str) -> bool:
         """Return True if an error message looks like a network/connectivity fault.

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -1297,7 +1297,12 @@ class BaseStep:
         message = str(result.get("error", "Unknown error"))
         exception = result.get("exception")
         cause = exception.get("message") if isinstance(exception, dict) else None
-        return f"{message}: {cause}" if cause else message
+        # Most call sites build the message as f"<verb> failed: {e}" and pass
+        # the same exception, so appending the cause unconditionally prints it
+        # twice.
+        if not cause or cause in message:
+            return message
+        return f"{message}: {cause}"
 
     def _jsonrpc_error_detail(self, result_data: Any) -> str:
         """Flatten a JSON-RPC error envelope onto one line for `expected_error`.

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -40,6 +40,9 @@ class BaseStep:
         # Validated here rather than in _validate_field_types() so a subclass
         # override cannot drop it.
         self._validate_expected_error()
+        # The raw value stands in until an executor binds it, so a config
+        # carrying no placeholder needs no binding at all.
+        self._expected_error = self.config.get("expected_error")
 
     def _get_exportable_variables(self) -> list[tuple[str, str, str]]:
         """
@@ -1269,6 +1272,21 @@ class BaseStep:
                 f"'expected_failure: true' - on its own it never asserts anything"
             )
 
+    def bind_expected_error(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> None:
+        """Resolve `expected_error`'s placeholders before the step can fail.
+
+        `_report_expected_failure` is reached from a hundred call sites that
+        hold no resolution context, so the executors that own both dicts bind
+        the value here instead of threading them through all of them.
+        """
+        expected = self.config.get("expected_error")
+        if isinstance(expected, str):
+            self._expected_error = self._resolve_dynamic_value(
+                expected, workflow_results, dynamic_values
+            )
+
     def _failure_detail(self, result: dict[str, Any]) -> str:
         """The most specific error text a `fail()` result carries.
 
@@ -1306,7 +1324,7 @@ class BaseStep:
         `expected_failure: true` would green-light a refusal that never
         happened, e.g. an unreachable node standing in for a rejected upgrade.
         """
-        expected = self.config.get("expected_error")
+        expected = self._expected_error
         if expected is not None and expected not in error_message:
             # markup=False so an error body containing brackets survives Rich.
             console.print(

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -1275,10 +1275,14 @@ class BaseStep:
         executors that own both dicts bind the value ahead of the step.
         """
         expected = self.config.get("expected_error")
-        if isinstance(expected, str):
-            self._expected_error = self._resolve_dynamic_value(
-                expected, workflow_results, dynamic_values
-            )
+        if not isinstance(expected, str):
+            return
+        resolved = str(
+            self._resolve_dynamic_value(expected, workflow_results, dynamic_values)
+        )
+        # A pin resolving to blank is a substring of every error, so it would
+        # accept any failure. Keep the raw form: it fails closed and names itself.
+        self._expected_error = resolved if resolved.strip() else expected
 
     def _failure_detail(self, result: dict[str, Any]) -> str:
         """`fail()` files the step's own message under `error` and the cause

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -37,11 +37,9 @@ class BaseStep:
         self._validate_required_fields()
         # Validate field types
         self._validate_field_types()
-        # Validated here rather than in _validate_field_types() so a subclass
-        # override cannot drop it.
+        # Kept out of _validate_field_types() so a subclass override cannot drop
+        # it. The raw value stands in until an executor binds any placeholders.
         self._validate_expected_error()
-        # The raw value stands in until an executor binds it, so a config
-        # carrying no placeholder needs no binding at all.
         self._expected_error = self.config.get("expected_error")
 
     def _get_exportable_variables(self) -> list[tuple[str, str, str]]:
@@ -1257,12 +1255,8 @@ class BaseStep:
         return value
 
     def _validate_expected_error(self) -> None:
-        """Validate `expected_error`, the optional reason pin on a negative test.
-
-        `expected_error` without `expected_failure` can never assert anything,
-        and silently asserting nothing is the exact failure mode it exists to
-        close, so that pairing is a hard config error.
-        """
+        """`expected_error` without `expected_failure` never asserts anything,
+        so that pairing is a config error rather than a silent no-op."""
         if self.config.get("expected_error") is None:
             return
         self._validate_string_field("expected_error", required=False)
@@ -1277,9 +1271,8 @@ class BaseStep:
     ) -> None:
         """Resolve `expected_error`'s placeholders before the step can fail.
 
-        `_report_expected_failure` is reached from a hundred call sites that
-        hold no resolution context, so the executors that own both dicts bind
-        the value here instead of threading them through all of them.
+        `_report_expected_failure` has no resolution context of its own, so the
+        executors that own both dicts bind the value ahead of the step.
         """
         expected = self.config.get("expected_error")
         if isinstance(expected, str):
@@ -1288,28 +1281,21 @@ class BaseStep:
             )
 
     def _failure_detail(self, result: dict[str, Any]) -> str:
-        """The most specific error text a `fail()` result carries.
-
-        `fail()` records the step's own message under `error` and the
-        underlying cause under `exception.message`. `expected_error` has to
-        match the cause, so report both rather than the generic message alone.
-        """
+        """`fail()` files the step's own message under `error` and the cause
+        under `exception.message`; `expected_error` has to match the cause."""
         message = str(result.get("error", "Unknown error"))
         exception = result.get("exception")
         cause = exception.get("message") if isinstance(exception, dict) else None
-        # Most call sites build the message as f"<verb> failed: {e}" and pass
-        # the same exception, so appending the cause unconditionally prints it
-        # twice.
+        # Call sites usually build the message as f"<verb> failed: {e}" from the
+        # same exception, so appending unconditionally would print it twice.
         if not cause or cause in message:
             return message
         return f"{message}: {cause}"
 
     def _jsonrpc_error_detail(self, result_data: Any) -> str:
-        """Flatten a JSON-RPC error envelope onto one line for `expected_error`.
-
-        merod puts the refusal reason in `error.data` for some routes and
-        `error.type` for others, so both are included verbatim.
-        """
+        """Flatten a JSON-RPC error envelope onto one line. merod puts the
+        refusal reason in `error.data` on some routes and `error.type` on
+        others, so `expected_error` gets both verbatim."""
         error = result_data.get("error") if isinstance(result_data, dict) else None
         if isinstance(error, dict):
             return (
@@ -1323,11 +1309,9 @@ class BaseStep:
     def _report_expected_failure(self, error_message: str) -> bool:
         """Report an expected failure, returning whether it was the RIGHT one.
 
-        With no `expected_error` configured any failure satisfies the step, so
-        this returns True. With one configured the step passes only if the
-        recorded message contains that substring (case-sensitive) - otherwise
-        `expected_failure: true` would green-light a refusal that never
-        happened, e.g. an unreachable node standing in for a rejected upgrade.
+        Any failure satisfies a step with no `expected_error`; with one, only a
+        message containing it (case-sensitive), so an unreachable node cannot
+        stand in for the refusal under test.
         """
         expected = self._expected_error
         if expected is not None and expected not in error_message:
@@ -1348,12 +1332,8 @@ class BaseStep:
         return True
 
     def _report_unexpected_success(self) -> bool:
-        """Fail the step when `expected_failure: true` was set but it succeeded.
-
-        A negative test whose subject succeeds has not been proven - it has
-        been disproven, so returning True here would make every gate the flag
-        guards unable to fail.
-        """
+        """A negative test whose subject succeeds has been disproven, so passing
+        here would make every gate the flag guards unable to fail."""
         console.print("[red]✗ expected_failure was set but the step succeeded[/red]")
         return False
 

--- a/merobox/commands/bootstrap/steps/context.py
+++ b/merobox/commands/bootstrap/steps/context.py
@@ -204,8 +204,9 @@ class CreateContextStep(BaseStep):
             # Check if the JSON-RPC response contains an error
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 return False
 
             # Store result for later use
@@ -249,12 +250,11 @@ class CreateContextStep(BaseStep):
                     )
 
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Context creation failed: "
                 f"{escape(str(result.get('error', 'Unknown error')))}[/red]"

--- a/merobox/commands/bootstrap/steps/delete_blob.py
+++ b/merobox/commands/bootstrap/steps/delete_blob.py
@@ -221,13 +221,12 @@ class DeleteBlobOnDiskStep(BaseStep):
             f"{verb} ({path})[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
     def _fail(self, message: str, expected_failure: bool) -> bool:
         if expected_failure:
-            self._report_expected_failure(message)
-            return True
+            return self._report_expected_failure(message)
         console.print(f"[red]delete_blob_on_disk failed: {message}[/red]")
         return False
 
@@ -316,14 +315,13 @@ class DeleteBlobStep(BaseStep):
                     f"already absent[/green]"
                 )
                 if expected_failure:
-                    self._report_unexpected_success()
+                    return self._report_unexpected_success()
                 return True
             result = fail(f"delete_blob failed: {e}", error=e)
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]delete_blob failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -332,8 +330,9 @@ class DeleteBlobStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         # client-py returns the flat `BlobDeleteResponse` (`{blob_id, deleted}`).
@@ -342,10 +341,9 @@ class DeleteBlobStep(BaseStep):
         data = result["data"]
         if not isinstance(data, dict):
             if expected_failure:
-                self._report_expected_failure(
+                return self._report_expected_failure(
                     f"unexpected delete_blob response type {type(data).__name__}"
                 )
-                return True
             console.print(
                 f"[red]delete_blob on {node_name}: unexpected response type "
                 f"{type(data).__name__}[/red]"
@@ -360,5 +358,5 @@ class DeleteBlobStep(BaseStep):
             f"[green]✓ delete_blob {blob_id} on {node_name}: deleted={deleted}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True

--- a/merobox/commands/bootstrap/steps/download_blob.py
+++ b/merobox/commands/bootstrap/steps/download_blob.py
@@ -104,8 +104,7 @@ class DownloadBlobStep(BaseStep):
         touched.
         """
         if self._is_expected_failure():
-            self._report_expected_failure(reason)
-            return True
+            return self._report_expected_failure(reason)
         console.print(f"[red]✗ {escape(reason)}[/red]")
         return False
 
@@ -285,14 +284,12 @@ class DownloadBlobStep(BaseStep):
         self._export_variables(blob_info, node_name, dynamic_values)
 
         if self._is_expected_failure():
-            # Warn rather than hard-fail, matching every other step's contract.
-            # Worth spelling out for this one: a negative control that succeeds
-            # means the node already had the bytes, so any cross-node assertion
-            # after it is proving nothing.
+            # A negative control that succeeds means the node already had the
+            # bytes, so any cross-node assertion after it proves nothing.
             console.print(
-                f"[yellow]⚠️  {blob_id} WAS retrievable on {node_name} — a "
-                f"following cross-node fetch cannot prove the network path[/yellow]"
+                f"[red]✗ {blob_id} WAS retrievable on {node_name} - a "
+                f"following cross-node fetch cannot prove the network path[/red]"
             )
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
 
         return True

--- a/merobox/commands/bootstrap/steps/execute.py
+++ b/merobox/commands/bootstrap/steps/execute.py
@@ -183,11 +183,6 @@ class ExecuteStep(BaseStep):
                     error_message = result.get("error", "Unknown error")
 
                     if expected_failure:
-                        # This is an expected failure - capture error details and continue
-                        console.print(
-                            f"[yellow]✓ Expected failure occurred: {error_message}[/yellow]"
-                        )
-
                         # Structure error information for export
                         error_info = self._extract_error_info(
                             result, expected=expected_failure
@@ -197,12 +192,14 @@ class ExecuteStep(BaseStep):
                         step_key = f"execute_{node_name}_{method}"
                         workflow_results[step_key] = error_info
 
-                        # Always export error details when expected_failure is True
+                        # Always export error details when expected_failure is
+                        # True, including when `expected_error` rejects the
+                        # verdict below; the assertion that follows needs them.
                         self._export_error_variables(
                             error_info, node_name, dynamic_values
                         )
 
-                        return True
+                        return self._report_expected_failure(str(error_message))
                     else:
                         # Unexpected failure - stop workflow
                         console.print(
@@ -239,10 +236,6 @@ class ExecuteStep(BaseStep):
                         result["data"], expected=expected_failure
                     )
                     if expected_failure:
-                        console.print(
-                            "[yellow]✓ Expected failure occurred (JSON-RPC error detected)[/yellow]"
-                        )
-
                         step_key = f"execute_{node_name}_{method}"
                         workflow_results[step_key] = error_info
 
@@ -250,7 +243,12 @@ class ExecuteStep(BaseStep):
                             error_info, node_name, dynamic_values
                         )
 
-                        return True
+                        # `expected_error` is matched against the whole error
+                        # envelope: merod splits the reason across `error_type`
+                        # and `error_message` inconsistently by route.
+                        return self._report_expected_failure(
+                            f"JSON-RPC error: {error_info.get('error')}"
+                        )
                     else:
                         console.print(
                             "[red]❌ Unexpected JSON-RPC error detected[/red]"
@@ -263,7 +261,10 @@ class ExecuteStep(BaseStep):
                 step_key = f"execute_{node_name}_{method}"
                 workflow_results[step_key] = result["data"]
 
-                # If failure was expected but call succeeded, warn the user
+                # `call` alone stays lenient here where every other step type
+                # now fails: shipped workflows use `expected_failure` on a read
+                # as a soft "may not have propagated yet" probe, and exporting
+                # None error fields is the documented contract for that.
                 if expected_failure:
                     console.print(
                         "[yellow]⚠️  Warning: Expected failure but call succeeded[/yellow]"

--- a/merobox/commands/bootstrap/steps/execute.py
+++ b/merobox/commands/bootstrap/steps/execute.py
@@ -242,11 +242,8 @@ class ExecuteStep(BaseStep):
                             error_info, node_name, dynamic_values
                         )
 
-                        # `expected_error` is matched against the whole error
-                        # envelope: merod splits the reason across `error_type`
-                        # and `error_message` inconsistently by route.
                         return self._report_expected_failure(
-                            f"JSON-RPC error: {error_info.get('error')}"
+                            self._jsonrpc_error_detail(result["data"])
                         )
                     else:
                         console.print(

--- a/merobox/commands/bootstrap/steps/execute.py
+++ b/merobox/commands/bootstrap/steps/execute.py
@@ -192,9 +192,8 @@ class ExecuteStep(BaseStep):
                         step_key = f"execute_{node_name}_{method}"
                         workflow_results[step_key] = error_info
 
-                        # Always export error details when expected_failure is
-                        # True, including when `expected_error` rejects the
-                        # verdict below; the assertion that follows needs them.
+                        # Exported even when `expected_error` rejects the verdict
+                        # below, so the mismatch can be diagnosed.
                         self._export_error_variables(
                             error_info, node_name, dynamic_values
                         )
@@ -261,10 +260,9 @@ class ExecuteStep(BaseStep):
                 step_key = f"execute_{node_name}_{method}"
                 workflow_results[step_key] = result["data"]
 
-                # `call` alone stays lenient here where every other step type
-                # now fails: shipped workflows use `expected_failure` on a read
-                # as a soft "may not have propagated yet" probe, and exporting
-                # None error fields is the documented contract for that.
+                # `call` alone stays lenient where every other step now fails:
+                # workflows use it as a soft "may not have propagated yet" probe
+                # and depend on the None error exports below.
                 if expected_failure:
                     console.print(
                         "[yellow]⚠️  Warning: Expected failure but call succeeded[/yellow]"

--- a/merobox/commands/bootstrap/steps/fuzzy_test.py
+++ b/merobox/commands/bootstrap/steps/fuzzy_test.py
@@ -408,6 +408,9 @@ class FuzzyTestStep(BaseStep):
                 continue
 
             try:
+                step_executor.bind_expected_error(
+                    workflow_results, pattern_dynamic_values
+                )
                 success = await step_executor.execute(
                     workflow_results, pattern_dynamic_values
                 )

--- a/merobox/commands/bootstrap/steps/get_application.py
+++ b/merobox/commands/bootstrap/steps/get_application.py
@@ -71,8 +71,7 @@ class GetApplicationStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]get_application failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -81,8 +80,9 @@ class GetApplicationStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         data = result["data"]
@@ -107,5 +107,5 @@ class GetApplicationStep(BaseStep):
             f"version={version} bytecode={bytecode}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True

--- a/merobox/commands/bootstrap/steps/group_create.py
+++ b/merobox/commands/bootstrap/steps/group_create.py
@@ -86,8 +86,9 @@ class CreateNamespaceStep(BaseStep):
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 return False
 
             namespace_data = result["data"]
@@ -113,12 +114,11 @@ class CreateNamespaceStep(BaseStep):
                 f"{dynamic_values.get(f'namespace_id_{node_name}', 'unknown')}[/green]"
             )
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Namespace creation failed on {node_name}: "
                 f"{escape(str(result.get('error', 'Unknown error')))}[/red]"

--- a/merobox/commands/bootstrap/steps/group_governance.py
+++ b/merobox/commands/bootstrap/steps/group_governance.py
@@ -50,8 +50,7 @@ class UpdateGroupSettingsStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]update_group_settings failed on {node_name}: {result.get('error')}[/red]"
             )
@@ -59,8 +58,9 @@ class UpdateGroupSettingsStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"update_group_settings_{node_name}"] = result["data"]
@@ -68,7 +68,7 @@ class UpdateGroupSettingsStep(BaseStep):
             f"[green]✓ Updated group {group_id} settings (upgrade_policy={upgrade_policy}) on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -110,8 +110,7 @@ class DetachContextFromGroupStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]detach_context_from_group failed on {node_name}: {result.get('error')}[/red]"
             )
@@ -119,8 +118,9 @@ class DetachContextFromGroupStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"detach_context_from_group_{node_name}"] = result["data"]
@@ -128,7 +128,7 @@ class DetachContextFromGroupStep(BaseStep):
             f"[green]✓ Detached context {context_id} from group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -165,8 +165,7 @@ class SyncGroupStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]sync_group failed on {node_name}: {result.get('error')}[/red]"
             )
@@ -174,8 +173,9 @@ class SyncGroupStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"sync_group_{node_name}"] = result["data"]
@@ -183,5 +183,5 @@ class SyncGroupStep(BaseStep):
             f"[green]✓ Triggered governance sync for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True

--- a/merobox/commands/bootstrap/steps/group_invite.py
+++ b/merobox/commands/bootstrap/steps/group_invite.py
@@ -80,8 +80,9 @@ class CreateNamespaceInvitationStep(BaseStep):
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 return False
 
             step_name = self.config.get("name", "")
@@ -111,21 +112,19 @@ class CreateNamespaceInvitationStep(BaseStep):
                 console.print(
                     f"[yellow]⚠️  Could not extract invitation from response on {node_name}[/yellow]"
                 )
-                # The API call itself succeeded (just with an unusable shape);
-                # honor expected_failure the same way the normal success path
-                # does — warn and pass rather than silently failing the step.
+                # The API call itself succeeded (just with an unusable shape),
+                # so route it through the same unexpected-success verdict as
+                # the normal success branch rather than a plain failure.
                 if expected_failure:
-                    self._report_unexpected_success()
-                    return True
+                    return self._report_unexpected_success()
                 return False
 
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Namespace invitation creation failed on {node_name}: "
                 f"{escape(str(result.get('error', 'Unknown error')))}[/red]"

--- a/merobox/commands/bootstrap/steps/group_join.py
+++ b/merobox/commands/bootstrap/steps/group_join.py
@@ -200,8 +200,9 @@ class JoinNamespaceStep(BaseStep):
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 return False
 
             step_key = f"join_namespace_{node_name}"
@@ -228,14 +229,13 @@ class JoinNamespaceStep(BaseStep):
                 f"[green]✓ Node {node_name} joined namespace successfully[/green]"
             )
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             exception = result.get("exception", {})
             detail = exception.get("message", result.get("error", "Unknown error"))
             if expected_failure:
-                self._report_expected_failure(str(detail))
-                return True
+                return self._report_expected_failure(str(detail))
             console.print(f"[red]Join namespace failed on {node_name}: {detail}[/red]")
             self._print_node_logs_on_failure(node_name=node_name, lines=50)
             return False

--- a/merobox/commands/bootstrap/steps/group_management.py
+++ b/merobox/commands/bootstrap/steps/group_management.py
@@ -63,8 +63,7 @@ class RemoveGroupMembersStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Failed to remove group members on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -72,15 +71,16 @@ class RemoveGroupMembersStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"remove_group_members_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Removed {len(members)} member(s) from group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -120,8 +120,7 @@ class ListGroupMembersStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]list_group_members failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -129,8 +128,9 @@ class ListGroupMembersStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"members_{node_name}"] = result["data"]
         self._export_variables(result["data"], node_name, dynamic_values)
@@ -138,7 +138,7 @@ class ListGroupMembersStep(BaseStep):
             f"[green]✓ Listed members for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -183,8 +183,7 @@ class UpdateMemberRoleStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]update_member_role failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -192,15 +191,16 @@ class UpdateMemberRoleStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"update_member_role_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Updated role to '{role}' for {member_id} in group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -246,8 +246,7 @@ class SetMemberCapabilitiesStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]set_member_capabilities failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -255,15 +254,16 @@ class SetMemberCapabilitiesStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"set_member_capabilities_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Set capabilities for {member_id} in group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -355,8 +355,7 @@ class SetMemberAutoFollowStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]set_member_auto_follow failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -364,8 +363,9 @@ class SetMemberAutoFollowStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"set_member_auto_follow_{node_name}"] = result["data"]
         console.print(
@@ -374,7 +374,7 @@ class SetMemberAutoFollowStep(BaseStep):
             f"{group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -419,8 +419,7 @@ class GetMemberCapabilitiesStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]get_member_capabilities failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -428,8 +427,9 @@ class GetMemberCapabilitiesStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"capabilities_{node_name}"] = result["data"]
         self._export_variables(result["data"], node_name, dynamic_values)
@@ -437,7 +437,7 @@ class GetMemberCapabilitiesStep(BaseStep):
             f"[green]✓ Got capabilities for {member_id} in group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -481,8 +481,7 @@ class SetDefaultCapabilitiesStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]set_default_capabilities failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -490,15 +489,16 @@ class SetDefaultCapabilitiesStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"set_default_capabilities_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Set default capabilities for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -550,8 +550,7 @@ class SetSubgroupVisibilityStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]set_subgroup_visibility failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -559,15 +558,16 @@ class SetSubgroupVisibilityStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"set_subgroup_visibility_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Set subgroup visibility to '{visibility}' for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -612,8 +612,7 @@ class GetGroupInfoStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]get_group_info failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -621,14 +620,15 @@ class GetGroupInfoStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"group_info_{node_name}"] = result["data"]
         self._export_variables(result["data"], node_name, dynamic_values)
         console.print(f"[green]✓ Got info for group {group_id} on {node_name}[/green]")
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -668,8 +668,7 @@ class ListGroupContextsStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]list_group_contexts failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -677,8 +676,9 @@ class ListGroupContextsStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"contexts_{node_name}"] = result["data"]
         self._export_variables(result["data"], node_name, dynamic_values)
@@ -686,7 +686,7 @@ class ListGroupContextsStep(BaseStep):
             f"[green]✓ Listed contexts for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -743,19 +743,19 @@ class DeleteGroupStep(BaseStep):
                 "error"
             )
             if expected_failure:
-                self._report_expected_failure(str(exc_msg or "Unknown error"))
-                return True
+                return self._report_expected_failure(str(exc_msg or "Unknown error"))
             console.print(f"[red]delete_group failed on {node_name}: {exc_msg}[/red]")
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"delete_group_{node_name}"] = result["data"]
         console.print(f"[green]✓ Deleted group {group_id} on {node_name}[/green]")
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -813,23 +813,23 @@ class DeleteNamespaceStep(BaseStep):
                 "error"
             )
             if expected_failure:
-                self._report_expected_failure(str(exc_msg or "Unknown error"))
-                return True
+                return self._report_expected_failure(str(exc_msg or "Unknown error"))
             console.print(
                 f"[red]delete_namespace failed on {node_name}: {exc_msg}[/red]"
             )
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"delete_namespace_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Deleted namespace {namespace_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -891,19 +891,19 @@ class DeleteContextStep(BaseStep):
                 "error"
             )
             if expected_failure:
-                self._report_expected_failure(str(exc_msg or "Unknown error"))
-                return True
+                return self._report_expected_failure(str(exc_msg or "Unknown error"))
             console.print(f"[red]delete_context failed on {node_name}: {exc_msg}[/red]")
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"delete_context_{node_name}"] = result["data"]
         console.print(f"[green]✓ Deleted context {context_id} on {node_name}[/green]")
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -944,8 +944,7 @@ class LeaveContextStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             exc_msg = (result.get("exception") or {}).get("message") or result.get(
                 "error"
             )
@@ -953,15 +952,16 @@ class LeaveContextStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"leave_context_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Node {node_name} left context {context_id} locally[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -1003,8 +1003,7 @@ class LeaveGroupStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             exc_msg = (result.get("exception") or {}).get("message") or result.get(
                 "error"
             )
@@ -1012,15 +1011,16 @@ class LeaveGroupStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"leave_group_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Node {node_name} left group {group_id} (MemberLeft published)[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -1063,8 +1063,7 @@ class LeaveNamespaceStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             exc_msg = (result.get("exception") or {}).get("message") or result.get(
                 "error"
             )
@@ -1074,15 +1073,16 @@ class LeaveNamespaceStep(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"leave_namespace_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Node {node_name} left namespace {namespace_id} (cascade complete)[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 

--- a/merobox/commands/bootstrap/steps/group_metadata.py
+++ b/merobox/commands/bootstrap/steps/group_metadata.py
@@ -135,8 +135,7 @@ class _SetMetadataBase(BaseStep):
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
         except Exception as e:
             if expected_failure:
-                self._report_expected_failure(f"node resolution failed: {e}")
-                return True
+                return self._report_expected_failure(f"node resolution failed: {e}")
             console.print(
                 f"[red]Failed to resolve node {node_name}: {escape(str(e))}[/red]"
             )
@@ -150,8 +149,7 @@ class _SetMetadataBase(BaseStep):
                     f"calimero-client-py >= {_REQUIRED_CLIENT_VERSION} (got an older version)"
                 )
                 if expected_failure:
-                    self._report_expected_failure(msg)
-                    return True
+                    return self._report_expected_failure(msg)
                 console.print(f"[red]{msg}[/red]")
                 return False
             method = getattr(client, self._api_method)
@@ -162,8 +160,7 @@ class _SetMetadataBase(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]{self._api_method} failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -172,8 +169,9 @@ class _SetMetadataBase(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             console.print(
                 f"[red]{self._api_method} returned a JSON-RPC error on {node_name}[/red]"
             )
@@ -185,7 +183,7 @@ class _SetMetadataBase(BaseStep):
             f"on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -249,8 +247,7 @@ class _GetMetadataBase(BaseStep):
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
         except Exception as e:
             if expected_failure:
-                self._report_expected_failure(f"node resolution failed: {e}")
-                return True
+                return self._report_expected_failure(f"node resolution failed: {e}")
             console.print(
                 f"[red]Failed to resolve node {node_name}: {escape(str(e))}[/red]"
             )
@@ -264,8 +261,7 @@ class _GetMetadataBase(BaseStep):
                     f"calimero-client-py >= {_REQUIRED_CLIENT_VERSION} (got an older version)"
                 )
                 if expected_failure:
-                    self._report_expected_failure(msg)
-                    return True
+                    return self._report_expected_failure(msg)
                 console.print(f"[red]{msg}[/red]")
                 return False
             method = getattr(client, self._api_method)
@@ -276,8 +272,7 @@ class _GetMetadataBase(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]{self._api_method} failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -285,8 +280,9 @@ class _GetMetadataBase(BaseStep):
             return False
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             console.print(
                 f"[red]{self._api_method} returned a JSON-RPC error on {node_name}[/red]"
             )
@@ -299,7 +295,7 @@ class _GetMetadataBase(BaseStep):
             f"on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import math
 import time
+from collections import Counter
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Any
@@ -150,13 +151,23 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     missing/partial rollup degrades to an all-zero (never-complete) summary
     rather than raising.
 
-    `failed` is reconciled against the per-member states (`max` of the rollup
-    counter and the count of members in `state:"failed"`) so the
-    `assert_migration_complete` fast-exit still honours a failed member even
-    when the rollup is missing or carries a non-int counter — without it the
-    documented fail-fast would silently degrade to a poll-to-timeout. `total`
-    falls back to the member count only when the rollup omits it entirely (an
-    explicit `0` cohort is preserved).
+    `failed`, `in_progress` and `unknown` are each reconciled against the
+    per-member states (`max` of the rollup counter and the count of members in
+    that state) so the `assert_migration_complete` fast-exit still honours a
+    failed member even when the rollup is missing or carries a non-int counter
+    — without it the documented fail-fast would silently degrade to a
+    poll-to-timeout.
+
+    `all_migrated` is then gated on all three being zero AND on no member row
+    holding a state other than `migrated`. `rollup.allMigrated` is core's own
+    answer to "did everyone converge", so trusting it is the one thing this
+    summary must not do: a response claiming it while a member sits `unknown`
+    or `in_progress` would otherwise be reported as converged, and the poll
+    loop checks `all_migrated` before anything else. The unconverged count is
+    taken over every state that is not `migrated` rather than over the three
+    named ones, so a state core spells differently or adds later still blocks
+    a green verdict. `total` falls back to the member count only when the
+    rollup omits it entirely (an explicit `0` cohort is preserved).
 
     `fleet_completed_at` and `cohort_pinned_at_hlc` are the two top-level
     optionals, passed through as `None` when the response omits them.
@@ -200,7 +211,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     raw_members = raw_members if isinstance(raw_members, list) else []
 
     members: list[dict[str, Any]] = []
-    members_failed = 0
+    member_states: Counter = Counter()
     reported_versions: list[int] = []
     residue_total = 0
     failure_reasons: list[str] = []
@@ -210,8 +221,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         report = entry.get("report")
         report = report if isinstance(report, dict) else {}
         state = str(entry.get("state", "")).lower()
-        if state == "failed":
-            members_failed += 1
+        member_states[state] += 1
         schema_version = _opt_int(report.get("schemaVersion"))
         if schema_version is not None:
             reported_versions.append(schema_version)
@@ -242,9 +252,16 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     total_raw = rollup.get("total")
     total = _as_int(total_raw) if total_raw is not None else len(members)
 
-    # Reconcile with member states so a failed member is never missed when the
-    # rollup counter is absent/malformed (see docstring).
-    failed = max(_as_int(rollup.get("failed")), members_failed)
+    # Reconcile every non-converged counter with the member states, so a member
+    # the rollup misses is never dropped (see docstring).
+    failed = max(_as_int(rollup.get("failed")), member_states["failed"])
+    in_progress = max(_as_int(rollup.get("inProgress")), member_states["in_progress"])
+    unknown = max(_as_int(rollup.get("unknown")), member_states["unknown"])
+    # Catches a state core spells differently or adds later, which no named
+    # counter above would see.
+    members_unconverged = sum(
+        count for state, count in member_states.items() if state != "migrated"
+    )
 
     target_version = _opt_int(source.get("targetVersion"))
     below_target = (
@@ -265,16 +282,20 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         "cohort_pinned_at_hlc": source.get("cohortPinnedAtHlc"),
         "total": total,
         "migrated": _as_int(rollup.get("migrated")),
-        "in_progress": _as_int(rollup.get("inProgress")),
-        "unknown": _as_int(rollup.get("unknown")),
+        "in_progress": in_progress,
+        "unknown": unknown,
         "failed": failed,
-        # core computes `allMigrated` directly (true iff every member converged
-        # with zero residue), but the assert poll loop checks all_migrated
-        # BEFORE failed — so gate it on `failed == 0` too, otherwise a response
-        # that (malformed) claims allMigrated while a member is failed would
-        # wrongly satisfy the assertion. An empty/no-record response yields
-        # false either way.
-        "all_migrated": bool(rollup.get("allMigrated", False)) and failed == 0,
+        # `rollup.allMigrated` is core's own answer to "did everyone converge",
+        # so it is reconciled against every non-converged signal rather than
+        # trusted (see docstring). An empty/no-record response yields false
+        # either way.
+        "all_migrated": (
+            bool(rollup.get("allMigrated", False))
+            and failed == 0
+            and in_progress == 0
+            and unknown == 0
+            and members_unconverged == 0
+        ),
         "members_pending_signature": _as_int(rollup.get("membersPendingSignature")),
         # Recomputed from the member rows, never from `rollup`. See docstring.
         "reported_at_target": (

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -128,11 +128,8 @@ def _summarize_cascade_status(response: Any) -> dict[str, Any]:
 
 
 def _opt_int(value: Any) -> int | None:
-    """Return `value` when it is a genuine int, else None (bool is not an int).
-
-    Distinct from the `_as_int` coercion inside the summarizer: a state version
-    or a residue count has a meaningful 0, so absent must not become 0.
-    """
+    """Unlike the summarizer's `_as_int`, absent stays None: a state version or
+    a residue count has a meaningful 0. bool is not an int here."""
     return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
@@ -153,21 +150,12 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
 
     `failed`, `in_progress` and `unknown` are each reconciled against the
     per-member states (`max` of the rollup counter and the count of members in
-    that state) so the `assert_migration_complete` fast-exit still honours a
-    failed member even when the rollup is missing or carries a non-int counter
-    — without it the documented fail-fast would silently degrade to a
-    poll-to-timeout.
-
-    `all_migrated` is then gated on all three being zero AND on no member row
-    holding a state other than `migrated`. `rollup.allMigrated` is core's own
-    answer to "did everyone converge", so trusting it is the one thing this
-    summary must not do: a response claiming it while a member sits `unknown`
-    or `in_progress` would otherwise be reported as converged, and the poll
-    loop checks `all_migrated` before anything else. The unconverged count is
-    taken over every state that is not `migrated` rather than over the three
-    named ones, so a state core spells differently or adds later still blocks
-    a green verdict. `total` falls back to the member count only when the
-    rollup omits it entirely (an explicit `0` cohort is preserved).
+    that state), and `all_migrated` is gated on all three plus on no member row
+    holding a non-`migrated` state - otherwise the fail-fast in
+    `assert_migration_complete`, which reads `all_migrated` first, would degrade
+    to a poll-to-timeout whenever the rollup disagrees with its own member rows.
+    `total` falls back to the member count only when the rollup omits it
+    entirely (an explicit `0` cohort is preserved).
 
     `fleet_completed_at` and `cohort_pinned_at_hlc` are the two top-level
     optionals, passed through as `None` when the response omits them.
@@ -177,31 +165,16 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     back down. Absent must therefore stay distinguishable from `0`, so neither
     goes through `_as_int`.
 
-    Each member row carries its whole report (`schema_version`, `residue_auto`,
-    `synced_up_to_hlc`, `reported_at`, `authored_remaining`) passed through
-    raw, absent as `None`. `report.schemaVersion` is the ABI *state* version of
-    the bytes a member actually holds, which is the only member-level evidence
-    that a state migration ran; the app's own `schema_info` is a constant
-    compiled into the binary and answers the same string whether or not the
-    state was ever migrated.
-
     The `reported_*` / `residue_total` / `failure_reasons` / `stuck_members`
-    aggregates are recomputed here from the raw member rows and NEVER read from
-    `rollup`. That
-    is the point of them: `rollup.allMigrated` is core's own answer to "did
-    everyone converge", so asserting it against itself cannot falsify the
-    rollup arithmetic. Do not "simplify" them back into the rollup fields.
-
-    `reported_at_target` / `reported_below_target` are `None` when the response
-    carries no `targetVersion` (a namespace with no upgrade record). Defaulting
-    the target to 0 would classify every member as at-target and hand back a
-    green summary for a namespace that never migrated. The other four
-    aggregates do not depend on the target and are always computed: a cohort
-    where nobody reported must surface as `reported_missing`, not as zeroes.
-    Together `reported_at_target`, `reported_below_target` and
-    `reported_missing` partition the member rows; a report whose
-    `schemaVersion` is missing or non-integer counts as missing, the direction
-    that cannot manufacture a green result.
+    aggregates are recomputed from the raw member rows and NEVER read from
+    `rollup`: asserting core's own convergence answer against itself cannot
+    falsify it. Do not "simplify" them back into the rollup fields.
+    `report.schemaVersion` is the ABI *state* version a member actually holds,
+    the only member-level evidence a migration ran - the app's `schema_info` is
+    a constant compiled into the binary. A missing or non-integer version counts
+    as `reported_missing`, the direction that cannot manufacture a green result,
+    and the two target-relative counters stay `None` with no `targetVersion` so
+    a namespace that never migrated is not reported as fully at-target.
 
     The summary is an allowlist, which silently drops anything core adds later.
     """
@@ -216,27 +189,29 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     reported_versions: list[int] = []
     residue_total = 0
     failure_reasons: list[str] = []
+    stuck_members: list[str] = []
     for entry in raw_members:
         if not isinstance(entry, dict):
             continue
         report = entry.get("report")
         report = report if isinstance(report, dict) else {}
         state = str(entry.get("state", "")).lower()
-        # Counted on a separator-free key: the response spells its sibling
-        # rollup counter `inProgress`, so lowercasing a camelCase state gives
-        # `inprogress` and matching only `in_progress` would silently skip the
-        # reconciliation. The row keeps the lowercased value it always had.
+        # Counted on a separator-free key: core spells the sibling rollup counter
+        # `inProgress`, so matching only `in_progress` would skip reconciliation.
         member_states[state.replace("_", "").replace("-", "")] += 1
         schema_version = _opt_int(report.get("schemaVersion"))
         if schema_version is not None:
             reported_versions.append(schema_version)
         residue_total += _opt_int(report.get("residueAuto")) or 0
+        peer = entry.get("peer")
         reason = report.get("migrationFailed")
         if reason is not None:
             failure_reasons.append(str(reason))
+            if peer is not None:
+                stuck_members.append(str(peer))
         members.append(
             {
-                "peer": entry.get("peer"),
+                "peer": peer,
                 "state": state,
                 "migration_failed": reason,
                 "schema_version": report.get("schemaVersion"),
@@ -290,17 +265,10 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         "in_progress": in_progress,
         "unknown": unknown,
         "failed": failed,
-        # `rollup.allMigrated` is core's own answer to "did everyone converge",
-        # so it is reconciled against every non-converged signal rather than
-        # trusted (see docstring). An empty/no-record response yields false
-        # either way.
-        "all_migrated": (
-            bool(rollup.get("allMigrated", False))
-            and failed == 0
-            and in_progress == 0
-            and unknown == 0
-            and members_unconverged == 0
-        ),
+        # Reconciled against every non-converged signal rather than trusted (see
+        # docstring). An empty/no-record response yields false either way.
+        "all_migrated": bool(rollup.get("allMigrated", False))
+        and not (failed or in_progress or unknown or members_unconverged),
         "members_pending_signature": _as_int(rollup.get("membersPendingSignature")),
         # Recomputed from the member rows, never from `rollup`. See docstring.
         "reported_at_target": (
@@ -313,18 +281,9 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         ),
         "residue_total": residue_total,
         "failure_reasons": sorted(failure_reasons),
-        # The peers behind those reasons. `failure_reasons` names WHAT went
-        # wrong; a count plus a reason still does not say WHICH member is
-        # holding the fleet back. Sorted, so it does not depend on member
-        # ordering the API never promised.
-        # `.get`, not `[]`: a member row omits the keys its node did not send,
-        # so a healthy member carries no `migration_failed` at all.
-        "stuck_members": sorted(
-            str(member["peer"])
-            for member in members
-            if member.get("migration_failed") is not None
-            and member.get("peer") is not None
-        ),
+        # `failure_reasons` names WHAT went wrong; this names WHICH member is
+        # holding the fleet back. Sorted, member order is not promised.
+        "stuck_members": sorted(stuck_members),
         "members": members,
     }
 
@@ -1428,8 +1387,7 @@ class AssertMigrationCompleteStep(BaseStep):
                 f"{last_summary['unknown']} unknown, {last_summary['failed']} failed"
             )
             # The counters alone cannot separate "a member is slow" from "a
-            # member is answering with the wrong state version", which is the
-            # whole reason the reported-version aggregates exist.
+            # member is on the wrong state version".
             below = last_summary["reported_below_target"]
             if below:
                 detail += (

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -317,10 +317,13 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         # wrong; a count plus a reason still does not say WHICH member is
         # holding the fleet back. Sorted, so it does not depend on member
         # ordering the API never promised.
+        # `.get`, not `[]`: a member row omits the keys its node did not send,
+        # so a healthy member carries no `migration_failed` at all.
         "stuck_members": sorted(
             str(member["peer"])
             for member in members
-            if member["migration_failed"] is not None and member["peer"] is not None
+            if member.get("migration_failed") is not None
+            and member.get("peer") is not None
         ),
         "members": members,
     }

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -126,6 +126,15 @@ def _summarize_cascade_status(response: Any) -> dict[str, Any]:
     }
 
 
+def _opt_int(value: Any) -> int | None:
+    """Return `value` when it is a genuine int, else None (bool is not an int).
+
+    Distinct from the `_as_int` coercion inside the summarizer: a state version
+    or a residue count has a meaningful 0, so absent must not become 0.
+    """
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 def _summarize_migration_status(response: Any) -> dict[str, Any]:
     """Flatten a `get_migration_status` response into a flat, exportable summary.
 
@@ -157,11 +166,32 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     back down. Absent must therefore stay distinguishable from `0`, so neither
     goes through `_as_int`.
 
+    Each member row carries its whole report (`schema_version`, `residue_auto`,
+    `synced_up_to_hlc`, `reported_at`, `authored_remaining`) passed through
+    raw, absent as `None`. `report.schemaVersion` is the ABI *state* version of
+    the bytes a member actually holds, which is the only member-level evidence
+    that a state migration ran; the app's own `schema_info` is a constant
+    compiled into the binary and answers the same string whether or not the
+    state was ever migrated.
+
+    The six `reported_*` / `residue_total` / `failure_reasons` aggregates are
+    recomputed here from the raw member rows and NEVER read from `rollup`. That
+    is the point of them: `rollup.allMigrated` is core's own answer to "did
+    everyone converge", so asserting it against itself cannot falsify the
+    rollup arithmetic. Do not "simplify" them back into the rollup fields.
+
+    `reported_at_target` / `reported_below_target` are `None` when the response
+    carries no `targetVersion` (a namespace with no upgrade record). Defaulting
+    the target to 0 would classify every member as at-target and hand back a
+    green summary for a namespace that never migrated. The other four
+    aggregates do not depend on the target and are always computed: a cohort
+    where nobody reported must surface as `reported_missing`, not as zeroes.
+    Together `reported_at_target`, `reported_below_target` and
+    `reported_missing` partition the member rows; a report whose
+    `schemaVersion` is missing or non-integer counts as missing, the direction
+    that cannot manufacture a green result.
+
     The summary is an allowlist, which silently drops anything core adds later.
-    The per-member rows are deliberately narrowed to `peer`, `state`, and
-    `migration_failed`; the rest of each member's report (`schema_version`,
-    `residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`) is
-    reachable only by widening that loop.
     """
     source = response if isinstance(response, dict) else {}
     rollup = source.get("rollup")
@@ -171,21 +201,34 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
 
     members: list[dict[str, Any]] = []
     members_failed = 0
+    reported_versions: list[int] = []
+    residue_total = 0
+    failure_reasons: list[str] = []
     for entry in raw_members:
         if not isinstance(entry, dict):
             continue
         report = entry.get("report")
-        report = report if isinstance(report, dict) else None
+        report = report if isinstance(report, dict) else {}
         state = str(entry.get("state", "")).lower()
         if state == "failed":
             members_failed += 1
+        schema_version = _opt_int(report.get("schemaVersion"))
+        if schema_version is not None:
+            reported_versions.append(schema_version)
+        residue_total += _opt_int(report.get("residueAuto")) or 0
+        reason = report.get("migrationFailed")
+        if reason is not None:
+            failure_reasons.append(str(reason))
         members.append(
             {
                 "peer": entry.get("peer"),
                 "state": state,
-                "migration_failed": (
-                    report.get("migrationFailed") if report is not None else None
-                ),
+                "migration_failed": reason,
+                "schema_version": report.get("schemaVersion"),
+                "residue_auto": report.get("residueAuto"),
+                "synced_up_to_hlc": report.get("syncedUpToHlc"),
+                "reported_at": report.get("reportedAt"),
+                "authored_remaining": report.get("authoredRemaining"),
             }
         )
 
@@ -202,6 +245,13 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     # Reconcile with member states so a failed member is never missed when the
     # rollup counter is absent/malformed (see docstring).
     failed = max(_as_int(rollup.get("failed")), members_failed)
+
+    target_version = _opt_int(source.get("targetVersion"))
+    below_target = (
+        None
+        if target_version is None
+        else sum(1 for v in reported_versions if v < target_version)
+    )
 
     return {
         "target_version": source.get("targetVersion"),
@@ -226,6 +276,17 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         # false either way.
         "all_migrated": bool(rollup.get("allMigrated", False)) and failed == 0,
         "members_pending_signature": _as_int(rollup.get("membersPendingSignature")),
+        # Recomputed from the member rows, never from `rollup`. See docstring.
+        "reported_at_target": (
+            None if below_target is None else len(reported_versions) - below_target
+        ),
+        "reported_below_target": below_target,
+        "reported_missing": len(members) - len(reported_versions),
+        "min_reported_schema_version": (
+            min(reported_versions) if reported_versions else None
+        ),
+        "residue_total": residue_total,
+        "failure_reasons": sorted(failure_reasons),
         "members": members,
     }
 
@@ -283,8 +344,7 @@ class RegisterGroupSigningKeyStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]register_group_signing_key failed on {node_name}: {result.get('error')}[/red]"
             )
@@ -292,8 +352,9 @@ class RegisterGroupSigningKeyStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         # Deliberately do NOT store the raw API response: if the server ever
@@ -308,7 +369,7 @@ class RegisterGroupSigningKeyStep(BaseStep):
             f"[green]✓ Registered signing key for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -360,8 +421,7 @@ class UpgradeGroupStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -386,8 +446,7 @@ class UpgradeGroupStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]upgrade_group failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -396,8 +455,9 @@ class UpgradeGroupStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"upgrade_group_{node_name}"] = result["data"]
@@ -405,7 +465,7 @@ class UpgradeGroupStep(BaseStep):
             f"[green]✓ Initiated upgrade of group {group_id} to {target_application_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -482,8 +542,7 @@ class CascadeNamespaceApplicationStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -515,8 +574,7 @@ class CascadeNamespaceApplicationStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]cascade_namespace_application failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -525,8 +583,9 @@ class CascadeNamespaceApplicationStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"cascade_namespace_application_{node_name}"] = result["data"]
@@ -540,7 +599,7 @@ class CascadeNamespaceApplicationStep(BaseStep):
             f"[green]✓ Cascaded namespace {namespace_id} to {target_application_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -587,8 +646,7 @@ class GetGroupUpgradeStatusStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]get_group_upgrade_status failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -597,8 +655,9 @@ class GetGroupUpgradeStatusStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"upgrade_status_{node_name}"] = result["data"]
@@ -611,7 +670,7 @@ class GetGroupUpgradeStatusStep(BaseStep):
             f"[green]✓ Read upgrade status for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -648,8 +707,7 @@ class RetryGroupUpgradeStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]retry_group_upgrade failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -658,8 +716,9 @@ class RetryGroupUpgradeStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"retry_group_upgrade_{node_name}"] = result["data"]
@@ -667,7 +726,7 @@ class RetryGroupUpgradeStep(BaseStep):
             f"[green]✓ Retried upgrade for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -715,8 +774,7 @@ class GetCascadeStatusStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -736,8 +794,7 @@ class GetCascadeStatusStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]get_cascade_status failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -749,8 +806,9 @@ class GetCascadeStatusStep(BaseStep):
         # an empty (all-zero) status.
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         summary = _summarize_cascade_status(result["data"])
@@ -767,7 +825,7 @@ class GetCascadeStatusStep(BaseStep):
             f"{summary['pending']} pending, {summary['failed']} failed[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -838,8 +896,7 @@ class AssertCascadeCompleteStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if expected_failure:
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -867,8 +924,7 @@ class AssertCascadeCompleteStep(BaseStep):
             client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
         except Exception as e:
             if expected_failure:
-                self._report_expected_failure(str(e))
-                return True
+                return self._report_expected_failure(str(e))
             console.print(
                 f"[red]assert_cascade_complete: failed to reach {node_name}: "
                 f"{escape(str(e))}[/red]"
@@ -931,7 +987,7 @@ class AssertCascadeCompleteStep(BaseStep):
                         f"all {summary['total']} groups migrated on {node_name}[/green]"
                     )
                     if expected_failure:
-                        self._report_unexpected_success()
+                        return self._report_unexpected_success()
                     return True
                 if summary["failed"] > 0:
                     # Unrecoverable: a failed descendant means all_completed
@@ -960,8 +1016,7 @@ class AssertCascadeCompleteStep(BaseStep):
         )
 
         if expected_failure:
-            self._report_expected_failure(msg)
-            return True
+            return self._report_expected_failure(msg)
         console.print(f"[red]✗ {msg}[/red]")
         return False
 
@@ -1006,8 +1061,7 @@ class AbortMigrationStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -1027,8 +1081,7 @@ class AbortMigrationStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]abort_migration failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -1038,8 +1091,9 @@ class AbortMigrationStep(BaseStep):
         # A transport-level success can still carry a JSON-RPC error body.
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         # The abort route returns a `{namespace_id, aborted}` object; coerce any
@@ -1056,7 +1110,7 @@ class AbortMigrationStep(BaseStep):
             f"aborted={aborted}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -1102,8 +1156,7 @@ class GetMigrationStatusStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -1123,8 +1176,7 @@ class GetMigrationStatusStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]get_migration_status failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -1135,8 +1187,9 @@ class GetMigrationStatusStep(BaseStep):
         # the cascade-status step so it isn't silently summarised as empty.
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         summary = _summarize_migration_status(result["data"])
@@ -1150,7 +1203,7 @@ class GetMigrationStatusStep(BaseStep):
             f"{summary['failed']} failed[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -1221,8 +1274,7 @@ class AssertMigrationCompleteStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if expected_failure:
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -1249,8 +1301,7 @@ class AssertMigrationCompleteStep(BaseStep):
             client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
         except Exception as e:
             if expected_failure:
-                self._report_expected_failure(str(e))
-                return True
+                return self._report_expected_failure(str(e))
             console.print(
                 f"[red]assert_migration_complete: failed to reach {node_name}: "
                 f"{escape(str(e))}[/red]"
@@ -1310,7 +1361,7 @@ class AssertMigrationCompleteStep(BaseStep):
                         f"all {summary['total']} cohort members migrated on {node_name}[/green]"
                     )
                     if expected_failure:
-                        self._report_unexpected_success()
+                        return self._report_unexpected_success()
                     return True
                 if summary["failed"] > 0:
                     # Unrecoverable: a failed member means all_migrated is
@@ -1338,6 +1389,21 @@ class AssertMigrationCompleteStep(BaseStep):
                 f"{last_summary['in_progress']} in-progress, "
                 f"{last_summary['unknown']} unknown, {last_summary['failed']} failed"
             )
+            # The counters alone cannot separate "a member is slow" from "a
+            # member is answering with the wrong state version", which is the
+            # whole reason the reported-version aggregates exist.
+            below = last_summary["reported_below_target"]
+            if below:
+                detail += (
+                    f" - {below} member(s) below target state version "
+                    f"{last_summary['target_version']} "
+                    f"(min reported: {last_summary['min_reported_schema_version']})"
+                )
+            if last_summary["reported_missing"]:
+                detail += (
+                    f" - {last_summary['reported_missing']} member(s) with no "
+                    f"reported state version"
+                )
         else:
             detail = "no successful status read"
             # No poll ever succeeded, so there's no summary to export. Synthesising
@@ -1354,8 +1420,7 @@ class AssertMigrationCompleteStep(BaseStep):
         )
 
         if expected_failure:
-            self._report_expected_failure(msg)
-            return True
+            return self._report_expected_failure(msg)
         console.print(f"[red]✗ {msg}[/red]")
         return False
 
@@ -1405,8 +1470,7 @@ class ResyncContextStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -1431,8 +1495,7 @@ class ResyncContextStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]resync_context failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -1441,8 +1504,9 @@ class ResyncContextStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         raw = result["data"]
@@ -1463,7 +1527,7 @@ class ResyncContextStep(BaseStep):
             f"resync_started={resync_started}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -1513,8 +1577,7 @@ class ListApplicationVersionsStep(BaseStep):
                 f"(installed: {_CLIENT_PY_VERSION_STR}) on {node_name}"
             )
             if self._is_expected_failure():
-                self._report_expected_failure(msg)
-                return True
+                return self._report_expected_failure(msg)
             console.print(f"[red]{msg}[/red]")
             return False
 
@@ -1534,8 +1597,7 @@ class ListApplicationVersionsStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]list_application_versions failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -1544,8 +1606,9 @@ class ListApplicationVersionsStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         data = result["data"]
@@ -1573,5 +1636,5 @@ class ListApplicationVersionsStep(BaseStep):
             f"{summary['count']} version(s)[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -221,7 +221,11 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         report = entry.get("report")
         report = report if isinstance(report, dict) else {}
         state = str(entry.get("state", "")).lower()
-        member_states[state] += 1
+        # Counted on a separator-free key: the response spells its sibling
+        # rollup counter `inProgress`, so lowercasing a camelCase state gives
+        # `inprogress` and matching only `in_progress` would silently skip the
+        # reconciliation. The row keeps the lowercased value it always had.
+        member_states[state.replace("_", "").replace("-", "")] += 1
         schema_version = _opt_int(report.get("schemaVersion"))
         if schema_version is not None:
             reported_versions.append(schema_version)
@@ -255,7 +259,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     # Reconcile every non-converged counter with the member states, so a member
     # the rollup misses is never dropped (see docstring).
     failed = max(_as_int(rollup.get("failed")), member_states["failed"])
-    in_progress = max(_as_int(rollup.get("inProgress")), member_states["in_progress"])
+    in_progress = max(_as_int(rollup.get("inProgress")), member_states["inprogress"])
     unknown = max(_as_int(rollup.get("unknown")), member_states["unknown"])
     # Catches a state core spells differently or adds later, which no named
     # counter above would see.

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -185,8 +185,9 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     compiled into the binary and answers the same string whether or not the
     state was ever migrated.
 
-    The six `reported_*` / `residue_total` / `failure_reasons` aggregates are
-    recomputed here from the raw member rows and NEVER read from `rollup`. That
+    The `reported_*` / `residue_total` / `failure_reasons` / `stuck_members`
+    aggregates are recomputed here from the raw member rows and NEVER read from
+    `rollup`. That
     is the point of them: `rollup.allMigrated` is core's own answer to "did
     everyone converge", so asserting it against itself cannot falsify the
     rollup arithmetic. Do not "simplify" them back into the rollup fields.
@@ -312,6 +313,15 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         ),
         "residue_total": residue_total,
         "failure_reasons": sorted(failure_reasons),
+        # The peers behind those reasons. `failure_reasons` names WHAT went
+        # wrong; a count plus a reason still does not say WHICH member is
+        # holding the fleet back. Sorted, so it does not depend on member
+        # ordering the API never promised.
+        "stuck_members": sorted(
+            str(member["peer"])
+            for member in members
+            if member["migration_failed"] is not None and member["peer"] is not None
+        ),
         "members": members,
     }
 

--- a/merobox/commands/bootstrap/steps/install.py
+++ b/merobox/commands/bootstrap/steps/install.py
@@ -242,8 +242,9 @@ class InstallApplicationStep(BaseStep):
             # Check if the JSON-RPC response contains an error
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 # Print node logs to help with debugging
                 self._print_node_logs_on_failure(node_name=node_name, lines=50)
                 return False
@@ -286,12 +287,11 @@ class InstallApplicationStep(BaseStep):
                     )
 
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Installation failed: {result.get('error', 'Unknown error')}[/red]"
             )

--- a/merobox/commands/bootstrap/steps/invite_open.py
+++ b/merobox/commands/bootstrap/steps/invite_open.py
@@ -99,8 +99,7 @@ class InviteOpenStep(BaseStep):
 
         if not result.get("success"):
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(f"  Error: {escape(str(result.get('error')))}")
             console.print(
                 f"[red]Namespace invitation creation failed: "
@@ -110,8 +109,9 @@ class InviteOpenStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         step_key = f"invite_{node_name}_{namespace_id}"
@@ -124,5 +124,5 @@ class InviteOpenStep(BaseStep):
         self._export_variables(synthetic_response, node_name, dynamic_values)
 
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True

--- a/merobox/commands/bootstrap/steps/join_context.py
+++ b/merobox/commands/bootstrap/steps/join_context.py
@@ -66,8 +66,9 @@ class JoinContextStep(BaseStep):
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 return False
 
             step_key = f"join_context_{node_name}"
@@ -93,12 +94,11 @@ class JoinContextStep(BaseStep):
                 f"[green]✓ Node {node_name} joined context {context_id}[/green]"
             )
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Join context failed on {node_name}: "
                 f"{escape(str(result.get('error', 'Unknown error')))}[/red]"

--- a/merobox/commands/bootstrap/steps/join_subgroup_inheritance.py
+++ b/merobox/commands/bootstrap/steps/join_subgroup_inheritance.py
@@ -92,8 +92,9 @@ class JoinSubgroupInheritanceStep(BaseStep):
         if result["success"]:
             if self._check_jsonrpc_error(result["data"]):
                 if expected_failure:
-                    self._report_expected_failure("JSON-RPC error returned")
-                    return True
+                    return self._report_expected_failure(
+                        self._jsonrpc_error_detail(result["data"])
+                    )
                 return False
 
             step_key = f"join_subgroup_inheritance_{node_name}"
@@ -126,12 +127,11 @@ class JoinSubgroupInheritanceStep(BaseStep):
                 f"via inheritance[/green]"
             )
             if expected_failure:
-                self._report_unexpected_success()
+                return self._report_unexpected_success()
             return True
         else:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]join_subgroup_inheritance failed on {node_name}: "
                 f"{escape(str(result.get('error', 'Unknown error')))}[/red]"

--- a/merobox/commands/bootstrap/steps/login.py
+++ b/merobox/commands/bootstrap/steps/login.py
@@ -88,8 +88,7 @@ class LoginStep(BaseStep):
                         f"connectivity error for {node_name}: {escape(str(e))}[/red]"
                     )
                     return False
-                self._report_expected_failure(str(e))
-                return True
+                return self._report_expected_failure(str(e))
             console.print(
                 f"[red]❌ Login failed for {node_name}: {escape(str(e))}[/red]"
             )

--- a/merobox/commands/bootstrap/steps/namespace.py
+++ b/merobox/commands/bootstrap/steps/namespace.py
@@ -243,8 +243,7 @@ class CreateGroupInNamespaceStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Failed to create group in namespace on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -253,14 +252,15 @@ class CreateGroupInNamespaceStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"group_in_namespace_{node_name}"] = result["data"]
         self._export_variables(result["data"], node_name, dynamic_values)
         console.print(f"[green]✓ Created group in namespace on {node_name}[/green]")
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 

--- a/merobox/commands/bootstrap/steps/parallel.py
+++ b/merobox/commands/bootstrap/steps/parallel.py
@@ -593,6 +593,9 @@ class ParallelStep(BaseStep):
                             }
 
                         # Execute the nested step
+                        step_executor.bind_expected_error(
+                            workflow_results, iteration_dynamic_values
+                        )
                         success = await step_executor.execute(
                             workflow_results, iteration_dynamic_values
                         )

--- a/merobox/commands/bootstrap/steps/refresh.py
+++ b/merobox/commands/bootstrap/steps/refresh.py
@@ -78,8 +78,7 @@ class RefreshStep(BaseStep):
                         f"connectivity error for {node_name}: {escape(str(e))}[/red]"
                     )
                     return False
-                self._report_expected_failure(str(e))
-                return True
+                return self._report_expected_failure(str(e))
             console.print(
                 f"[red]❌ Token refresh failed for {node_name}: {escape(str(e))}[/red]"
             )

--- a/merobox/commands/bootstrap/steps/repeat.py
+++ b/merobox/commands/bootstrap/steps/repeat.py
@@ -215,6 +215,9 @@ class RepeatStep(BaseStep):
                         return False
 
                     # Execute the nested step with iteration-specific dynamic values
+                    step_executor.bind_expected_error(
+                        workflow_results, iteration_dynamic_values
+                    )
                     success = await step_executor.execute(
                         workflow_results, iteration_dynamic_values
                     )

--- a/merobox/commands/bootstrap/steps/subgroup.py
+++ b/merobox/commands/bootstrap/steps/subgroup.py
@@ -57,8 +57,7 @@ class ReparentGroupStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]reparent_group failed on {node_name}: "
                 f"{escape(str(result.get('error', 'Unknown error')))}[/red]"
@@ -67,8 +66,9 @@ class ReparentGroupStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
 
         workflow_results[f"reparent_group_{node_name}"] = result["data"]
@@ -76,7 +76,7 @@ class ReparentGroupStep(BaseStep):
             f"[green]✓ Reparented group {child_group_id} to {new_parent_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -183,8 +183,7 @@ class AddGroupMembersStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Failed to add group members on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -193,13 +192,14 @@ class AddGroupMembersStep(BaseStep):
 
         if self._check_jsonrpc_error(result["data"]):
             if expected_failure:
-                self._report_expected_failure("JSON-RPC error returned")
-                return True
+                return self._report_expected_failure(
+                    self._jsonrpc_error_detail(result["data"])
+                )
             return False
         workflow_results[f"add_group_members_{node_name}"] = result["data"]
         console.print(
             f"[green]✓ Added {len(resolved_members)} member(s) to group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True

--- a/merobox/commands/bootstrap/steps/tee.py
+++ b/merobox/commands/bootstrap/steps/tee.py
@@ -159,8 +159,7 @@ class SetTeeAdmissionPolicyStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]set_tee_admission_policy failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -173,7 +172,7 @@ class SetTeeAdmissionPolicyStep(BaseStep):
             f"for group {group_id} on {node_name}[/green]"
         )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 
@@ -243,8 +242,7 @@ class TeeFleetJoinStep(BaseStep):
 
         if not result["success"]:
             if expected_failure:
-                self._report_expected_failure(str(result.get("error", "Unknown error")))
-                return True
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]tee_fleet_join failed on {node_name}: "
                 f"{escape(str(result.get('error')))}[/red]"
@@ -278,7 +276,7 @@ class TeeFleetJoinStep(BaseStep):
                 f"assert_tee_member is the gate)[/yellow]"
             )
         if expected_failure:
-            self._report_unexpected_success()
+            return self._report_unexpected_success()
         return True
 
 

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -195,8 +195,7 @@ class WebSocketConnectStep(_WebSocketStepBase):
             return False
 
         if expected_failure:
-            self._report_unexpected_success()
-            return False
+            return self._report_unexpected_success()
 
         console.print(f"[green]✓ WebSocket connected to {node_name}[/green]")
         return True

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -174,8 +174,7 @@ class WebSocketConnectStep(_WebSocketStepBase):
             detail = self._redact(str(e), token)
             if expected_failure:
                 if e.status in (401, 403):
-                    self._report_expected_failure(detail)
-                    return True
+                    return self._report_expected_failure(detail)
                 console.print(
                     f"[red]❌ Expected a 401/403 auth rejection but the "
                     f"{node_name} handshake returned HTTP {e.status}[/red]"

--- a/merobox/tests/unit/test_download_blob_step.py
+++ b/merobox/tests/unit/test_download_blob_step.py
@@ -328,9 +328,8 @@ class TestDownloadBlobExpectedFailure:
             assert _run(step.execute({}, {})) is False
 
     def test_unexpected_success_fails_but_still_exports(self):
-        # The negative control's premise is that the bytes are NOT here. If they
-        # are, the following cross-node fetch proves nothing, so the step fails,
-        # but the export still lands so the failure can be diagnosed.
+        # The negative control's premise is that the bytes are NOT here; if they
+        # are it proves nothing. The export still lands, to diagnose the failure.
         step = DownloadBlobStep(self.config)
         client = MagicMock()
         client.download_blob.return_value = _PAYLOAD

--- a/merobox/tests/unit/test_download_blob_step.py
+++ b/merobox/tests/unit/test_download_blob_step.py
@@ -327,16 +327,17 @@ class TestDownloadBlobExpectedFailure:
         with p1, p2, p3:
             assert _run(step.execute({}, {})) is False
 
-    def test_unexpected_success_still_returns_true_and_exports(self):
-        # Warn-only, matching every other step's `expected_failure` contract —
-        # an over-eager flag must not flip a passing workflow to failing.
+    def test_unexpected_success_fails_but_still_exports(self):
+        # The negative control's premise is that the bytes are NOT here. If they
+        # are, the following cross-node fetch proves nothing, so the step fails,
+        # but the export still lands so the failure can be diagnosed.
         step = DownloadBlobStep(self.config)
         client = MagicMock()
         client.download_blob.return_value = _PAYLOAD
         workflow_results = {}
         p1, p2, p3 = self._patched(step, client)
         with p1, p2, p3:
-            assert _run(step.execute(workflow_results, {})) is True
+            assert _run(step.execute(workflow_results, {})) is False
         assert workflow_results["downloaded_blob_node-2"]["sha256"] == _SHA
 
     def test_unresolved_placeholder_fails_even_when_expected(self):

--- a/merobox/tests/unit/test_expected_failure.py
+++ b/merobox/tests/unit/test_expected_failure.py
@@ -78,11 +78,8 @@ class TestExpectedFailureHelpers:
 
 
 class TestExpectedErrorHelper:
-    """`expected_error` pins WHICH failure a negative test accepts.
-
-    Without it `expected_failure: true` passes on any error at all, including
-    the node being unreachable standing in for the refusal under test.
-    """
+    """`expected_error` pins WHICH failure a negative test accepts; without it
+    an unreachable node stands in for the refusal under test."""
 
     def _step(self, **extra):
         return JoinContextStep(
@@ -165,8 +162,8 @@ class TestExpectedErrorHelper:
 
     @pytest.mark.asyncio
     async def test_the_workflow_executor_binds_before_running_a_step(self):
-        # The binding is what makes a dynamic `expected_error` work at all, so
-        # the executor forgetting it must not be a silent regression.
+        # A dynamic `expected_error` only works if the executor binds it, so
+        # dropping that call must not be a silent regression.
         from merobox.commands.bootstrap.run.executor import WorkflowExecutor
 
         step = self._step(expected_failure=True, expected_error="{{reason}}")
@@ -237,11 +234,8 @@ class TestJoinContextExpectedFailure:
     def test_jsonrpc_error_path_passes_when_expected(self):
         """HTTP-200 response carrying a JSON-RPC error envelope is the
         real-world shape merod returns for "context does not belong to any
-        group" - this is the branch we regressed on before the fix.
-
-        `ok()` stores the client's return value verbatim under `data`, so the
-        error envelope has to be at the top level of what the client returns
-        for `_check_jsonrpc_error` to see it.
+        group" - this is the branch we regressed on before the fix. `ok()`
+        stores the client's return verbatim, so the envelope must be top level.
         """
         mock_client = MagicMock()
         mock_client.join_context.return_value = {
@@ -263,9 +257,8 @@ class TestJoinContextExpectedFailure:
 
 
 class TestUpgradeGroupRefusalGate:
-    """End-to-end on `upgrade_group`, the step the migration suite gates
-    refusals with: an L1 identity downgrade and a target with no embedded ABI
-    must be refused, for the named reason, or the step is red."""
+    """End-to-end on `upgrade_group`: an identity downgrade or a target with no
+    embedded ABI must be refused for the named reason, or the step is red."""
 
     def _step(self, **extra):
         return UpgradeGroupStep(
@@ -306,9 +299,8 @@ class TestUpgradeGroupRefusalGate:
         assert self._exec(step, self._raising("identity downgrade forbidden")) is True
 
     def test_an_unreachable_node_no_longer_stands_in_for_the_refusal(self):
-        # `fail()` files the step's own message under `error` and the real cause
-        # under `exception.message`; matching only the former would accept any
-        # error at all, which is what expected_error exists to stop.
+        # `fail()` files the cause under `exception.message`; matching only the
+        # step's own `error` message would accept any error at all.
         step = self._step(
             expected_failure=True, expected_error="identity downgrade forbidden"
         )
@@ -331,8 +323,8 @@ class TestUpgradeGroupRefusalGate:
         assert self._exec(step, client) is False
 
     def test_a_gate_that_lets_the_upgrade_through_now_fails(self):
-        # The whole point of W2: before this, a broken refusal gate left the
-        # step green with a warning and the workflow had no failing guard.
+        # Before this, a broken refusal gate left the step green with a warning,
+        # so the workflow had no failing guard at all.
         client = MagicMock()
         client.upgrade_group.return_value = {"status": "in_progress"}
         step = self._step(
@@ -378,11 +370,8 @@ class TestCreateNamespaceInvitationUnexpectedShape:
         )
 
     def test_unusable_shape_with_expected_failure_reports_unexpected_success(self):
-        # Client returns a string instead of a dict → ok(api_result) wraps it
-        # as {"success": True, "data": "not-a-dict"} and the shape-extraction
-        # block can't find the nested invitation. The API call itself succeeded,
-        # so this is the unexpected-success verdict rather than a plain failure;
-        # either way the step is red, but the message names the right cause.
+        # The API call itself succeeded (the shape is just unusable), so this is
+        # the unexpected-success verdict rather than a plain failure.
         assert self._exec(self._step(expected_failure=True), "not-a-dict") is False
 
     def test_unusable_shape_without_flag_still_fails(self):

--- a/merobox/tests/unit/test_expected_failure.py
+++ b/merobox/tests/unit/test_expected_failure.py
@@ -32,6 +32,7 @@ from merobox.commands.bootstrap.steps.group_management import (
     SetSubgroupVisibilityStep,
     UpdateMemberRoleStep,
 )
+from merobox.commands.bootstrap.steps.group_upgrade import UpgradeGroupStep
 from merobox.commands.bootstrap.steps.install import InstallApplicationStep
 from merobox.commands.bootstrap.steps.join_context import JoinContextStep
 from merobox.commands.bootstrap.steps.namespace import CreateGroupInNamespaceStep
@@ -74,6 +75,56 @@ class TestExpectedFailureHelpers:
         step = self._make_step(expected_failure="yes")
         with pytest.raises(ValueError, match="expected_failure.*boolean"):
             step._is_expected_failure()
+
+
+class TestExpectedErrorHelper:
+    """`expected_error` pins WHICH failure a negative test accepts.
+
+    Without it `expected_failure: true` passes on any error at all, including
+    the node being unreachable standing in for the refusal under test.
+    """
+
+    def _step(self, **extra):
+        return JoinContextStep(
+            {
+                "type": "join_context",
+                "name": "reason test",
+                "node": "n1",
+                "context_id": "ctx1",
+                **extra,
+            }
+        )
+
+    def test_matching_substring_passes(self):
+        step = self._step(expected_failure=True, expected_error="identity downgrade")
+        assert step._report_expected_failure("identity downgrade forbidden") is True
+
+    def test_wrong_reason_fails(self):
+        step = self._step(expected_failure=True, expected_error="identity downgrade")
+        assert step._report_expected_failure("connection refused") is False
+
+    def test_match_is_case_sensitive(self):
+        step = self._step(expected_failure=True, expected_error="No Embedded ABI")
+        assert step._report_expected_failure("no embedded ABI") is False
+
+    def test_no_expected_error_accepts_any_failure(self):
+        assert (
+            self._step(expected_failure=True)._report_expected_failure("boom") is True
+        )
+
+    def test_without_expected_failure_it_is_a_config_error(self):
+        # Silently never asserting is the exact failure mode being closed here.
+        with pytest.raises(ValueError, match="expected_error.*requires"):
+            self._step(expected_error="whatever")
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError, match="'expected_error' must be a string"):
+            self._step(expected_failure=True, expected_error=7)
+
+    def test_empty_string_raises(self):
+        # An empty substring matches everything, so it asserts nothing.
+        with pytest.raises(ValueError, match="expected_error.*empty"):
+            self._step(expected_failure=True, expected_error="  ")
 
 
 # =============================================================================
@@ -130,24 +181,108 @@ class TestJoinContextExpectedFailure:
     def test_jsonrpc_error_path_passes_when_expected(self):
         """HTTP-200 response carrying a JSON-RPC error envelope is the
         real-world shape merod returns for "context does not belong to any
-        group" — this is the branch we regressed on before the fix."""
+        group" - this is the branch we regressed on before the fix.
+
+        `ok()` stores the client's return value verbatim under `data`, so the
+        error envelope has to be at the top level of what the client returns
+        for `_check_jsonrpc_error` to see it.
+        """
         mock_client = MagicMock()
         mock_client.join_context.return_value = {
-            "data": {"error": {"type": "ApiError", "data": "context does not belong"}}
+            "error": {"type": "ApiError", "data": "context does not belong"}
         }
         step = self._setup(expected_failure=True)
         assert self._run_with_mock_client(step, mock_client) is True
 
-    def test_success_with_expected_failure_warns_but_still_passes(self):
-        """Matches the existing `call` semantic: an over-eager
-        expected_failure flag should not convert a passing workflow into a
-        failing one during refactor."""
+    def test_success_with_expected_failure_fails(self):
+        """A negative test whose subject succeeds has been disproven, not
+        proven. Passing here would make every gate the flag guards - the
+        identity-downgrade refusal, the missing-ABI refusal - unable to fail."""
         mock_client = MagicMock()
         mock_client.join_context.return_value = {
             "data": {"contextId": "ctx", "memberPublicKey": "pk"}
         }
         step = self._setup(expected_failure=True)
-        assert self._run_with_mock_client(step, mock_client) is True
+        assert self._run_with_mock_client(step, mock_client) is False
+
+
+class TestUpgradeGroupRefusalGate:
+    """End-to-end on `upgrade_group`, the step the migration suite gates
+    refusals with: an L1 identity downgrade and a target with no embedded ABI
+    must be refused, for the named reason, or the step is red."""
+
+    def _step(self, **extra):
+        return UpgradeGroupStep(
+            {
+                "type": "upgrade_group",
+                "name": "t",
+                "node": "n1",
+                "group_id": "g",
+                "target_application_id": "app-v2",
+                **extra,
+            }
+        )
+
+    def _exec(self, step, client):
+        with (
+            patch.object(
+                step,
+                "_resolve_node_for_client",
+                return_value=("http://localhost:1234", "n1"),
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.group_upgrade.get_client_for_rpc_url",
+                return_value=client,
+            ),
+            patch.object(step, "_resolve_dynamic_value", side_effect=lambda v, *_: v),
+        ):
+            return _run(step.execute({}, {}))
+
+    def _raising(self, message):
+        client = MagicMock()
+        client.upgrade_group.side_effect = RuntimeError(message)
+        return client
+
+    def test_named_refusal_passes(self):
+        step = self._step(
+            expected_failure=True, expected_error="identity downgrade forbidden"
+        )
+        assert self._exec(step, self._raising("identity downgrade forbidden")) is True
+
+    def test_an_unreachable_node_no_longer_stands_in_for_the_refusal(self):
+        # `fail()` files the step's own message under `error` and the real cause
+        # under `exception.message`; matching only the former would accept any
+        # error at all, which is what expected_error exists to stop.
+        step = self._step(
+            expected_failure=True, expected_error="identity downgrade forbidden"
+        )
+        assert self._exec(step, self._raising("Connection refused")) is False
+
+    def test_jsonrpc_refusal_reason_is_matched(self):
+        client = MagicMock()
+        client.upgrade_group.return_value = {
+            "error": {"type": "ApiError", "data": "no embedded ABI in target bundle"}
+        }
+        step = self._step(expected_failure=True, expected_error="no embedded ABI")
+        assert self._exec(step, client) is True
+
+    def test_jsonrpc_wrong_reason_fails(self):
+        client = MagicMock()
+        client.upgrade_group.return_value = {
+            "error": {"type": "ApiError", "data": "group not found"}
+        }
+        step = self._step(expected_failure=True, expected_error="no embedded ABI")
+        assert self._exec(step, client) is False
+
+    def test_a_gate_that_lets_the_upgrade_through_now_fails(self):
+        # The whole point of W2: before this, a broken refusal gate left the
+        # step green with a warning and the workflow had no failing guard.
+        client = MagicMock()
+        client.upgrade_group.return_value = {"status": "in_progress"}
+        step = self._step(
+            expected_failure=True, expected_error="identity downgrade forbidden"
+        )
+        assert self._exec(step, client) is False
 
 
 class TestCreateNamespaceInvitationUnexpectedShape:
@@ -186,12 +321,13 @@ class TestCreateNamespaceInvitationUnexpectedShape:
             }
         )
 
-    def test_unusable_shape_with_expected_failure_passes(self):
+    def test_unusable_shape_with_expected_failure_reports_unexpected_success(self):
         # Client returns a string instead of a dict → ok(api_result) wraps it
         # as {"success": True, "data": "not-a-dict"} and the shape-extraction
-        # block can't find the nested invitation. That path used to hit
-        # return False unconditionally, ignoring expected_failure.
-        assert self._exec(self._step(expected_failure=True), "not-a-dict") is True
+        # block can't find the nested invitation. The API call itself succeeded,
+        # so this is the unexpected-success verdict rather than a plain failure;
+        # either way the step is red, but the message names the right cause.
+        assert self._exec(self._step(expected_failure=True), "not-a-dict") is False
 
     def test_unusable_shape_without_flag_still_fails(self):
         assert self._exec(self._step(expected_failure=False), "not-a-dict") is False
@@ -560,17 +696,21 @@ class TestSetMemberCapabilitiesExpectedFailure:
         mock_client = MagicMock()
         mock_client.set_member_capabilities.side_effect = RuntimeError("nope")
         step = self._setup(expected_failure=True)
-        with patch.object(step, "_report_expected_failure") as report:
+        with patch.object(
+            step, "_report_expected_failure", return_value=True
+        ) as report:
             assert self._run_with_mock_client(step, mock_client) is True
             report.assert_called_once()
 
-    def test_success_with_expected_failure_warns_but_passes(self):
+    def test_success_with_expected_failure_fails(self):
         mock_client = MagicMock()
         mock_client.set_member_capabilities.return_value = {"data": "ok"}
         step = self._setup(expected_failure=True)
-        with patch.object(step, "_report_unexpected_success") as warn:
-            assert self._run_with_mock_client(step, mock_client) is True
-            warn.assert_called_once()
+        with patch.object(
+            step, "_report_unexpected_success", return_value=False
+        ) as report:
+            assert self._run_with_mock_client(step, mock_client) is False
+            report.assert_called_once()
 
     def test_exception_path_fails_without_flag(self):
         mock_client = MagicMock()

--- a/merobox/tests/unit/test_expected_failure.py
+++ b/merobox/tests/unit/test_expected_failure.py
@@ -107,6 +107,24 @@ class TestExpectedErrorHelper:
         step = self._step(expected_failure=True, expected_error="No Embedded ABI")
         assert step._report_expected_failure("no embedded ABI") is False
 
+    def test_failure_detail_does_not_repeat_an_embedded_cause(self):
+        """Call sites build the message as f"<verb> failed: {e}" and pass the
+        same exception, so appending the cause would print it twice."""
+        from merobox.commands.result import fail
+
+        step = self._step(expected_failure=True)
+        err = RuntimeError("node unreachable")
+        detail = step._failure_detail(fail(f"create_context failed: {err}", error=err))
+        assert detail == "create_context failed: node unreachable"
+
+    def test_failure_detail_appends_a_distinct_cause(self):
+        from merobox.commands.result import fail
+
+        step = self._step(expected_failure=True)
+        err = RuntimeError("node unreachable")
+        detail = step._failure_detail(fail("create_context failed", error=err))
+        assert detail == "create_context failed: node unreachable"
+
     def test_no_expected_error_accepts_any_failure(self):
         assert (
             self._step(expected_failure=True)._report_expected_failure("boom") is True

--- a/merobox/tests/unit/test_expected_failure.py
+++ b/merobox/tests/unit/test_expected_failure.py
@@ -160,6 +160,18 @@ class TestExpectedErrorHelper:
         step.bind_expected_error({}, {"version": "1.2.3"})
         assert step._report_expected_failure("refused: downgrade to 1.2.3") is True
 
+    def test_a_placeholder_resolving_to_empty_does_not_accept_any_failure(self):
+        # "" is a substring of every message, so a pin resolving to it would
+        # reopen the loophole the config-time empty check closes.
+        step = self._step(expected_failure=True, expected_error="{{reason}}")
+        step.bind_expected_error({}, {"reason": ""})
+        assert step._report_expected_failure("connection refused") is False
+
+    def test_a_non_string_placeholder_value_does_not_crash_the_match(self):
+        step = self._step(expected_failure=True, expected_error="{{code}}")
+        step.bind_expected_error({}, {"code": 404})
+        assert step._report_expected_failure("HTTP 404 returned") is True
+
     @pytest.mark.asyncio
     async def test_the_workflow_executor_binds_before_running_a_step(self):
         # A dynamic `expected_error` only works if the executor binds it, so

--- a/merobox/tests/unit/test_expected_failure.py
+++ b/merobox/tests/unit/test_expected_failure.py
@@ -10,7 +10,7 @@ add_group_members.
 """
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -125,6 +125,44 @@ class TestExpectedErrorHelper:
         # An empty substring matches everything, so it asserts nothing.
         with pytest.raises(ValueError, match="expected_error.*empty"):
             self._step(expected_failure=True, expected_error="  ")
+
+    def test_a_placeholder_is_resolved_before_matching(self):
+        # An unresolved template can never occur in a runtime error, so an
+        # unbound `expected_error` fails every gate that parameterizes it.
+        step = self._step(expected_failure=True, expected_error="{{reason}}")
+        step.bind_expected_error({}, {"reason": "identity downgrade"})
+        assert step._report_expected_failure("identity downgrade forbidden") is True
+
+    def test_a_resolved_placeholder_still_rejects_the_wrong_reason(self):
+        step = self._step(expected_failure=True, expected_error="{{reason}}")
+        step.bind_expected_error({}, {"reason": "identity downgrade"})
+        assert step._report_expected_failure("connection refused") is False
+
+    def test_an_embedded_placeholder_is_resolved(self):
+        step = self._step(
+            expected_failure=True, expected_error="downgrade to {{version}}"
+        )
+        step.bind_expected_error({}, {"version": "1.2.3"})
+        assert step._report_expected_failure("refused: downgrade to 1.2.3") is True
+
+    @pytest.mark.asyncio
+    async def test_the_workflow_executor_binds_before_running_a_step(self):
+        # The binding is what makes a dynamic `expected_error` work at all, so
+        # the executor forgetting it must not be a silent regression.
+        from merobox.commands.bootstrap.run.executor import WorkflowExecutor
+
+        step = self._step(expected_failure=True, expected_error="{{reason}}")
+        step.execute = AsyncMock(return_value=True)
+        executor = WorkflowExecutor(
+            {"name": "wf", "steps": [{"type": "join_context", "name": "s"}]},
+            MagicMock(),
+        )
+        executor.dynamic_values["reason"] = "identity downgrade"
+
+        with patch.object(executor, "_create_step_executor", return_value=step):
+            assert await executor._execute_workflow_steps() is True
+
+        assert step._report_expected_failure("identity downgrade forbidden") is True
 
 
 # =============================================================================

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -232,6 +232,22 @@ class TestSummarizeMigrationStatus:
         assert s["in_progress"] == 1
         assert s["all_migrated"] is False
 
+    def test_the_in_progress_state_is_counted_whichever_way_core_spells_it(self):
+        # The rollup spells its own counter `inProgress`, so the member state
+        # may well be camelCase too. Reconciliation must not depend on which.
+        for spelling in ("in_progress", "inProgress", "IN_PROGRESS", "in-progress"):
+            s = _summarize_migration_status(
+                {
+                    "rollup": _rollup(migrated=1, total=2, allMigrated=True),
+                    "members": [
+                        {"peer": "a", "state": "migrated"},
+                        {"peer": "b", "state": spelling},
+                    ],
+                }
+            )
+            assert s["in_progress"] == 1, spelling
+            assert s["all_migrated"] is False, spelling
+
     def test_unknown_and_in_progress_reconciled_from_members(self):
         # The rollup zeroes both counters while the member rows contradict it,
         # the same shape the `failed` reconciliation was written for.

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -203,6 +203,77 @@ class TestSummarizeMigrationStatus:
         assert s["failed"] == 1
         assert s["all_migrated"] is False
 
+    def test_all_migrated_false_when_a_member_is_unknown(self):
+        # `unknown` is the state a member that never reported sits in, and it
+        # is the shape the three-node cohort test asserts on. Trusting core's
+        # flag here would report a cohort with a silent member as converged.
+        s = _summarize_migration_status(
+            {
+                "rollup": _rollup(migrated=1, unknown=1, total=2, allMigrated=True),
+                "members": [
+                    {"peer": "a", "state": "migrated"},
+                    {"peer": "b", "state": "unknown"},
+                ],
+            }
+        )
+        assert s["unknown"] == 1
+        assert s["all_migrated"] is False
+
+    def test_all_migrated_false_when_a_member_is_in_progress(self):
+        s = _summarize_migration_status(
+            {
+                "rollup": _rollup(migrated=1, inProgress=1, total=2, allMigrated=True),
+                "members": [
+                    {"peer": "a", "state": "migrated"},
+                    {"peer": "b", "state": "in_progress"},
+                ],
+            }
+        )
+        assert s["in_progress"] == 1
+        assert s["all_migrated"] is False
+
+    def test_unknown_and_in_progress_reconciled_from_members(self):
+        # The rollup zeroes both counters while the member rows contradict it,
+        # the same shape the `failed` reconciliation was written for.
+        s = _summarize_migration_status(
+            {
+                "rollup": _rollup(migrated=2, total=2, allMigrated=True),
+                "members": [
+                    {"peer": "a", "state": "unknown"},
+                    {"peer": "b", "state": "in_progress"},
+                ],
+            }
+        )
+        assert s["unknown"] == 1
+        assert s["in_progress"] == 1
+        assert s["all_migrated"] is False
+
+    def test_all_migrated_false_on_a_state_no_counter_names(self):
+        # A state core adds or spells differently is still not `migrated`, so
+        # it must not be waved through as converged.
+        s = _summarize_migration_status(
+            {
+                "rollup": _rollup(migrated=2, total=2, allMigrated=True),
+                "members": [
+                    {"peer": "a", "state": "migrated"},
+                    {"peer": "b", "state": "quarantined"},
+                ],
+            }
+        )
+        assert s["all_migrated"] is False
+
+    def test_all_migrated_survives_a_fully_converged_cohort(self):
+        s = _summarize_migration_status(
+            {
+                "rollup": _rollup(migrated=2, total=2, allMigrated=True),
+                "members": [
+                    {"peer": "a", "state": "migrated"},
+                    {"peer": "b", "state": "migrated"},
+                ],
+            }
+        )
+        assert s["all_migrated"] is True
+
 
 # =============================================================================
 # _summarize_migration_status - the per-member report and the aggregates

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -204,9 +204,8 @@ class TestSummarizeMigrationStatus:
         assert s["all_migrated"] is False
 
     def test_all_migrated_false_when_a_member_is_unknown(self):
-        # `unknown` is the state a member that never reported sits in, and it
-        # is the shape the three-node cohort test asserts on. Trusting core's
-        # flag here would report a cohort with a silent member as converged.
+        # `unknown` is where a member that never reported sits; trusting core's
+        # flag would report a cohort with a silent member as converged.
         s = _summarize_migration_status(
             {
                 "rollup": _rollup(migrated=1, unknown=1, total=2, allMigrated=True),
@@ -293,8 +292,7 @@ class TestSummarizeMigrationStatus:
 
 # =============================================================================
 # _summarize_migration_status - the per-member report and the aggregates
-# recomputed from it. These are the only evidence that a member STATE-migrated:
-# the app's own schema_info is a constant compiled into the binary.
+# recomputed from it, the only evidence that a member STATE-migrated.
 # =============================================================================
 
 
@@ -329,9 +327,8 @@ class TestReportedSchemaVersions:
         assert m["authored_remaining"] == 0
 
     def test_a_member_below_target_is_counted_even_when_core_claims_converged(self):
-        # The load-bearing case. A rollup comparing the wrong version axis can
-        # answer allMigrated while a member still holds pre-migration state;
-        # the aggregate is recomputed from the raw reports, so it dissents.
+        # The load-bearing case: a rollup comparing the wrong version axis can
+        # answer allMigrated while a member still holds pre-migration state.
         s = _summarize_migration_status(
             {
                 "targetVersion": 2,
@@ -365,7 +362,7 @@ class TestReportedSchemaVersions:
 
     def test_no_report_is_missing_not_below_target(self):
         # "did not report" and "reported the wrong version" are different
-        # failures; 28's no-false-green contract turns on the distinction.
+        # failures, and only the latter is evidence the migration ran wrong.
         s = _summarize_migration_status(
             {
                 "targetVersion": 2,
@@ -747,8 +744,7 @@ class TestAssertMigrationCompleteExecute:
 
     def test_timeout_message_names_the_below_target_member(self, capsys):
         # The bare counters cannot separate "a member is slow" from "a member is
-        # answering with the wrong state version" - the whole point of the
-        # reported-version aggregates.
+        # on the wrong state version".
         step = AssertMigrationCompleteStep(self.config)
         client = MagicMock()
         client.get_migration_status.return_value = {

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -449,6 +449,23 @@ class TestReportedSchemaVersions:
             {"members": [_member("peerA", schemaVersion=2)]}
         )
         assert s["failure_reasons"] == []
+        assert s["stuck_members"] == []
+
+    def test_stuck_members_name_the_peers_behind_the_reasons(self):
+        # The reason list says WHAT went wrong; a count plus a reason still
+        # does not say WHICH member is holding the fleet back.
+        s = _summarize_migration_status(
+            {
+                "members": [
+                    _member("peerB", state="failed", migrationFailed="check_aborted"),
+                    _member(
+                        "peerA", state="failed", migrationFailed="no_migration_path"
+                    ),
+                    _member("peerC", schemaVersion=2),
+                ]
+            }
+        )
+        assert s["stuck_members"] == ["peerA", "peerB"]
 
 
 # =============================================================================

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -205,6 +205,166 @@ class TestSummarizeMigrationStatus:
 
 
 # =============================================================================
+# _summarize_migration_status - the per-member report and the aggregates
+# recomputed from it. These are the only evidence that a member STATE-migrated:
+# the app's own schema_info is a constant compiled into the binary.
+# =============================================================================
+
+
+def _member(peer, state="migrated", **report):
+    return {"peer": peer, "state": state, "report": {**report}}
+
+
+class TestReportedSchemaVersions:
+    def test_report_fields_are_passed_through(self):
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "rollup": _rollup(migrated=1, total=1, allMigrated=True),
+                "members": [
+                    _member(
+                        "peerA",
+                        schemaVersion=2,
+                        residueAuto=0,
+                        residueIdentity=0,
+                        syncedUpToHlc="hlc-9",
+                        reportedAt=1_700_000_000,
+                        authoredRemaining=0,
+                    )
+                ],
+            }
+        )
+        m = s["members"][0]
+        assert m["schema_version"] == 2
+        assert m["residue_auto"] == 0
+        assert m["synced_up_to_hlc"] == "hlc-9"
+        assert m["reported_at"] == 1_700_000_000
+        assert m["authored_remaining"] == 0
+
+    def test_a_member_below_target_is_counted_even_when_core_claims_converged(self):
+        # The load-bearing case. A rollup comparing the wrong version axis can
+        # answer allMigrated while a member still holds pre-migration state;
+        # the aggregate is recomputed from the raw reports, so it dissents.
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "rollup": _rollup(migrated=2, total=2, allMigrated=True),
+                "members": [
+                    _member("peerA", schemaVersion=2),
+                    _member("peerB", schemaVersion=1),
+                ],
+            }
+        )
+        assert s["all_migrated"] is True
+        assert s["reported_below_target"] == 1
+        assert s["reported_at_target"] == 1
+        assert s["min_reported_schema_version"] == 1
+
+    def test_a_converged_cohort_is_zero_below_target(self):
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "rollup": _rollup(migrated=2, total=2, allMigrated=True),
+                "members": [
+                    _member("peerA", schemaVersion=2),
+                    _member("peerB", schemaVersion=3),
+                ],
+            }
+        )
+        assert s["reported_below_target"] == 0
+        assert s["reported_at_target"] == 2
+        assert s["reported_missing"] == 0
+        assert s["min_reported_schema_version"] == 2
+
+    def test_no_report_is_missing_not_below_target(self):
+        # "did not report" and "reported the wrong version" are different
+        # failures; 28's no-false-green contract turns on the distinction.
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "rollup": _rollup(migrated=1, unknown=1, total=2),
+                "members": [
+                    _member("peerA", schemaVersion=2),
+                    {"peer": "peerB", "state": "unknown"},
+                ],
+            }
+        )
+        assert s["reported_missing"] == 1
+        assert s["reported_below_target"] == 0
+        assert s["reported_at_target"] == 1
+        assert s["members"][1]["schema_version"] is None
+
+    def test_absent_target_leaves_the_target_relative_counters_none(self):
+        # Defaulting the target to 0 would classify every member as at-target
+        # and hand back a green summary for a namespace that never migrated.
+        s = _summarize_migration_status(
+            {
+                "rollup": _rollup(total=1),
+                "members": [_member("peerA", schemaVersion=1)],
+            }
+        )
+        assert s["reported_at_target"] is None
+        assert s["reported_below_target"] is None
+        # The target-independent aggregates are still computed.
+        assert s["min_reported_schema_version"] == 1
+        assert s["reported_missing"] == 0
+
+    def test_absent_target_still_reports_a_silent_cohort_as_missing(self):
+        s = _summarize_migration_status(
+            {"rollup": _rollup(total=2), "members": [{"peer": "a"}, {"peer": "b"}]}
+        )
+        assert s["reported_missing"] == 2
+        assert s["min_reported_schema_version"] is None
+
+    def test_a_bool_schema_version_counts_as_missing(self):
+        # bool is an int subclass. Counting True as version 1 would silently
+        # manufacture a reported version out of a malformed report.
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "members": [_member("peerA", schemaVersion=True)],
+            }
+        )
+        assert s["reported_missing"] == 1
+        assert s["reported_below_target"] == 0
+
+    def test_residue_is_summed_and_zero_stays_zero(self):
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "members": [
+                    _member("peerA", schemaVersion=2, residueAuto=3),
+                    _member("peerB", schemaVersion=2, residueAuto=0),
+                    _member("peerC", schemaVersion=2),
+                ],
+            }
+        )
+        assert s["residue_total"] == 3
+
+    def test_failure_reasons_are_sorted_and_order_independent(self):
+        # A sorted list can be asserted whole; members.N.migration_failed
+        # depends on an ordering the API does not guarantee.
+        s = _summarize_migration_status(
+            {
+                "members": [
+                    _member(
+                        "peerA", state="failed", migrationFailed="no_migration_path"
+                    ),
+                    _member("peerB", state="failed", migrationFailed="check_aborted"),
+                    _member("peerC", schemaVersion=2),
+                ]
+            }
+        )
+        assert s["failure_reasons"] == ["check_aborted", "no_migration_path"]
+
+    def test_no_failures_is_an_empty_reason_list(self):
+        s = _summarize_migration_status(
+            {"members": [_member("peerA", schemaVersion=2)]}
+        )
+        assert s["failure_reasons"] == []
+
+
+# =============================================================================
 # GetMigrationStatusStep
 # =============================================================================
 
@@ -480,6 +640,34 @@ class TestAssertMigrationCompleteExecute:
         ):
             result = _run(step.execute({}, {}))
         assert result is False
+
+    def test_timeout_message_names_the_below_target_member(self, capsys):
+        # The bare counters cannot separate "a member is slow" from "a member is
+        # answering with the wrong state version" - the whole point of the
+        # reported-version aggregates.
+        step = AssertMigrationCompleteStep(self.config)
+        client = MagicMock()
+        client.get_migration_status.return_value = {
+            "targetVersion": 2,
+            "rollup": _rollup(migrated=1, inProgress=1, total=2),
+            "members": [
+                _member("peerA", schemaVersion=2),
+                _member("peerB", state="in_progress", schemaVersion=1),
+            ],
+        }
+        p1, p2, p3, p4 = self._patched(step, client)
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch(f"{_MODULE}.time.monotonic", side_effect=itertools.count(0, 5)),
+        ):
+            assert _run(step.execute({}, {})) is False
+        # Rich hard-wraps to the terminal width, so compare on collapsed space.
+        out = " ".join(capsys.readouterr().out.split())
+        assert "1 member(s) below target state version 2" in out
+        assert "min reported: 1" in out
 
     def test_all_polls_jsonrpc_error_times_out(self):
         # Every poll returns a JSON-RPC error body → summary always None →


### PR DESCRIPTION
## Summary

Stacks on #324 (branched from `feat/ws-event-assertion`, which carries `assert_ws_event` and the `fleetCompletedAt` / `cohortPinnedAtHlc` passthrough this builds on). Review after that one merges; the diff against `master` will shrink accordingly.

Two capabilities the migration e2e suite needs in order to assert against the API instead of grepping node logs.

**Per-member migration reports.** `_summarize_migration_status` narrowed each member to `peer` / `state` / `migration_failed` and dropped the rest of its report. `report.schemaVersion` is a u32 ABI **state** version and the only member-level evidence that a state migration actually ran; an application's own `schema_info` is a semver string compiled into the binary, so it reports which WASM is loaded and answers the same whether or not the bytes were migrated. The whole report is now passed through (`schema_version`, `residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`), raw, absent as `None`.

Alongside it, six aggregates recomputed from the raw member rows and never read from `rollup`: `reported_at_target`, `reported_below_target`, `reported_missing`, `min_reported_schema_version`, `residue_total`, `failure_reasons`. Asserting core's own `allMigrated` against itself cannot falsify the rollup arithmetic, and that arithmetic is where the original defect lived. The two target-relative counters are `None` when the response carries no `targetVersion`, because defaulting the target to `0` would classify every member as at-target and hand back a green summary for a namespace that never migrated. `assert_migration_complete`'s timeout message now names the below-target member, which the bare counters cannot distinguish from a slow one.

**`expected_failure` can fail.** `_report_unexpected_success` warned and returned `True`, so a step marked `expected_failure: true` **passed when the operation unexpectedly succeeded** - every refusal gated that way had no failing guard at all. It now fails the step, and the ~50 call sites propagate the verdict. `call` is the one exception and keeps the lenient behaviour: shipped workflows use the flag on a read as a soft "may not have propagated yet" probe and depend on its `None` error exports.

**New `expected_error`** pins *which* failure a negative test accepts, so an unreachable node can no longer stand in for the refusal under test:

```yaml
- type: upgrade_group
  expected_failure: true
  expected_error: 'identity downgrade forbidden'
```

Substring, case-sensitive, available on every step type. It requires `expected_failure` and is a hard config error without it, since silently asserting nothing is the failure mode being closed. Reaching the reason at all required fixing the reported text: `fail()` files the step's own message under `error` and the real cause under `exception.message`, so `expected_error` matched against a static string like `"upgrade_group failed"` and could never fire. The 86 call sites passing `result.get("error")` or the bare `"JSON-RPC error returned"` literal now report the cause too.

### Behaviour changes to watch

- `expected_failure: true` on any non-`call` step now fails when the operation succeeds. All shipped example workflows were audited: every non-`call` use is a genuine refusal assertion (`is rejected` / `is refused` / `must fail`). Two were only ever verified under the lenient contract and get their first real assertion here: `retry_group_upgrade` on a completed upgrade (`workflow-group-upgrade-example.yml`) and the `download_blob` negative controls (`workflow-blob-cross-node-download-example.yml`).
- One pre-existing test was passing for the wrong reason: `test_jsonrpc_error_path_passes_when_expected` built its mock one level too deep, so `_check_jsonrpc_error` never fired and the test was green only because unexpected-success returned `True`. The mock is corrected; the branch is now actually exercised.

## Test plan

`make format-check` clean, `pytest merobox/tests/unit` at **1242 passed** (baseline on `feat/ws-event-assertion` is 1219: 23 new, 4 rewritten to the new contract).

Every new test was proven a gate by breaking the behaviour, capturing the failure, and restoring:

| Mutation | Tests that go red |
| --- | --- |
| Member report passthrough dropped | `test_report_fields_are_passed_through` |
| `reported_below_target` read from `rollup` instead of recomputed | `test_a_member_below_target_is_counted_even_when_core_claims_converged` |
| Absent `targetVersion` defaults to `0` | `test_absent_target_leaves_the_target_relative_counters_none` |
| Timeout message drops the below-target detail | `test_timeout_message_names_the_below_target_member` |
| `_report_unexpected_success` returns `True` again | 4 tests, incl. `test_a_gate_that_lets_the_upgrade_through_now_fails` |
| `expected_error` never checked | 4 tests, incl. `test_an_unreachable_node_no_longer_stands_in_for_the_refusal` |
| `_failure_detail` drops the underlying cause | `test_named_refusal_passes` |
| `expected_error` accepted without `expected_failure` | `test_without_expected_failure_it_is_a_config_error` |

`TestUpgradeGroupRefusalGate` covers the consumer end to end on `upgrade_group`: a named refusal passes, a connection error under the same `expected_error` fails, the JSON-RPC envelope path matches on `error.data`, and an upgrade that unexpectedly goes through fails.