### PR TITLE
feat(bootstrap): assert on a node's raw admin-API response

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -631,15 +631,15 @@ deserializer.
 ```yaml
 - type: assert_api_response
   node: calimero-node-1
-  path: "/admin-api/namespaces/{{namespace_id}}/migration-status"
+  path: "/admin-api/groups/{{namespace_id}}/migration-status"
   match:
-    data.rollup.allMigrated: true
+    rollup.allMigrated: true
   present:
-    - data.fleetCompletedAt
+    - fleetCompletedAt
 ```
 
 Paths address the body verbatim, envelope included: the admin API wraps payloads
-in `data` and serializes camelCase, so a field reads `data.fleetCompletedAt`.
+directly, camelCase, with no envelope, so a field reads `fleetCompletedAt`.
 `match` is a subset test, so unlisted fields are ignored.
 
 Core marks optional fields `skip_serializing_if = "Option::is_none"`, so a key

--- a/LLM.md
+++ b/LLM.md
@@ -616,6 +616,53 @@ step triggered it. And `CascadeProgress` is admin-gated at subscribe time while
 the other migration events are member-visible, so a non-admin subscriber never
 receives it and `absent: true` on it would pass for the wrong reason.
 
+#### 9b. Raw Admin-API Assertion Step (`assert_api_response`)
+
+Issue the HTTP request directly and assert against the JSON the node sent.
+
+Every other step reads its response through `calimero-client-py`, a compiled
+wrapper built from a pinned core revision whose DTOs drop any key that build
+does not know about - silently, on deserialize, before merobox sees the body.
+So a field newly added to core reads as missing everywhere, and a brand-new
+field is indistinguishable from a broken one in exactly the environment where
+you would want to verify it. This step never hands the body to a typed
+deserializer.
+
+```yaml
+- type: assert_api_response
+  node: calimero-node-1
+  path: "/admin-api/namespaces/{{namespace_id}}/migration-status"
+  match:
+    data.rollup.allMigrated: true
+  present:
+    - data.fleetCompletedAt
+```
+
+Paths address the body verbatim, envelope included: the admin API wraps payloads
+in `data` and serializes camelCase, so a field reads `data.fleetCompletedAt`.
+`match` is a subset test, so unlisted fields are ignored.
+
+Core marks optional fields `skip_serializing_if = "Option::is_none"`, so a key
+being ABSENT is meaningful and distinct from present-and-null. The three
+assertions separate the two states:
+
+| Assertion | Present with a value | Present and null | Absent |
+| --- | --- | --- | --- |
+| `present: [k]` | pass | pass | fail |
+| `absent: [k]` | fail | fail | pass |
+| `match: {k: null}` | fail | pass | fail (reported as absent) |
+
+At least one of `match` / `present` / `absent` is required, so the step can never
+silently assert nothing. A failure prints the per-path verdict and then the whole
+response body, so CI output alone tells "the field is missing" from "the field is
+wrong".
+
+One request, no polling - wrap it in `repeat` or precede it with `wait_for_sync`
+when the assertion has to wait for state to settle. The JWT a prior `login`
+cached for the node is attached as a bearer token, or an explicit `token:`
+overrides it; a node running without auth needs neither. A non-2xx status fails
+the step and composes with `expected_failure` / `expected_error`.
+
 #### 10. Proposals
 
 Create and vote on proposals in a context.

--- a/LLM.md
+++ b/LLM.md
@@ -663,6 +663,11 @@ cached for the node is attached as a bearer token, or an explicit `token:`
 overrides it; a node running without auth needs neither. A non-2xx status fails
 the step and composes with `expected_failure` / `expected_error`.
 
+Those two govern the request outcome only, never the assertion verdicts. An
+assertion that misses always fails the step: letting a miss satisfy
+`expected_failure` would turn a typo in a path into a green negative test,
+which is the failure the flag exists to prevent, not one it should manufacture.
+
 #### 10. Proposals
 
 Create and vote on proposals in a context.

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1463,6 +1463,67 @@ at least `min_matches` times; `assert_log_absent` fails if any pattern appears.
     - 'panicked'
 ```
 
+### assert_api_response
+
+GET a path on a node's admin API and assert against the JSON the node actually
+sent. Every other step reads its response through `calimero-client-py`, whose
+compiled DTOs silently drop any key the pinned core build does not know about,
+so a field added to core is unassertable until a client release lands. This step
+never hands the body to a typed deserializer.
+
+| Field | Required | Type | Meaning |
+| --- | --- | --- | --- |
+| `node` | yes | string | Node whose admin API is queried. |
+| `path` | yes | string | Admin-API path, e.g. `/admin-api/health`. |
+| `match` | one of | map | Dotted paths mapped to expected values. |
+| `present` | one of | list | Dotted paths that must exist, whatever their value. |
+| `absent` | one of | list | Dotted paths that must not exist. |
+| `token` | no | string | Explicit JWT (otherwise the token `login` cached for the node). |
+
+At least one of `match` / `present` / `absent` is required, so a step can never
+silently assert nothing. Paths address the body verbatim, envelope included: the
+admin API wraps payloads in `data` and serializes camelCase, so a field reads
+`data.fleetCompletedAt`.
+
+```yaml
+- type: assert_api_response
+  node: calimero-node-1
+  path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
+  match:
+    data.rollup.allMigrated: true
+  present:
+    - data.fleetCompletedAt
+```
+
+Core marks optional fields `skip_serializing_if = "Option::is_none"`, so a key
+being **absent** is meaningful and distinct from present-and-null. The three
+assertions separate the two states: `present` accepts a null value, `absent`
+rejects one, and `match: {path: null}` demands the key be there *and* null - an
+absent key fails it and is reported as absent, not as null.
+
+```yaml
+# A namespace with no upgrade record must not emit the field at all.
+- type: assert_api_response
+  node: calimero-node-1
+  path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
+  absent:
+    - data.targetVersion
+```
+
+A failure prints the per-path verdict and then the whole response body, so CI
+output alone tells "the field is missing" from "the field is wrong". The step
+issues one request and does not poll; wrap it in `repeat` or precede it with
+`wait_for_sync` when the assertion has to wait for state to settle. A non-2xx
+status fails the step and works with `expected_failure` / `expected_error`:
+
+```yaml
+- type: assert_api_response
+  node: calimero-node-1
+  path: '/admin-api/namespaces/deadbeef/migration-status'
+  expected_failure: true
+  expected_error: 'HTTP 404'
+```
+
 ---
 
 ## Mesh & fuzzy steps

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1524,6 +1524,10 @@ status fails the step and works with `expected_failure` / `expected_error`:
   expected_error: 'HTTP 404'
 ```
 
+Both govern the request outcome only, never the assertion verdicts. An
+assertion that misses always fails the step: letting a miss satisfy
+`expected_failure` would turn a typo in a path into a green negative test.
+
 ---
 
 ## Mesh & fuzzy steps

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1481,18 +1481,18 @@ never hands the body to a typed deserializer.
 | `token` | no | string | Explicit JWT (otherwise the token `login` cached for the node). |
 
 At least one of `match` / `present` / `absent` is required, so a step can never
-silently assert nothing. Paths address the body verbatim, envelope included: the
-admin API wraps payloads in `data` and serializes camelCase, so a field reads
-`data.fleetCompletedAt`.
+silently assert nothing. Paths address the body verbatim: the admin API
+serializes its payload directly, camelCase, with no envelope, so a field reads
+`fleetCompletedAt`.
 
 ```yaml
 - type: assert_api_response
   node: calimero-node-1
-  path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
+  path: '/admin-api/groups/{{namespace_id}}/migration-status'
   match:
-    data.rollup.allMigrated: true
+    rollup.allMigrated: true
   present:
-    - data.fleetCompletedAt
+    - fleetCompletedAt
 ```
 
 Core marks optional fields `skip_serializing_if = "Option::is_none"`, so a key
@@ -1502,12 +1502,12 @@ rejects one, and `match: {path: null}` demands the key be there *and* null - an
 absent key fails it and is reported as absent, not as null.
 
 ```yaml
-# A namespace with no upgrade record must not emit the field at all.
+# A namespace whose fleet never converged must not emit the stamp at all.
 - type: assert_api_response
   node: calimero-node-1
-  path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
+  path: '/admin-api/groups/{{namespace_id}}/migration-status'
   absent:
-    - data.targetVersion
+    - fleetCompletedAt
 ```
 
 A failure prints the per-path verdict and then the whole response body, so CI

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -132,6 +132,7 @@ VALID_STEP_TYPES = frozenset(
         "ws_connect",
         "ws_subscribe",
         "assert_ws_event",
+        "assert_api_response",
     }
 )
 
@@ -426,6 +427,27 @@ class WebSocketEventAssertStepConfig(BaseStepConfig):
     )
     timeout_seconds: Optional[float] = Field(
         None, gt=0, description="Length of the watch window in seconds"
+    )
+    token: Optional[str] = Field(
+        None, description="Explicit JWT to attach (overrides the cached token)"
+    )
+
+
+class AssertApiResponseStepConfig(BaseStepConfig):
+    """Configuration for assert_api_response step (raw admin-API assertion)."""
+
+    type: Literal["assert_api_response"] = "assert_api_response"
+    node: str = Field(..., description="Node whose admin API is queried")
+    path: str = Field(..., description="Admin-API path, e.g. /admin-api/health")
+    match: Optional[dict[str, Any]] = Field(
+        None,
+        description="Dotted paths into the response body mapped to expected values",
+    )
+    present: Optional[list[str]] = Field(
+        None, description="Dotted paths that must exist, whatever their value"
+    )
+    absent: Optional[list[str]] = Field(
+        None, description="Dotted paths that must not exist in the body"
     )
     token: Optional[str] = Field(
         None, description="Explicit JWT to attach (overrides the cached token)"
@@ -1689,6 +1711,7 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "ws_connect": WebSocketConnectStepConfig,
     "ws_subscribe": WebSocketConnectStepConfig,
     "assert_ws_event": WebSocketEventAssertStepConfig,
+    "assert_api_response": AssertApiResponseStepConfig,
     "wait": WaitStep,
     "wait_for_sync": WaitForSyncStep,
     "repeat": RepeatStep,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -2184,6 +2184,12 @@ class WorkflowExecutor:
             )
 
             return WebSocketEventAssertStep(step_config, **common_kwargs)
+        elif step_type == "assert_api_response":
+            from merobox.commands.bootstrap.steps.api_assertion import (
+                AssertApiResponseStep,
+            )
+
+            return AssertApiResponseStep(step_config, **common_kwargs)
         elif step_type == "wait":
             return WaitStep(step_config, **common_kwargs)
         elif step_type == "wait_for_sync":

--- a/merobox/commands/bootstrap/steps/api_assertion.py
+++ b/merobox/commands/bootstrap/steps/api_assertion.py
@@ -1,0 +1,221 @@
+"""
+Raw admin-API response assertion.
+
+``calimero-client-py`` is compiled from a pinned core revision and its DTOs drop
+any response key that build does not know about, silently, on deserialize. So a
+field newly added to core reads as missing through every typed step, and a
+brand-new field is indistinguishable from a broken one. This step issues the
+HTTP request itself and asserts against the parsed body, so the assertion sees
+what the node actually sent.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+
+from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.constants import (
+    DEFAULT_CONNECTION_TIMEOUT,
+    DEFAULT_READ_TIMEOUT,
+)
+from merobox.commands.result import fail, ok
+from merobox.commands.utils import console
+
+# Distinguishes an absent key from one present with a null value. Core marks
+# optional fields `skip_serializing_if = "Option::is_none"`, so omission is the
+# observable difference between None and a value, and collapsing the two would
+# blind the step to exactly the case it exists to test.
+_MISSING = object()
+
+
+def _lookup(payload: Any, path: str) -> Any:
+    """Value at a dotted path, or ``_MISSING`` if the path does not exist.
+
+    Unlike ``BaseStep._get_value`` this re-parses nothing on the way down: a
+    string stays a string, so the assertion sees the body verbatim.
+    """
+    current = payload
+    for segment in path.split("."):
+        if isinstance(current, list) and segment.isdigit():
+            index = int(segment)
+            if index >= len(current):
+                return _MISSING
+            current = current[index]
+        elif isinstance(current, dict) and segment in current:
+            current = current[segment]
+        else:
+            return _MISSING
+    return current
+
+
+class AssertApiResponseStep(BaseStep):
+    """GET a path on a node's admin API and assert against the JSON it returned.
+
+    Required fields: ``node``, ``path``, and at least one of ``match`` /
+    ``present`` / ``absent``.
+
+    Optional fields:
+    - ``match`` (dict): dotted paths mapped to expected values. ``null`` asserts
+      the key is present AND null, which an absent key does not satisfy.
+    - ``present`` (list): dotted paths that must exist, whatever their value.
+    - ``absent`` (list): dotted paths that must not exist.
+    - ``token`` (str): explicit JWT (supports ``{{placeholders}}``); otherwise
+      the token a prior ``login`` cached for the node, or none at all on a node
+      running without auth.
+
+    Paths address the body verbatim, envelope included: the admin API wraps
+    payloads in ``data`` and serializes camelCase, so a field reads
+    ``data.fleetCompletedAt``.
+
+    One request, no polling - the other assertion steps do not poll either.
+    Compose with ``repeat`` or ``wait_for_sync`` when the assertion has to wait
+    for state to settle.
+    """
+
+    def _get_required_fields(self) -> list[str]:
+        return ["node", "path"]
+
+    def _validate_field_types(self) -> None:
+        self._validate_string_field("node")
+        self._validate_string_field("path")
+        self._validate_string_field("token", required=False)
+        self._validate_dict_field("match", required=False)
+        self._validate_list_field("present", required=False, element_type=str)
+        self._validate_list_field("absent", required=False, element_type=str)
+        # Iterating a dict yields its keys and a list its elements, so one loop
+        # covers all three fields.
+        for field in ("match", "present", "absent"):
+            for path in self.config.get(field) or []:
+                if not isinstance(path, str) or not path.strip():
+                    raise ValueError(
+                        f"Step '{self._get_step_name()}': '{field}' entries must "
+                        f"be non-empty dotted paths into the response body"
+                    )
+        if not self._assertion_count() and not self._is_expected_failure():
+            # An assertion step with nothing to assert passes unconditionally,
+            # the silent no-op `expected_error` exists to close.
+            raise ValueError(
+                f"Step '{self._get_step_name()}': needs at least one of 'match', "
+                f"'present' or 'absent' - without one it asserts nothing"
+            )
+
+    def _assertion_count(self) -> int:
+        return sum(
+            len(self.config.get(f) or []) for f in ("match", "present", "absent")
+        )
+
+    async def execute(
+        self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
+    ) -> bool:
+        node_name = self.config["node"]
+        path = self._resolve_dynamic_value(
+            self.config["path"], workflow_results, dynamic_values
+        )
+
+        try:
+            rpc_url, cache_node_name = self._resolve_node_target(node_name)
+        except Exception as e:
+            console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
+            return False
+
+        token = self._resolve_token(cache_node_name, workflow_results, dynamic_values)
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+        try:
+            response = requests.get(
+                f"{rpc_url.rstrip('/')}/{path.lstrip('/')}",
+                headers=headers,
+                timeout=(DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT),
+            )
+            if response.status_code != 200:
+                result = fail(
+                    f"GET {path} on {node_name} returned HTTP "
+                    f"{response.status_code}: {response.text}"
+                )
+            else:
+                # json.loads, not _parse_json: its fallbacks would repair a body
+                # the node should not have sent, and hide that it did.
+                result = ok(json.loads(response.text))
+        except json.JSONDecodeError as e:
+            result = fail(f"GET {path} on {node_name} returned a non-JSON body: {e}")
+        except Exception as e:
+            result = fail(f"GET {path} on {node_name} failed", error=e)
+
+        expected_failure = self._is_expected_failure()
+
+        if not result["success"]:
+            if expected_failure:
+                return self._report_expected_failure(self._failure_detail(result))
+            # markup=False so a response body containing brackets survives Rich.
+            console.print(
+                f"✗ assert_api_response: {result['error']}",
+                style="red",
+                markup=False,
+            )
+            return False
+
+        payload = result["data"]
+        workflow_results[f"api_response_{node_name}"] = payload
+
+        failures = self._assertion_failures(payload, workflow_results, dynamic_values)
+        if failures:
+            console.print(
+                f"✗ assert_api_response on {node_name}: GET {path} missed "
+                f"{len(failures)} of {self._assertion_count()} assertion(s)",
+                style="red",
+                markup=False,
+            )
+            for failure in failures:
+                console.print(f"    {failure}", style="red", markup=False)
+            console.print(
+                f"  body: {json.dumps(payload, sort_keys=True)}",
+                style="red",
+                markup=False,
+            )
+            return False
+
+        if expected_failure:
+            return self._report_unexpected_success()
+
+        console.print(
+            f"[green]✓ assert_api_response: GET {path} on {node_name} satisfied "
+            f"{self._assertion_count()} assertion(s)[/green]"
+        )
+        return True
+
+    def _assertion_failures(
+        self,
+        payload: Any,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> list[str]:
+        """Per-path verdicts; empty means the body satisfied every assertion."""
+        failures = []
+
+        for path, expected in (self.config.get("match") or {}).items():
+            if isinstance(expected, str):
+                expected = self._resolve_dynamic_value(
+                    expected, workflow_results, dynamic_values
+                )
+            actual = _lookup(payload, path)
+            if actual is _MISSING:
+                failures.append(f"{path}: expected {expected!r}, but the key is absent")
+            elif actual != expected:
+                failures.append(f"{path}: expected {expected!r}, got {actual!r}")
+
+        for path in self.config.get("present") or []:
+            if _lookup(payload, path) is _MISSING:
+                failures.append(f"{path}: expected the key to be present, it is absent")
+
+        for path in self.config.get("absent") or []:
+            actual = _lookup(payload, path)
+            if actual is not _MISSING:
+                failures.append(
+                    f"{path}: expected the key to be absent, it is present "
+                    f"with {actual!r}"
+                )
+
+        return failures

--- a/merobox/commands/bootstrap/steps/api_assertion.py
+++ b/merobox/commands/bootstrap/steps/api_assertion.py
@@ -123,17 +123,20 @@ class AssertApiResponseStep(BaseStep):
                 result = ok(json.loads(response.content))
         except (json.JSONDecodeError, UnicodeDecodeError) as e:
             result = fail(f"GET {path} on {node_name} returned a non-JSON body: {e}")
-        except Exception as e:
+        # Only what `requests` raises for a transport fault: a TypeError from
+        # this step's own plumbing must not pass as an ordinary request failure.
+        except requests.RequestException as e:
             result = fail(f"GET {path} on {node_name} failed", error=e)
 
         expected_failure = self._is_expected_failure()
 
         if not result["success"]:
+            detail = self._failure_detail(result)
             if expected_failure:
-                return self._report_expected_failure(self._failure_detail(result))
+                return self._report_expected_failure(detail)
             # markup=False so a response body containing brackets survives Rich.
             console.print(
-                f"✗ assert_api_response: {result['error']}",
+                f"✗ assert_api_response: {detail}",
                 style="red",
                 markup=False,
             )

--- a/merobox/commands/bootstrap/steps/api_assertion.py
+++ b/merobox/commands/bootstrap/steps/api_assertion.py
@@ -11,6 +11,7 @@ what the node actually sent.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -130,7 +131,11 @@ class AssertApiResponseStep(BaseStep):
         headers = {"Authorization": f"Bearer {token}"} if token else {}
 
         try:
-            response = requests.get(
+            # Off the loop: this is the one step that issues its own HTTP
+            # rather than delegating to the compiled client, so it is the one
+            # that can yield while a `parallel:` sibling runs.
+            response = await asyncio.to_thread(
+                requests.get,
                 f"{rpc_url.rstrip('/')}/{path.lstrip('/')}",
                 headers=headers,
                 timeout=(DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT),

--- a/merobox/commands/bootstrap/steps/api_assertion.py
+++ b/merobox/commands/bootstrap/steps/api_assertion.py
@@ -73,6 +73,11 @@ class AssertApiResponseStep(BaseStep):
     One request, no polling - the other assertion steps do not poll either.
     Compose with ``repeat`` or ``wait_for_sync`` when the assertion has to wait
     for state to settle.
+
+    ``expected_failure`` / ``expected_error`` govern the request outcome only.
+    An assertion that misses always fails the step: a miss satisfying
+    ``expected_failure`` would turn a typo in a path into a green negative
+    test, which is the failure the flag exists to prevent.
     """
 
     def _get_required_fields(self) -> list[str]:

--- a/merobox/commands/bootstrap/steps/api_assertion.py
+++ b/merobox/commands/bootstrap/steps/api_assertion.py
@@ -130,7 +130,10 @@ class AssertApiResponseStep(BaseStep):
                 headers=headers,
                 timeout=(DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT),
             )
-            if response.status_code != 200:
+            # The whole 2xx range, not just 200: a route answering 201/204 has
+            # served the request, and rejecting it would report a working
+            # endpoint as an HTTP failure.
+            if not 200 <= response.status_code < 300:
                 result = fail(
                     f"GET {path} on {node_name} returned HTTP "
                     f"{response.status_code}: {response.text}"

--- a/merobox/commands/bootstrap/steps/api_assertion.py
+++ b/merobox/commands/bootstrap/steps/api_assertion.py
@@ -2,11 +2,9 @@
 Raw admin-API response assertion.
 
 ``calimero-client-py`` is compiled from a pinned core revision and its DTOs drop
-any response key that build does not know about, silently, on deserialize. So a
-field newly added to core reads as missing through every typed step, and a
-brand-new field is indistinguishable from a broken one. This step issues the
-HTTP request itself and asserts against the parsed body, so the assertion sees
-what the node actually sent.
+unknown response keys silently on deserialize, so a field newly added to core
+reads as missing through every typed step. This step issues the HTTP request
+itself and asserts against the parsed body.
 """
 
 from __future__ import annotations
@@ -25,24 +23,21 @@ from merobox.commands.constants import (
 from merobox.commands.result import fail, ok
 from merobox.commands.utils import console
 
-# Distinguishes an absent key from one present with a null value. Core marks
-# optional fields `skip_serializing_if = "Option::is_none"`, so omission is the
-# observable difference between None and a value, and collapsing the two would
-# blind the step to exactly the case it exists to test.
+# Core marks optional fields `skip_serializing_if = "Option::is_none"`, so an
+# absent key is the observable difference between None and a value.
 _MISSING = object()
 
 
 def _lookup(payload: Any, path: str) -> Any:
     """Value at a dotted path, or ``_MISSING`` if the path does not exist.
 
-    Unlike ``BaseStep._get_value`` this re-parses nothing on the way down: a
-    string stays a string, so the assertion sees the body verbatim.
+    Unlike ``BaseStep._get_value`` this neither re-parses JSON on the way down
+    nor collapses a missing path to None, so the assertion sees the body verbatim.
     """
     current = payload
     for segment in path.split("."):
         if isinstance(current, list) and segment.isdigit():
-            index = int(segment)
-            if index >= len(current):
+            if (index := int(segment)) >= len(current):
                 return _MISSING
             current = current[index]
         elif isinstance(current, dict) and segment in current:
@@ -55,30 +50,9 @@ def _lookup(payload: Any, path: str) -> Any:
 class AssertApiResponseStep(BaseStep):
     """GET a path on a node's admin API and assert against the JSON it returned.
 
-    Required fields: ``node``, ``path``, and at least one of ``match`` /
-    ``present`` / ``absent``.
-
-    Optional fields:
-    - ``match`` (dict): dotted paths mapped to expected values. ``null`` asserts
-      the key is present AND null, which an absent key does not satisfy.
-    - ``present`` (list): dotted paths that must exist, whatever their value.
-    - ``absent`` (list): dotted paths that must not exist.
-    - ``token`` (str): explicit JWT (supports ``{{placeholders}}``); otherwise
-      the token a prior ``login`` cached for the node, or none at all on a node
-      running without auth.
-
-    Paths address the body verbatim, envelope included: the admin API wraps
-    payloads in ``data`` and serializes camelCase, so a field reads
-    ``data.fleetCompletedAt``.
-
-    One request, no polling - the other assertion steps do not poll either.
-    Compose with ``repeat`` or ``wait_for_sync`` when the assertion has to wait
-    for state to settle.
-
     ``expected_failure`` / ``expected_error`` govern the request outcome only.
-    An assertion that misses always fails the step: a miss satisfying
-    ``expected_failure`` would turn a typo in a path into a green negative
-    test, which is the failure the flag exists to prevent.
+    A missed assertion always fails the step, or a typo'd path would read as a
+    green negative test.
     """
 
     def _get_required_fields(self) -> list[str]:
@@ -91,8 +65,6 @@ class AssertApiResponseStep(BaseStep):
         self._validate_dict_field("match", required=False)
         self._validate_list_field("present", required=False, element_type=str)
         self._validate_list_field("absent", required=False, element_type=str)
-        # Iterating a dict yields its keys and a list its elements, so one loop
-        # covers all three fields.
         for field in ("match", "present", "absent"):
             for path in self.config.get(field) or []:
                 if not isinstance(path, str) or not path.strip():
@@ -100,9 +72,8 @@ class AssertApiResponseStep(BaseStep):
                         f"Step '{self._get_step_name()}': '{field}' entries must "
                         f"be non-empty dotted paths into the response body"
                     )
+        # Without an assertion the step would pass unconditionally.
         if not self._assertion_count() and not self._is_expected_failure():
-            # An assertion step with nothing to assert passes unconditionally,
-            # the silent no-op `expected_error` exists to close.
             raise ValueError(
                 f"Step '{self._get_step_name()}': needs at least one of 'match', "
                 f"'present' or 'absent' - without one it asserts nothing"
@@ -131,28 +102,26 @@ class AssertApiResponseStep(BaseStep):
         headers = {"Authorization": f"Bearer {token}"} if token else {}
 
         try:
-            # Off the loop: this is the one step that issues its own HTTP
-            # rather than delegating to the compiled client, so it is the one
-            # that can yield while a `parallel:` sibling runs.
+            # Off the loop: `requests` is synchronous, and this is the one step
+            # issuing its own HTTP, so a `parallel:` sibling must keep running.
             response = await asyncio.to_thread(
                 requests.get,
                 f"{rpc_url.rstrip('/')}/{path.lstrip('/')}",
                 headers=headers,
                 timeout=(DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT),
             )
-            # The whole 2xx range, not just 200: a route answering 201/204 has
-            # served the request, and rejecting it would report a working
-            # endpoint as an HTTP failure.
+            # The whole 2xx range: a route answering 201/204 has served the
+            # request, and failing it would report a working endpoint as broken.
             if not 200 <= response.status_code < 300:
                 result = fail(
                     f"GET {path} on {node_name} returned HTTP "
                     f"{response.status_code}: {response.text}"
                 )
             else:
-                # json.loads, not _parse_json: its fallbacks would repair a body
-                # the node should not have sent, and hide that it did.
-                result = ok(json.loads(response.text))
-        except json.JSONDecodeError as e:
+                # Raw bytes, not response.text, whose charset requests guesses;
+                # json.loads, not _parse_json, whose repairs would hide a bad body.
+                result = ok(json.loads(response.content))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
             result = fail(f"GET {path} on {node_name} returned a non-JSON body: {e}")
         except Exception as e:
             result = fail(f"GET {path} on {node_name} failed", error=e)

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from rich.markup import escape
 
+from merobox.commands.auth import AuthManager
 from merobox.commands.utils import LOG_LEVEL_VERBOSE, console, get_node_rpc_url, vprint
 
 if TYPE_CHECKING:
@@ -765,6 +766,32 @@ class BaseStep:
             client_node_name = node_name if self.auth_mode == "embedded" else None
 
         return rpc_url, client_node_name
+
+    def _resolve_node_target(self, node_name: str) -> tuple[str, str]:
+        """Resolve a node to its RPC URL and the name its token is cached under."""
+        resolved = self._resolve_node(node_name)
+        if resolved:
+            return resolved.url, resolved.node_name
+        return self._get_node_rpc_url(node_name), node_name
+
+    def _resolve_token(
+        self,
+        cache_node_name: str,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> Optional[str]:
+        """Resolve the JWT to attach: explicit ``token`` field wins, else cache.
+
+        A node running without auth issues no token, so None is a normal answer
+        and not an error - the request's own outcome is the auth signal.
+        """
+        explicit = self.config.get("token")
+        if explicit:
+            return self._resolve_dynamic_value(
+                explicit, workflow_results, dynamic_values
+            )
+        cached = AuthManager().get_cached_token(cache_node_name)
+        return cached.access_token if cached else None
 
     def _parse_json(self, value: Any) -> Any:
         """Parse JSON string to Python object using a robust multi-strategy parser.

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -22,7 +22,6 @@ from typing import Any
 import aiohttp
 from rich.markup import escape
 
-from merobox.commands.auth import AuthManager
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.constants import DEFAULT_CONNECTION_TIMEOUT
 from merobox.commands.utils import console
@@ -42,29 +41,7 @@ _REDACTED = "***"
 
 
 class _WebSocketStepBase(BaseStep):
-    """Shared node/token/URL resolution for the WebSocket steps."""
-
-    def _resolve_ws_target(self, node_name: str) -> tuple[str, str]:
-        """Resolve a node to its RPC URL and the name its token is cached under."""
-        resolved = self._resolve_node(node_name)
-        if resolved:
-            return resolved.url, resolved.node_name
-        return self._get_node_rpc_url(node_name), node_name
-
-    def _resolve_token(
-        self,
-        cache_node_name: str,
-        workflow_results: dict[str, Any],
-        dynamic_values: dict[str, Any],
-    ) -> str | None:
-        """Resolve the JWT to attach: explicit ``token`` field wins, else cache."""
-        explicit = self.config.get("token")
-        if explicit:
-            return self._resolve_dynamic_value(
-                explicit, workflow_results, dynamic_values
-            )
-        cached = AuthManager().get_cached_token(cache_node_name)
-        return cached.access_token if cached else None
+    """Shared ``ws(s)://`` URL construction for the WebSocket steps."""
 
     def _build_ws_url(self, rpc_url: str, token: str | None) -> str:
         """Build the ``ws(s)://host:port/ws[?token=...]`` URL from the RPC URL."""
@@ -131,7 +108,7 @@ class WebSocketConnectStep(_WebSocketStepBase):
         )
 
         try:
-            rpc_url, cache_node_name = self._resolve_ws_target(node_name)
+            rpc_url, cache_node_name = self._resolve_node_target(node_name)
         except Exception as e:
             console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
             return False
@@ -312,7 +289,7 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         }
 
         try:
-            rpc_url, cache_node_name = self._resolve_ws_target(node_name)
+            rpc_url, cache_node_name = self._resolve_node_target(node_name)
         except Exception as e:
             console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
             return False

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -11,6 +11,7 @@ from merobox.commands.bootstrap.steps.account import (
     AccountRevokeStep,
     AccountShowStep,
 )
+from merobox.commands.bootstrap.steps.api_assertion import AssertApiResponseStep
 from merobox.commands.bootstrap.steps.assert_log import (
     AssertLogAbsentStep,
     AssertLogPresentStep,
@@ -420,6 +421,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = WebSocketConnectStep
         elif step_type == "assert_ws_event":
             step_class = WebSocketEventAssertStep
+        elif step_type == "assert_api_response":
+            step_class = AssertApiResponseStep
         elif step_type == "set_tee_admission_policy":
             step_class = SetTeeAdmissionPolicyStep
         elif step_type == "tee_fleet_join":

--- a/merobox/tests/unit/test_api_response_assertion.py
+++ b/merobox/tests/unit/test_api_response_assertion.py
@@ -265,12 +265,23 @@ class TestNullIsNotAbsent:
 
 
 class TestTransportFailures:
-    def test_a_non_200_fails_and_prints_the_status_and_body(self, capsys):
+    def test_a_non_2xx_fails_and_prints_the_status_and_body(self, capsys):
         result, _, _ = _execute(_step(present=["data"]), "nope", status=404)
         assert result is False
         out = capsys.readouterr().out
         assert "returned HTTP 404" in out
         assert "nope" in out
+
+    def test_another_2xx_status_is_a_served_request(self):
+        # The contract is "a non-2xx status fails", so a route answering 201
+        # has served the request and its body is what gets asserted on.
+        result, _, _ = _execute(_step(present=["data"]), _body(), status=201)
+        assert result is True
+
+    def test_a_3xx_status_still_fails(self, capsys):
+        result, _, _ = _execute(_step(present=["data"]), _body(), status=302)
+        assert result is False
+        assert "returned HTTP 302" in capsys.readouterr().out
 
     def test_a_non_json_body_fails(self, capsys):
         result, _, _ = _execute(_step(present=["data"]), "<html>502</html>")

--- a/merobox/tests/unit/test_api_response_assertion.py
+++ b/merobox/tests/unit/test_api_response_assertion.py
@@ -299,6 +299,14 @@ class TestTransportFailures:
         assert result is False
         assert "HTTP 403" in capsys.readouterr().out
 
+    def test_a_missed_assertion_is_not_an_expected_failure(self, capsys):
+        # `expected_failure` pins the request outcome, never the verdicts: a
+        # miss satisfying it would make a typo'd path a green negative test.
+        step = _step(expected_failure=True, match={"data.targetVersion": 9})
+        result, _, _ = _execute(step, _body())
+        assert result is False
+        assert "missed 1 of 1 assertion(s)" in capsys.readouterr().out
+
     def test_expected_failure_fails_when_the_request_succeeds(self, capsys):
         result, _, _ = _execute(_step(expected_failure=True), _body())
         assert result is False

--- a/merobox/tests/unit/test_api_response_assertion.py
+++ b/merobox/tests/unit/test_api_response_assertion.py
@@ -14,6 +14,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from merobox.commands.bootstrap.steps.api_assertion import AssertApiResponseStep
 
@@ -78,11 +79,13 @@ def _execute(
     workflow_results=None,
     dynamic=None,
     text=None,
+    error=None,
 ):
     """Run the step against a canned response, returning (result, get, results).
 
     ``text`` overrides only the decoded view, so a test can simulate requests
     guessing the charset wrong while the transmitted bytes stay correct.
+    ``error`` makes the request raise instead of answering.
     """
     auth = MagicMock()
     auth.get_cached_token.return_value = (
@@ -100,6 +103,7 @@ def _execute(
         patch(
             "merobox.commands.bootstrap.steps.api_assertion.requests.get",
             return_value=response,
+            side_effect=error,
         ) as get,
     ):
         return _run(step.execute(results, dynamic or {})), get, results
@@ -331,6 +335,21 @@ class TestTransportFailures:
         raw = json.dumps(_body(reason=reason), ensure_ascii=False)
         step = _step(match={"data.reason": reason})
         assert _execute(step, raw, text=raw.encode().decode("latin-1"))[0] is True
+
+    def test_an_unreachable_node_fails_the_step_rather_than_raising(self, capsys):
+        step = _step(present=["data"])
+        result, _, _ = _execute(
+            step, _body(), error=requests.ConnectionError("refused")
+        )
+        assert result is False
+        assert "refused" in capsys.readouterr().out
+
+    def test_a_bug_in_the_step_is_not_reported_as_a_request_failure(self):
+        # A TypeError from this step's own plumbing must reach the runner, not
+        # `expected_failure`, or a negative test turns green on a defect.
+        step = _step(expected_failure=True, present=["data"])
+        with pytest.raises(TypeError):
+            _execute(step, _body(), error=TypeError("headers is not a mapping"))
 
     def test_expected_failure_accepts_a_refused_request(self):
         step = _step(expected_failure=True, expected_error="HTTP 403")

--- a/merobox/tests/unit/test_api_response_assertion.py
+++ b/merobox/tests/unit/test_api_response_assertion.py
@@ -70,15 +70,29 @@ def _step(**extra):
     return AssertApiResponseStep(config, manager=_manager())
 
 
-def _execute(step, payload, status=200, token=None, workflow_results=None):
-    """Run the step against a canned response, returning (result, get, results)."""
+def _execute(
+    step,
+    payload,
+    status=200,
+    token=None,
+    workflow_results=None,
+    dynamic=None,
+    text=None,
+):
+    """Run the step against a canned response, returning (result, get, results).
+
+    ``text`` overrides only the decoded view, so a test can simulate requests
+    guessing the charset wrong while the transmitted bytes stay correct.
+    """
     auth = MagicMock()
     auth.get_cached_token.return_value = (
         MagicMock(access_token=token) if token else None
     )
+    body = payload if isinstance(payload, str) else json.dumps(payload)
     response = MagicMock()
     response.status_code = status
-    response.text = payload if isinstance(payload, str) else json.dumps(payload)
+    response.content = body.encode()
+    response.text = body if text is None else text
 
     results = workflow_results if workflow_results is not None else {}
     with (
@@ -88,7 +102,7 @@ def _execute(step, payload, status=200, token=None, workflow_results=None):
             return_value=response,
         ) as get,
     ):
-        return _run(step.execute(results, {})), get, results
+        return _run(step.execute(results, dynamic or {})), get, results
 
 
 class TestConcurrency:
@@ -101,7 +115,7 @@ class TestConcurrency:
         auth.get_cached_token.return_value = None
         response = MagicMock()
         response.status_code = 200
-        response.text = json.dumps(_body())
+        response.content = json.dumps(_body()).encode()
 
         def slow_get(*args, **kwargs):
             time.sleep(0.3)
@@ -132,8 +146,9 @@ class TestConcurrency:
             ),
         ):
             assert _run(both()) is True
-        # A blocked loop yields no ticks at all; a free one manages ~30.
-        assert ticks > 10
+        # Exactly 0 if the loop was blocked: nothing before the call awaits, so
+        # the ticker never starts. A count threshold would only time the runner.
+        assert ticks > 0
 
 
 class TestRequest:
@@ -148,21 +163,7 @@ class TestRequest:
 
     def test_the_path_resolves_placeholders(self):
         step = _step(path="/admin-api/namespaces/{{ns}}/x", present=["data"])
-        auth = MagicMock()
-        auth.get_cached_token.return_value = None
-        response = MagicMock()
-        response.status_code = 200
-        response.text = json.dumps(_body())
-        with (
-            patch(
-                "merobox.commands.bootstrap.steps.base.AuthManager", return_value=auth
-            ),
-            patch(
-                "merobox.commands.bootstrap.steps.api_assertion.requests.get",
-                return_value=response,
-            ) as get,
-        ):
-            _run(step.execute({}, {"ns": "deadbeef"}))
+        _, get, _ = _execute(step, _body(), dynamic={"ns": "deadbeef"})
         assert get.call_args[0][0].endswith("/admin-api/namespaces/deadbeef/x")
 
     def test_a_cached_token_is_attached_as_a_bearer_header(self):
@@ -215,21 +216,8 @@ class TestMatch:
 
     def test_a_match_value_resolves_placeholders(self):
         step = _step(match={"data.fleetCompletedAt": "{{stamp}}"})
-        auth = MagicMock()
-        auth.get_cached_token.return_value = None
-        response = MagicMock()
-        response.status_code = 200
-        response.text = json.dumps(_body(fleetCompletedAt="42"))
-        with (
-            patch(
-                "merobox.commands.bootstrap.steps.base.AuthManager", return_value=auth
-            ),
-            patch(
-                "merobox.commands.bootstrap.steps.api_assertion.requests.get",
-                return_value=response,
-            ),
-        ):
-            assert _run(step.execute({}, {"stamp": "42"})) is True
+        body = _body(fleetCompletedAt="42")
+        assert _execute(step, body, dynamic={"stamp": "42"})[0] is True
 
     def test_unlisted_fields_are_ignored(self):
         # A subset test: the body carries four more keys than are asserted.
@@ -334,6 +322,16 @@ class TestTransportFailures:
         assert result is False
         assert "non-JSON body" in capsys.readouterr().out
 
+    def test_a_utf8_body_is_read_from_the_bytes_not_the_guessed_text(self):
+        # requests guesses the charset whenever the response omits it, so
+        # `.text` can arrive mojibaked while the bytes are intact.
+        reason = "quorum perdu à 3 nœuds"
+        # ensure_ascii=False, or the body is pure ASCII escapes and both the
+        # bytes and the mis-decoded text would agree.
+        raw = json.dumps(_body(reason=reason), ensure_ascii=False)
+        step = _step(match={"data.reason": reason})
+        assert _execute(step, raw, text=raw.encode().decode("latin-1"))[0] is True
+
     def test_expected_failure_accepts_a_refused_request(self):
         step = _step(expected_failure=True, expected_error="HTTP 403")
         result, _, _ = _execute(step, "forbidden", status=403)
@@ -387,7 +385,3 @@ class TestValidation:
     def test_match_must_be_a_dict(self):
         with pytest.raises(ValueError, match="match"):
             _step(match=["data"])
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/merobox/tests/unit/test_api_response_assertion.py
+++ b/merobox/tests/unit/test_api_response_assertion.py
@@ -10,6 +10,7 @@ envelope: a camelCase payload under `data`, with the optional fields core marks
 
 import asyncio
 import json
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -88,6 +89,51 @@ def _execute(step, payload, status=200, token=None, workflow_results=None):
         ) as get,
     ):
         return _run(step.execute(results, {})), get, results
+
+
+class TestConcurrency:
+    def test_the_request_does_not_block_the_event_loop(self):
+        # `requests` is synchronous, so without the thread hand-off a
+        # `parallel:` sibling - including assert_ws_event, whose verdict is a
+        # deadline - makes no progress for the length of the request.
+        step = _step(present=["data"])
+        auth = MagicMock()
+        auth.get_cached_token.return_value = None
+        response = MagicMock()
+        response.status_code = 200
+        response.text = json.dumps(_body())
+
+        def slow_get(*args, **kwargs):
+            time.sleep(0.3)
+            return response
+
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        async def both():
+            beat = asyncio.ensure_future(ticker())
+            try:
+                return await step.execute({}, {})
+            finally:
+                beat.cancel()
+
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.base.AuthManager", return_value=auth
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.api_assertion.requests.get",
+                new=slow_get,
+            ),
+        ):
+            assert _run(both()) is True
+        # A blocked loop yields no ticks at all; a free one manages ~30.
+        assert ticks > 10
 
 
 class TestRequest:

--- a/merobox/tests/unit/test_api_response_assertion.py
+++ b/merobox/tests/unit/test_api_response_assertion.py
@@ -1,0 +1,328 @@
+"""
+Unit tests for the assert_api_response workflow step.
+
+`requests` is mocked with a canned admin-API body, since the property under test
+is that the step asserts against the bytes the node sent rather than against a
+typed DTO that may have dropped keys. The body shape is the migration-status
+envelope: a camelCase payload under `data`, with the optional fields core marks
+`skip_serializing_if = "Option::is_none"` genuinely absent rather than null.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.api_assertion import AssertApiResponseStep
+
+_PATH = "/admin-api/namespaces/abc/migration-status"
+
+
+@pytest.fixture(autouse=True)
+def _wide_console():
+    """Rich soft-wraps at terminal width, splitting the strings asserted on."""
+    from merobox.commands.utils import console
+
+    original = console.width
+    console.width = 400
+    yield
+    console.width = original
+
+
+def _run(coro):
+    """Run a coroutine on a dedicated loop, leaving a fresh current loop behind."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def _manager():
+    manager = MagicMock()
+    manager.get_node_rpc_port.return_value = 2528
+    return manager
+
+
+def _body(**overrides):
+    data = {
+        "targetVersion": 2,
+        "fleetCompletedAt": 1786635547,
+        "rollup": {"total": 3, "migrated": 3, "allMigrated": True},
+        "members": [{"peer": "p1", "report": {"schemaVersion": 2}}],
+    }
+    data.update(overrides)
+    return {"data": data}
+
+
+def _step(**extra):
+    config = {
+        "type": "assert_api_response",
+        "name": "raw-migration-status",
+        "node": "calimero-node-1",
+        "path": _PATH,
+        **extra,
+    }
+    return AssertApiResponseStep(config, manager=_manager())
+
+
+def _execute(step, payload, status=200, token=None, workflow_results=None):
+    """Run the step against a canned response, returning (result, get, results)."""
+    auth = MagicMock()
+    auth.get_cached_token.return_value = (
+        MagicMock(access_token=token) if token else None
+    )
+    response = MagicMock()
+    response.status_code = status
+    response.text = payload if isinstance(payload, str) else json.dumps(payload)
+
+    results = workflow_results if workflow_results is not None else {}
+    with (
+        patch("merobox.commands.bootstrap.steps.base.AuthManager", return_value=auth),
+        patch(
+            "merobox.commands.bootstrap.steps.api_assertion.requests.get",
+            return_value=response,
+        ) as get,
+    ):
+        return _run(step.execute(results, {})), get, results
+
+
+class TestRequest:
+    def test_the_url_is_built_from_the_node_and_the_path(self):
+        _, get, _ = _execute(_step(present=["data"]), _body())
+        assert get.call_args[0][0] == f"http://localhost:2528{_PATH}"
+
+    def test_a_path_without_a_leading_slash_reaches_the_same_url(self):
+        step = _step(path=_PATH.lstrip("/"), present=["data"])
+        _, get, _ = _execute(step, _body())
+        assert get.call_args[0][0] == f"http://localhost:2528{_PATH}"
+
+    def test_the_path_resolves_placeholders(self):
+        step = _step(path="/admin-api/namespaces/{{ns}}/x", present=["data"])
+        auth = MagicMock()
+        auth.get_cached_token.return_value = None
+        response = MagicMock()
+        response.status_code = 200
+        response.text = json.dumps(_body())
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.base.AuthManager", return_value=auth
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.api_assertion.requests.get",
+                return_value=response,
+            ) as get,
+        ):
+            _run(step.execute({}, {"ns": "deadbeef"}))
+        assert get.call_args[0][0].endswith("/admin-api/namespaces/deadbeef/x")
+
+    def test_a_cached_token_is_attached_as_a_bearer_header(self):
+        _, get, _ = _execute(_step(present=["data"]), _body(), token="acc.jwt.tok")
+        assert get.call_args[1]["headers"] == {"Authorization": "Bearer acc.jwt.tok"}
+
+    def test_no_cached_token_sends_no_authorization_header(self):
+        # A node running without auth issues no token; that is not an error here,
+        # the response status is the auth signal.
+        _, get, _ = _execute(_step(present=["data"]), _body())
+        assert get.call_args[1]["headers"] == {}
+
+    def test_an_explicit_token_overrides_the_cache(self):
+        step = _step(present=["data"], token="explicit.jwt")
+        _, get, _ = _execute(step, _body(), token="cached.jwt")
+        assert get.call_args[1]["headers"] == {"Authorization": "Bearer explicit.jwt"}
+
+    def test_the_raw_body_is_stored_for_later_steps(self):
+        _, _, results = _execute(_step(present=["data"]), _body())
+        assert results["api_response_calimero-node-1"] == _body()
+
+
+class TestMatch:
+    def test_a_matching_field_passes(self):
+        step = _step(match={"data.fleetCompletedAt": 1786635547})
+        result, _, _ = _execute(step, _body())
+        assert result is True
+
+    def test_a_field_the_typed_client_would_drop_is_still_asserted(self):
+        # The whole point: an additive core field lands in the body and the
+        # assertion sees it, with no client-py release in the chain.
+        step = _step(match={"data.newlyAddedField": "hello"})
+        result, _, _ = _execute(step, _body(newlyAddedField="hello"))
+        assert result is True
+
+    def test_a_mismatched_value_fails_and_prints_what_arrived(self, capsys):
+        step = _step(match={"data.fleetCompletedAt": 1786635547})
+        result, _, _ = _execute(step, _body(fleetCompletedAt=1786635548))
+        assert result is False
+        out = capsys.readouterr().out
+        assert "data.fleetCompletedAt: expected 1786635547, got 1786635548" in out
+        # The whole body is replayed, so CI output alone diagnoses the failure.
+        assert '"allMigrated": true' in out
+        assert '"schemaVersion": 2' in out
+
+    def test_a_nested_and_indexed_path_is_matched(self):
+        step = _step(match={"data.members.0.report.schemaVersion": 2})
+        result, _, _ = _execute(step, _body())
+        assert result is True
+
+    def test_a_match_value_resolves_placeholders(self):
+        step = _step(match={"data.fleetCompletedAt": "{{stamp}}"})
+        auth = MagicMock()
+        auth.get_cached_token.return_value = None
+        response = MagicMock()
+        response.status_code = 200
+        response.text = json.dumps(_body(fleetCompletedAt="42"))
+        with (
+            patch(
+                "merobox.commands.bootstrap.steps.base.AuthManager", return_value=auth
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.api_assertion.requests.get",
+                return_value=response,
+            ),
+        ):
+            assert _run(step.execute({}, {"stamp": "42"})) is True
+
+    def test_unlisted_fields_are_ignored(self):
+        # A subset test: the body carries four more keys than are asserted.
+        step = _step(match={"data.targetVersion": 2})
+        result, _, _ = _execute(step, _body())
+        assert result is True
+
+    def test_every_missed_path_is_reported_not_just_the_first(self, capsys):
+        step = _step(match={"data.targetVersion": 9, "data.fleetCompletedAt": 1})
+        result, _, _ = _execute(step, _body())
+        assert result is False
+        out = capsys.readouterr().out
+        assert "missed 2 of 2 assertion(s)" in out
+        assert "data.targetVersion" in out
+        assert "data.fleetCompletedAt" in out
+
+
+class TestPresence:
+    def test_a_present_key_satisfies_present(self):
+        result, _, _ = _execute(_step(present=["data.fleetCompletedAt"]), _body())
+        assert result is True
+
+    def test_an_absent_key_fails_present(self, capsys):
+        # `skip_serializing_if` omits the key entirely, so this is what a
+        # never-completed fleet actually looks like on the wire.
+        body = _body()
+        del body["data"]["fleetCompletedAt"]
+        result, _, _ = _execute(_step(present=["data.fleetCompletedAt"]), body)
+        assert result is False
+        out = capsys.readouterr().out
+        assert (
+            "data.fleetCompletedAt: expected the key to be present, it is absent" in out
+        )
+        assert '"targetVersion": 2' in out, "the body must still be printed"
+
+    def test_an_absent_key_satisfies_absent(self):
+        body = _body()
+        del body["data"]["fleetCompletedAt"]
+        result, _, _ = _execute(_step(absent=["data.fleetCompletedAt"]), body)
+        assert result is True
+
+    def test_a_present_key_fails_absent(self, capsys):
+        result, _, _ = _execute(_step(absent=["data.fleetCompletedAt"]), _body())
+        assert result is False
+        out = capsys.readouterr().out
+        assert "expected the key to be absent, it is present with 1786635547" in out
+
+
+class TestNullIsNotAbsent:
+    """`skip_serializing_if` makes omission meaningful, so the two must differ."""
+
+    def test_present_and_null_satisfies_present(self):
+        result, _, _ = _execute(
+            _step(present=["data.fleetCompletedAt"]), _body(fleetCompletedAt=None)
+        )
+        assert result is True
+
+    def test_present_and_null_violates_absent(self, capsys):
+        result, _, _ = _execute(
+            _step(absent=["data.fleetCompletedAt"]), _body(fleetCompletedAt=None)
+        )
+        assert result is False
+        assert "it is present with None" in capsys.readouterr().out
+
+    def test_matching_null_passes_on_an_explicit_null(self):
+        result, _, _ = _execute(
+            _step(match={"data.fleetCompletedAt": None}), _body(fleetCompletedAt=None)
+        )
+        assert result is True
+
+    def test_matching_null_fails_on_an_absent_key(self, capsys):
+        body = _body()
+        del body["data"]["fleetCompletedAt"]
+        result, _, _ = _execute(_step(match={"data.fleetCompletedAt": None}), body)
+        assert result is False
+        # The report has to say "absent", not "got None", or the two states read
+        # identically in CI - the exact conflation this step exists to remove.
+        assert "expected None, but the key is absent" in capsys.readouterr().out
+
+
+class TestTransportFailures:
+    def test_a_non_200_fails_and_prints_the_status_and_body(self, capsys):
+        result, _, _ = _execute(_step(present=["data"]), "nope", status=404)
+        assert result is False
+        out = capsys.readouterr().out
+        assert "returned HTTP 404" in out
+        assert "nope" in out
+
+    def test_a_non_json_body_fails(self, capsys):
+        result, _, _ = _execute(_step(present=["data"]), "<html>502</html>")
+        assert result is False
+        assert "non-JSON body" in capsys.readouterr().out
+
+    def test_expected_failure_accepts_a_refused_request(self):
+        step = _step(expected_failure=True, expected_error="HTTP 403")
+        result, _, _ = _execute(step, "forbidden", status=403)
+        assert result is True
+
+    def test_expected_error_pins_which_refusal_counts(self, capsys):
+        step = _step(expected_failure=True, expected_error="HTTP 403")
+        result, _, _ = _execute(step, "missing", status=404)
+        assert result is False
+        assert "HTTP 403" in capsys.readouterr().out
+
+    def test_expected_failure_fails_when_the_request_succeeds(self, capsys):
+        result, _, _ = _execute(_step(expected_failure=True), _body())
+        assert result is False
+        assert (
+            "expected_failure was set but the step succeeded" in capsys.readouterr().out
+        )
+
+
+class TestValidation:
+    def test_node_and_path_are_required(self):
+        with pytest.raises(ValueError):
+            AssertApiResponseStep(
+                {"type": "assert_api_response", "node": "calimero-node-1"},
+                manager=_manager(),
+            )
+
+    def test_a_step_with_no_assertion_is_rejected(self):
+        with pytest.raises(ValueError, match="asserts nothing"):
+            _step()
+
+    def test_a_negative_test_may_assert_nothing_but_the_refusal(self):
+        _step(expected_failure=True, expected_error="HTTP 404")
+
+    def test_an_empty_path_entry_is_rejected(self):
+        with pytest.raises(ValueError, match="non-empty dotted paths"):
+            _step(match={"": 1})
+
+    def test_a_non_string_present_entry_is_rejected(self):
+        with pytest.raises(ValueError):
+            _step(present=[1])
+
+    def test_match_must_be_a_dict(self):
+        with pytest.raises(ValueError, match="match"):
+            _step(match=["data"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/merobox/tests/unit/test_auth_steps.py
+++ b/merobox/tests/unit/test_auth_steps.py
@@ -387,7 +387,7 @@ class TestWebSocketConnectStep:
 
         with (
             patch(
-                "merobox.commands.bootstrap.steps.websocket.AuthManager",
+                "merobox.commands.bootstrap.steps.base.AuthManager",
                 return_value=fake_auth,
             ),
             patch(
@@ -407,7 +407,7 @@ class TestWebSocketConnectStep:
         fake_auth.get_cached_token.return_value = None
 
         with patch(
-            "merobox.commands.bootstrap.steps.websocket.AuthManager",
+            "merobox.commands.bootstrap.steps.base.AuthManager",
             return_value=fake_auth,
         ):
             result = _run(step.execute({}, {}))
@@ -511,7 +511,7 @@ class TestWebSocketTokenRedaction:
         fake_auth.get_cached_token.return_value = _token()
         with (
             patch(
-                "merobox.commands.bootstrap.steps.websocket.AuthManager",
+                "merobox.commands.bootstrap.steps.base.AuthManager",
                 return_value=fake_auth,
             ),
             patch(

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -175,7 +175,7 @@ def _execute(step, frames, workflow_results=None, session=None, token=None):
     )
     with (
         patch(
-            "merobox.commands.bootstrap.steps.websocket.AuthManager",
+            "merobox.commands.bootstrap.steps.base.AuthManager",
             return_value=auth,
         ),
         patch(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,9 @@ dependencies = [
     # 0.6.21 is where `revoke_device` grew its `proof` argument. Below it the
     # account_revoke step's three-argument call is a TypeError at run time, not a
     # resolution failure at install time, so the floor has to say so.
-    "calimero-client-py>=0.6.24",
+    # 0.6.26 decodes `join_namespace` into a master-only struct requiring
+    # `memberAccount`, which no released node sends. Lift once one does.
+    "calimero-client-py>=0.6.24,<0.6.26",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ PyYAML>=6.0.0
 #     requires and a master node ignores. 0.6.22 and 0.6.23 omitted it and could
 #     not create a namespace on any released node — which is what turned this
 #     suite red when it was floored at 0.6.23.
-calimero-client-py>=0.6.24
+# 0.6.26 gives that up: it decodes `join_namespace` into a master-only struct
+# requiring `memberAccount`, which no released node sends. Lift once one does.
+calimero-client-py>=0.6.24,<0.6.26
 aiohttp>=3.9.0
 toml>=0.10.2
 pydantic>=2.0.0

--- a/workflow-examples/workflow-assert-api-response-example.yml
+++ b/workflow-examples/workflow-assert-api-response-example.yml
@@ -25,17 +25,21 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  # A namespace nobody has upgraded: the rollup exists, and the fields core
-  # only serializes for an active upgrade are genuinely absent.
+  # A namespace nobody has upgraded. `fleetCompletedAt` is stamped only when a
+  # fleet converges, and core marks it skip_serializing_if_none, so its absence
+  # here is a fact - distinct from present-and-null, which is what the typed
+  # client used to manufacture.
   - name: Assert the untouched migration-status shape
     type: assert_api_response
     node: calimero-node-1
-    path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
+    path: '/admin-api/groups/{{namespace_id}}/migration-status'
+    match:
+      rollup.total: 1
     present:
-      - data.rollup
-      - data.members
+      - rollup.allMigrated
+      - members
     absent:
-      - data.targetVersion
+      - fleetCompletedAt
 
   # The same read through the typed client. It agreeing with the raw body is
   # what makes a later disagreement mean a dropped field rather than a defect.

--- a/workflow-examples/workflow-assert-api-response-example.yml
+++ b/workflow-examples/workflow-assert-api-response-example.yml
@@ -1,0 +1,47 @@
+description: Assert against the JSON a node's admin API actually sent
+name: Assert API Response Example
+
+# Keep it light: single node to speed up CI
+nodes:
+  count: 1
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: calimero-node
+  base_port: 9012
+  base_rpc_port: 9112
+
+steps:
+  - name: Install Application
+    type: install_application
+    node: calimero-node-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace
+    type: create_namespace
+    node: calimero-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  # A namespace nobody has upgraded: the rollup exists, and the fields core
+  # only serializes for an active upgrade are genuinely absent.
+  - name: Assert the untouched migration-status shape
+    type: assert_api_response
+    node: calimero-node-1
+    path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
+    present:
+      - data.rollup
+      - data.members
+    absent:
+      - data.targetVersion
+
+  # The same read through the typed client. It agreeing with the raw body is
+  # what makes a later disagreement mean a dropped field rather than a defect.
+  - name: Read the rollup through the typed client
+    type: get_migration_status
+    node: calimero-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      typed_total: total


### PR DESCRIPTION
## Summary

Stacks on #326 and #324 - the diff against `master` includes their commits until they merge.

`calimero-client-py` is a compiled Rust wrapper built from a pinned core revision, and its DTOs drop any response key that build does not know about - silently, on deserialize, before merobox sees the body. Proven on a live node: core returns `"fleetCompletedAt":1786635547` over curl while `get_client(...).get_migration_status(...)` returns a dict without the key at all. Consequence: every additive admin-API field is untestable end to end until a client-py release lands, and a brand-new field is indistinguishable from a broken one in exactly the environment where you would want to verify it. That is a structural hole in the test chain, not a one-off.

New `assert_api_response` step issues the HTTP request itself and asserts against the parsed JSON, so the assertion sees what core actually sent.

```yaml
- type: assert_api_response
  node: calimero-node-1
  path: '/admin-api/namespaces/{{namespace_id}}/migration-status'
  match:
    data.rollup.allMigrated: true
  present:
    - data.fleetCompletedAt
  absent:
    - data.targetVersion
```

- **Endpoint** is a node name plus a path, not a URL: the step reuses the node resolution every other step uses, so a workflow never hand-writes a host or port. Paths address the body verbatim, envelope included, and nothing is re-parsed on the way down - `_get_value`'s JSON-repair fallbacks would hide a malformed body rather than surface it.
- **Auth** reuses the WebSocket steps' path: an explicit `token:` wins, otherwise the JWT a prior `login` cached for the node, attached as `Authorization: Bearer`. A node running without auth issues no token and needs none; the response status is the auth signal. That resolution (and the node/URL/cache-name resolution beside it) moved from `_WebSocketStepBase` to `BaseStep` rather than being duplicated.
- **Absent vs null.** Core marks optional fields `skip_serializing_if = "Option::is_none"`, so an absent key is meaningful and distinct from present-and-null. A lookup collapsing the two would blind the step to the case it exists to test, so a sentinel separates them and the three assertions address the states independently:

  | Assertion | Present with a value | Present and null | Absent |
  | --- | --- | --- | --- |
  | `present: [k]` | pass | pass | fail |
  | `absent: [k]` | fail | fail | pass |
  | `match: {k: null}` | fail | pass | fail (reported as absent) |

- **At least one** of `match` / `present` / `absent` is required, so the step can never silently assert nothing - the same no-op `expected_error` was added to close. The exception is a negative test (`expected_failure: true`), where the refusal itself is the assertion.
- **Failure output** prints the per-path verdict and then the whole response body, so CI output alone tells "the field is missing" from "the field is wrong".
- **No retry or polling**: no other assertion step polls, and `repeat` / `wait_for_sync` already compose for that. GET only for the same reason - the gap being closed is additive fields on status reads, and adding `method`/`body` later is a purely additive YAML change.

Documented in `LLM.md` and the workflow YAML catalogue.

## Test plan

- `make format-check` (black + ruff): clean.
- `pytest merobox/tests/unit`: **1276 passed**, from a 1242 baseline on `feat/migration-report-and-expected-error` (33 new tests, plus one from the parametrized validator-coverage guard picking up the new step type).
- Each new test proven to be a gate by breaking the behaviour and confirming the failure, then restoring:
  - `_MISSING = None` (collapse absent into null) -> the three `TestNullIsNotAbsent` cases that assert null is observable fail.
  - `_lookup` swapped for `_get_value` (the None-collapsing traversal) -> `test_matching_null_fails_on_an_absent_key`, `test_an_absent_key_fails_present`, `test_an_absent_key_satisfies_absent` fail; `test_a_match_value_resolves_placeholders` fails too, since `_get_value` re-parses the string `"42"` into an int.
  - Body dropped from the failure report -> `test_a_mismatched_value_fails_and_prints_what_arrived` and `test_an_absent_key_fails_present` fail.
  - Bearer header dropped, and the "asserts nothing" guard disabled -> the two token tests and `test_a_step_with_no_assertion_is_rejected` fail.
  - URL join and the status check broken -> the URL test and both non-2xx tests fail.
- Not run: e2e/Docker, scheduled separately.