### PR TITLE
fix(bootstrap): omit what a node did not send from the status summaries

### DIFF
--- a/docs/src/content/docs/workflows/engine.mdx
+++ b/docs/src/content/docs/workflows/engine.mdx
@@ -153,7 +153,7 @@ A source the response does not carry **fails the step**.
 A capture that silently produced nothing would leave its placeholder unbound, and an unbound placeholder reaches later steps as the literal text `{{name}}`, which satisfies most assertions.
 Capturing a field that is present and `null` is fine - absent and null are different answers.
 
-Steps that roll a response up before exporting it — the cascade and migration status steps — carry that distinction into their summary, leaving a field the node did not send out of the summary rather than offering it as `null`.
+The cascade and migration status steps roll a response up before exporting it, and carry that distinction into their summary: a field the node did not send is left out rather than offered as `null`.
 So capturing `fleet_completed_at` from a node that has not converged fails naming the field, instead of binding a `null` no assertion can tell from a real one.
 
 The one exception is a step whose call failed: an error report carries the error fields and never the ones the call itself would have returned, so on that path a capture that cannot bind is skipped rather than fatal.

--- a/docs/src/content/docs/workflows/engine.mdx
+++ b/docs/src/content/docs/workflows/engine.mdx
@@ -153,7 +153,10 @@ A source the response does not carry **fails the step**.
 A capture that silently produced nothing would leave its placeholder unbound, and an unbound placeholder reaches later steps as the literal text `{{name}}`, which satisfies most assertions.
 Capturing a field that is present and `null` is fine - absent and null are different answers.
 
-The exception is a step whose call failed: an error report carries the error fields and never the ones the call itself would have returned, so a capture that cannot bind there is skipped rather than fatal.
+Steps that roll a response up before exporting it — the cascade and migration status steps — carry that distinction into their summary, leaving a field the node did not send out of the summary rather than offering it as `null`.
+So capturing `fleet_completed_at` from a node that has not converged fails naming the field, instead of binding a `null` no assertion can tell from a real one.
+
+The one exception is a step whose call failed: an error report carries the error fields and never the ones the call itself would have returned, so on that path a capture that cannot bind is skipped rather than fatal.
 That only matters for [`expected_failure`](#failure-handling) steps, since any other failing call has already stopped the workflow.
 
 ### Variable substitution

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1093,6 +1093,14 @@ Poll until a namespace migration finishes, or fail. Same fields as
 `residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`,
 `migration_failed`).
 
+Any of those the node did not send is **left out** of the summary rather than
+offered as `null`, so capturing one
+[fails the step](/workflows/engine/#capturing-outputs) naming the field. A node that has not converged omits `fleet_completed_at`, and
+a member that has not reported omits its whole report, so a capture of either is
+a real failure rather than a `null` an assertion cannot tell from a converged
+one. A field the node genuinely sends as `null` still binds. The rollup counters
+are computed, not passed through, and are always present.
+
 Alongside those, merobox recomputes these aggregates from the raw member reports
 rather than reading core's rollup, so an assertion on them can falsify the
 rollup rather than confirm it against itself:

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1093,13 +1093,9 @@ Poll until a namespace migration finishes, or fail. Same fields as
 `residue_auto`, `synced_up_to_hlc`, `reported_at`, `authored_remaining`,
 `migration_failed`).
 
-Any of those the node did not send is **left out** of the summary rather than
-offered as `null`, so capturing one
-[fails the step](/workflows/engine/#capturing-outputs) naming the field. A node that has not converged omits `fleet_completed_at`, and
-a member that has not reported omits its whole report, so a capture of either is
-a real failure rather than a `null` an assertion cannot tell from a converged
-one. A field the node genuinely sends as `null` still binds. The rollup counters
-are computed, not passed through, and are always present.
+Any of those the node did not send is **left out** of the summary rather than offered as `null`, so capturing it [fails the step](/workflows/engine/#capturing-outputs) naming the field.
+A node that has not converged omits `fleet_completed_at`, and a member that has not reported omits its whole report.
+A field the node genuinely sends as `null` still binds, and the rollup counters are computed rather than passed through, so they are always present.
 
 Alongside those, merobox recomputes these aggregates from the raw member reports
 rather than reading core's rollup, so an assertion on them can falsify the

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -21,6 +21,27 @@ if TYPE_CHECKING:
 _MISSING = object()
 
 
+def lookup(payload: Any, path: str) -> Any:
+    """Value at a dotted path, or ``_MISSING`` if the path does not exist.
+
+    Unlike ``BaseStep._get_value`` this re-parses nothing on the way down: a
+    string stays a string, so an assertion sees what the node sent. Capture
+    wants the opposite, which is why the two are separate.
+    """
+    current = payload
+    for segment in path.split("."):
+        if isinstance(current, list) and segment.isdigit():
+            index = int(segment)
+            if index >= len(current):
+                return _MISSING
+            current = current[index]
+        elif isinstance(current, dict) and segment in current:
+            current = current[segment]
+        else:
+            return _MISSING
+    return current
+
+
 def _describe_keys(data: Any) -> str:
     """The keys a failed capture could have named, for the error message."""
     if not isinstance(data, dict):

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -82,9 +82,9 @@ def _client_py_below(min_version: tuple[int, int, int]) -> bool:
 def _drop_absent(summary: dict[str, Any]) -> dict[str, Any]:
     """Drop the `_MISSING`-marked keys, so a capture of one raises instead of binding.
 
-    A summary key is merobox's invention, so `.get()`-ing an absent response
-    field makes it always bindable; leaving it out routes it back through the
-    absent-key check `_export_custom_outputs` applies to a raw response.
+    A summary key is merobox's invention: `.get()`-ing an absent response field
+    would make it bindable, where omitting it hits the same absent-key check
+    `_export_custom_outputs` applies to a raw response.
     """
     return {key: value for key, value in summary.items() if value is not _MISSING}
 
@@ -111,10 +111,8 @@ def _summarize_cascade_status(response: Any) -> dict[str, Any]:
     `outputs:`. Keeping the list under `groups` leaves the whole summary
     addressable.
 
-    `groups` mirrors core's `data`, so a response that carried no list at all
-    omits it rather than offering an empty one: the counters are honestly
-    derived from nothing, but `groups: []` would claim core answered with an
-    empty subtree.
+    `groups` mirrors core's `data`, so a response carrying no list omits it:
+    `groups: []` would claim core answered with an empty subtree.
     """
     raw_entries = response.get("data") if isinstance(response, dict) else None
     entries: list[Any] = raw_entries if isinstance(raw_entries, list) else []
@@ -157,8 +155,8 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     `all_migrated`) alongside one `members` row per cohort member
     (`{peer, report?, state}`). This lifts the rollup counters to the top level
     (so `outputs:` can address them without an `all_migrated` envelope), answers
-    `all_migrated` from core's flag reconciled against the member rows, and
-    re-attaches a compact per-member list under `members` carrying each member's `state` plus
+    `all_migrated` from core's flag reconciled against the rows, and re-attaches a
+    compact per-member list under `members` carrying each member's `state` plus
     the `migration_failed` reason from its report (a stranded member surfaces as
     `state:"failed"`). Counter keys are coerced to ints with a 0 default so a
     missing/partial rollup degrades to an all-zero (never-complete) summary
@@ -174,35 +172,32 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     entirely (an explicit `0` cohort is preserved).
 
     `target_version`, `expected_members`, `fleet_completed_at` and
-    `cohort_pinned_at_hlc` are the top-level pass-throughs, and each is OMITTED
-    from the summary when the response omits it (`_drop_absent`) rather than
-    offered as `None`. `fleet_completed_at` is the durable answer to "did this
-    fleet ever converge": `all_migrated` is recomputed from in-TTL heartbeats
-    and lapses when a converged member goes quiet, while the timestamp does not
-    follow it back down. Absent must therefore stay distinguishable both from
-    `0` (so neither goes through `_as_int`) and from a null core did send, which
-    is what the omission buys — a capture of a field a pre-convergence node
-    never sent fails naming that field instead of binding `None`.
+    `cohort_pinned_at_hlc` are the top-level pass-throughs, each OMITTED when
+    the response omits it (`_drop_absent`) rather than offered as `None`.
+    `fleet_completed_at` is the durable answer to "did this fleet ever
+    converge": `all_migrated` is recomputed from in-TTL heartbeats and lapses
+    when a converged member goes quiet, while the timestamp does not follow it
+    back down. Absent must therefore stay distinct from `0` (so it skips
+    `_as_int`) and from a null core did send, which a capture cannot tell apart.
 
     Each member row carries its whole report (`schema_version`, `residue_auto`,
-    `synced_up_to_hlc`, `reported_at`, `authored_remaining`) passed through
-    raw, and omits the ones the report did not carry, on the same rule. A
-    member that has not reported at all therefore yields a row of `peer` and
-    `state` alone. `report.schemaVersion` is the ABI *state* version of the
-    bytes a member actually holds, which is the only member-level evidence that
-    a state migration ran; the app's own `schema_info` is a constant compiled
-    into the binary and answers the same string whether or not the state was
-    ever migrated.
+    `synced_up_to_hlc`, `reported_at`, `authored_remaining`) passed through raw,
+    omitting the ones the report did not carry, on the same rule: a member that
+    never reported yields a row of `peer` and `state` alone.
+    `report.schemaVersion` is the ABI *state* version of the bytes a member
+    actually holds, which is the only member-level evidence that a state
+    migration ran; the app's own `schema_info` is a constant compiled into the
+    binary and answers the same string whether or not the state was ever
+    migrated.
 
     The six `reported_*` / `residue_total` / `failure_reasons` aggregates are
     recomputed here from the raw member rows and NEVER read from `rollup`. That
     is the point of them: `rollup.allMigrated` is core's own answer to "did
     everyone converge", so asserting it against itself cannot falsify the
-    rollup arithmetic. Do not "simplify" them back into the rollup fields. They
-    are computed from the raw report values, so the omission above never enters
-    their arithmetic as a zero: `_opt_int` rejects the absence marker like any
-    non-int, and an absent `migrationFailed` is tested for explicitly so it
-    cannot stringify into `failure_reasons`.
+    rollup arithmetic. Do not "simplify" them back into the rollup fields. The
+    omission above never enters their arithmetic as a zero: `_opt_int` rejects
+    the absence marker like any non-int, and an absent `migrationFailed` is
+    tested for explicitly so it cannot stringify into `failure_reasons`.
 
     `reported_at_target` / `reported_below_target` are `None` when the response
     carries no `targetVersion` (a namespace with no upgrade record). Defaulting
@@ -242,10 +237,9 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         schema_version = report.get("schemaVersion", _MISSING)
         residue_auto = report.get("residueAuto", _MISSING)
         reason = report.get("migrationFailed", _MISSING)
-        # The aggregates below take these raw values, and `_MISSING` is not an
-        # int, so `_opt_int` rejects it the way it rejects any non-int: an
-        # unreported version lands in `reported_missing` rather than arriving as
-        # a zero that reads as at-target.
+        # `_MISSING` is not an int, so `_opt_int` rejects it like any non-int:
+        # an unreported version lands in `reported_missing` rather than in a
+        # zero that reads as at-target.
         version = _opt_int(schema_version)
         if version is not None:
             reported_versions.append(version)
@@ -299,8 +293,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
 
     return _drop_absent(
         {
-            # The four top-level pass-throughs: absent stays absent rather than
-            # becoming a 0 (`_as_int`) or a null. See the docstring.
+            # Absent stays absent, never a 0 (`_as_int`) or a null. See docstring.
             "target_version": source.get("targetVersion", _MISSING),
             "expected_members": source.get("expectedMembers", _MISSING),
             "fleet_completed_at": source.get("fleetCompletedAt", _MISSING),

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -225,6 +225,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     reported_versions: list[int] = []
     residue_total = 0
     failure_reasons: list[str] = []
+    stuck_members: list[str] = []
     for entry in member_entries:
         if not isinstance(entry, dict):
             continue
@@ -244,6 +245,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         if version is not None:
             reported_versions.append(version)
         residue_total += _opt_int(residue_auto) or 0
+        peer = entry.get("peer")
         if reason is not _MISSING and reason is not None:
             failure_reasons.append(str(reason))
             if peer is not None:
@@ -326,13 +328,7 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
             ),
             "residue_total": residue_total,
             "failure_reasons": sorted(failure_reasons),
-            # `.get`, not `[]`: a row omits the keys its node did not send.
-            "stuck_members": sorted(
-                str(member["peer"])
-                for member in members
-                if member.get("migration_failed") is not None
-                and member.get("peer") is not None
-            ),
+            "stuck_members": sorted(stuck_members),
             "members": members if isinstance(raw_members, list) else _MISSING,
         }
     )

--- a/merobox/commands/bootstrap/steps/group_upgrade.py
+++ b/merobox/commands/bootstrap/steps/group_upgrade.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from rich.markup import escape
 
-from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.bootstrap.steps.base import _MISSING, BaseStep
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
 from merobox.commands.utils import LOG_LEVEL_VERBOSE, console, vprint
@@ -79,6 +79,16 @@ def _client_py_below(min_version: tuple[int, int, int]) -> bool:
     return _CLIENT_PY_VERSION is not None and _CLIENT_PY_VERSION < min_version
 
 
+def _drop_absent(summary: dict[str, Any]) -> dict[str, Any]:
+    """Drop the `_MISSING`-marked keys, so a capture of one raises instead of binding.
+
+    A summary key is merobox's invention, so `.get()`-ing an absent response
+    field makes it always bindable; leaving it out routes it back through the
+    absent-key check `_export_custom_outputs` applies to a raw response.
+    """
+    return {key: value for key, value in summary.items() if value is not _MISSING}
+
+
 def _summarize_cascade_status(response: Any) -> dict[str, Any]:
     """Roll a `get_cascade_status` response up into per-status counts.
 
@@ -100,10 +110,14 @@ def _summarize_cascade_status(response: Any) -> dict[str, Any]:
     as an envelope to unwrap, which would hide the count fields from
     `outputs:`. Keeping the list under `groups` leaves the whole summary
     addressable.
+
+    `groups` mirrors core's `data`, so a response that carried no list at all
+    omits it rather than offering an empty one: the counters are honestly
+    derived from nothing, but `groups: []` would claim core answered with an
+    empty subtree.
     """
-    entries: list[Any] = []
-    if isinstance(response, dict) and isinstance(response.get("data"), list):
-        entries = response["data"]
+    raw_entries = response.get("data") if isinstance(response, dict) else None
+    entries: list[Any] = raw_entries if isinstance(raw_entries, list) else []
 
     completed = 0
     failed = 0
@@ -117,14 +131,16 @@ def _summarize_cascade_status(response: Any) -> dict[str, Any]:
             failed += 1
 
     total = len(entries)
-    return {
-        "total": total,
-        "completed": completed,
-        "failed": failed,
-        "pending": total - completed - failed,
-        "all_completed": total > 0 and completed == total,
-        "groups": entries,
-    }
+    return _drop_absent(
+        {
+            "total": total,
+            "completed": completed,
+            "failed": failed,
+            "pending": total - completed - failed,
+            "all_completed": total > 0 and completed == total,
+            "groups": entries if isinstance(raw_entries, list) else _MISSING,
+        }
+    )
 
 
 def _opt_int(value: Any) -> int | None:
@@ -140,9 +156,9 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     (`rollup`: migrated / in_progress / unknown / failed / total +
     `all_migrated`) alongside one `members` row per cohort member
     (`{peer, report?, state}`). This lifts the rollup counters to the top level
-    (so `outputs:` can address them without an `all_migrated` envelope), faithfully
-    passes through core's authoritative `all_migrated` flag, and re-attaches a
-    compact per-member list under `members` carrying each member's `state` plus
+    (so `outputs:` can address them without an `all_migrated` envelope), answers
+    `all_migrated` from core's flag reconciled against the member rows, and
+    re-attaches a compact per-member list under `members` carrying each member's `state` plus
     the `migration_failed` reason from its report (a stranded member surfaces as
     `state:"failed"`). Counter keys are coerced to ints with a 0 default so a
     missing/partial rollup degrades to an all-zero (never-complete) summary
@@ -157,40 +173,64 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
     `total` falls back to the member count only when the rollup omits it
     entirely (an explicit `0` cohort is preserved).
 
-    `fleet_completed_at` and `cohort_pinned_at_hlc` are the two top-level
-    optionals, passed through as `None` when the response omits them.
-    `fleet_completed_at` is the durable answer to "did this fleet ever
-    converge": `all_migrated` is recomputed from in-TTL heartbeats and lapses
-    when a converged member goes quiet, while the timestamp does not follow it
-    back down. Absent must therefore stay distinguishable from `0`, so neither
-    goes through `_as_int`.
+    `target_version`, `expected_members`, `fleet_completed_at` and
+    `cohort_pinned_at_hlc` are the top-level pass-throughs, and each is OMITTED
+    from the summary when the response omits it (`_drop_absent`) rather than
+    offered as `None`. `fleet_completed_at` is the durable answer to "did this
+    fleet ever converge": `all_migrated` is recomputed from in-TTL heartbeats
+    and lapses when a converged member goes quiet, while the timestamp does not
+    follow it back down. Absent must therefore stay distinguishable both from
+    `0` (so neither goes through `_as_int`) and from a null core did send, which
+    is what the omission buys — a capture of a field a pre-convergence node
+    never sent fails naming that field instead of binding `None`.
 
-    The `reported_*` / `residue_total` / `failure_reasons` / `stuck_members`
-    aggregates are recomputed from the raw member rows and NEVER read from
-    `rollup`: asserting core's own convergence answer against itself cannot
-    falsify it. Do not "simplify" them back into the rollup fields.
-    `report.schemaVersion` is the ABI *state* version a member actually holds,
-    the only member-level evidence a migration ran - the app's `schema_info` is
-    a constant compiled into the binary. A missing or non-integer version counts
-    as `reported_missing`, the direction that cannot manufacture a green result,
-    and the two target-relative counters stay `None` with no `targetVersion` so
-    a namespace that never migrated is not reported as fully at-target.
+    Each member row carries its whole report (`schema_version`, `residue_auto`,
+    `synced_up_to_hlc`, `reported_at`, `authored_remaining`) passed through
+    raw, and omits the ones the report did not carry, on the same rule. A
+    member that has not reported at all therefore yields a row of `peer` and
+    `state` alone. `report.schemaVersion` is the ABI *state* version of the
+    bytes a member actually holds, which is the only member-level evidence that
+    a state migration ran; the app's own `schema_info` is a constant compiled
+    into the binary and answers the same string whether or not the state was
+    ever migrated.
+
+    The six `reported_*` / `residue_total` / `failure_reasons` aggregates are
+    recomputed here from the raw member rows and NEVER read from `rollup`. That
+    is the point of them: `rollup.allMigrated` is core's own answer to "did
+    everyone converge", so asserting it against itself cannot falsify the
+    rollup arithmetic. Do not "simplify" them back into the rollup fields. They
+    are computed from the raw report values, so the omission above never enters
+    their arithmetic as a zero: `_opt_int` rejects the absence marker like any
+    non-int, and an absent `migrationFailed` is tested for explicitly so it
+    cannot stringify into `failure_reasons`.
+
+    `reported_at_target` / `reported_below_target` are `None` when the response
+    carries no `targetVersion` (a namespace with no upgrade record). Defaulting
+    the target to 0 would classify every member as at-target and hand back a
+    green summary for a namespace that never migrated. The other four
+    aggregates do not depend on the target and are always computed: a cohort
+    where nobody reported must surface as `reported_missing`, not as zeroes.
+    Together `reported_at_target`, `reported_below_target` and
+    `reported_missing` partition the member rows; a report whose
+    `schemaVersion` is missing or non-integer counts as missing, the direction
+    that cannot manufacture a green result.
 
     The summary is an allowlist, which silently drops anything core adds later.
+    `members` itself mirrors core's list and is omitted when the response
+    carried none, so an empty cohort stays distinct from an unanswered one.
     """
     source = response if isinstance(response, dict) else {}
     rollup = source.get("rollup")
     rollup = rollup if isinstance(rollup, dict) else {}
     raw_members = source.get("members")
-    raw_members = raw_members if isinstance(raw_members, list) else []
+    member_entries = raw_members if isinstance(raw_members, list) else []
 
     members: list[dict[str, Any]] = []
     member_states: Counter = Counter()
     reported_versions: list[int] = []
     residue_total = 0
     failure_reasons: list[str] = []
-    stuck_members: list[str] = []
-    for entry in raw_members:
+    for entry in member_entries:
         if not isinstance(entry, dict):
             continue
         report = entry.get("report")
@@ -199,27 +239,34 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         # Counted on a separator-free key: core spells the sibling rollup counter
         # `inProgress`, so matching only `in_progress` would skip reconciliation.
         member_states[state.replace("_", "").replace("-", "")] += 1
-        schema_version = _opt_int(report.get("schemaVersion"))
-        if schema_version is not None:
-            reported_versions.append(schema_version)
-        residue_total += _opt_int(report.get("residueAuto")) or 0
-        peer = entry.get("peer")
-        reason = report.get("migrationFailed")
-        if reason is not None:
+        schema_version = report.get("schemaVersion", _MISSING)
+        residue_auto = report.get("residueAuto", _MISSING)
+        reason = report.get("migrationFailed", _MISSING)
+        # The aggregates below take these raw values, and `_MISSING` is not an
+        # int, so `_opt_int` rejects it the way it rejects any non-int: an
+        # unreported version lands in `reported_missing` rather than arriving as
+        # a zero that reads as at-target.
+        version = _opt_int(schema_version)
+        if version is not None:
+            reported_versions.append(version)
+        residue_total += _opt_int(residue_auto) or 0
+        if reason is not _MISSING and reason is not None:
             failure_reasons.append(str(reason))
             if peer is not None:
                 stuck_members.append(str(peer))
         members.append(
-            {
-                "peer": peer,
-                "state": state,
-                "migration_failed": reason,
-                "schema_version": report.get("schemaVersion"),
-                "residue_auto": report.get("residueAuto"),
-                "synced_up_to_hlc": report.get("syncedUpToHlc"),
-                "reported_at": report.get("reportedAt"),
-                "authored_remaining": report.get("authoredRemaining"),
-            }
+            _drop_absent(
+                {
+                    "peer": entry.get("peer", _MISSING),
+                    "state": state,
+                    "migration_failed": reason,
+                    "schema_version": schema_version,
+                    "residue_auto": residue_auto,
+                    "synced_up_to_hlc": report.get("syncedUpToHlc", _MISSING),
+                    "reported_at": report.get("reportedAt", _MISSING),
+                    "authored_remaining": report.get("authoredRemaining", _MISSING),
+                }
+            )
         )
 
     def _as_int(value: Any) -> int:
@@ -250,42 +297,52 @@ def _summarize_migration_status(response: Any) -> dict[str, Any]:
         else sum(1 for v in reported_versions if v < target_version)
     )
 
-    return {
-        "target_version": source.get("targetVersion"),
-        "expected_members": source.get("expectedMembers"),
-        # Both are omitted from the response rather than sent null, and both
-        # have a meaningful zero, so they pass through untouched: coercing an
-        # absent key to 0 would claim the fleet converged at the epoch, and
-        # coercing it to a falsy default would lose the difference from a
-        # namespace that genuinely has not converged.
-        "fleet_completed_at": source.get("fleetCompletedAt"),
-        "cohort_pinned_at_hlc": source.get("cohortPinnedAtHlc"),
-        "total": total,
-        "migrated": _as_int(rollup.get("migrated")),
-        "in_progress": in_progress,
-        "unknown": unknown,
-        "failed": failed,
-        # Reconciled against every non-converged signal rather than trusted (see
-        # docstring). An empty/no-record response yields false either way.
-        "all_migrated": bool(rollup.get("allMigrated", False))
-        and not (failed or in_progress or unknown or members_unconverged),
-        "members_pending_signature": _as_int(rollup.get("membersPendingSignature")),
-        # Recomputed from the member rows, never from `rollup`. See docstring.
-        "reported_at_target": (
-            None if below_target is None else len(reported_versions) - below_target
-        ),
-        "reported_below_target": below_target,
-        "reported_missing": len(members) - len(reported_versions),
-        "min_reported_schema_version": (
-            min(reported_versions) if reported_versions else None
-        ),
-        "residue_total": residue_total,
-        "failure_reasons": sorted(failure_reasons),
-        # `failure_reasons` names WHAT went wrong; this names WHICH member is
-        # holding the fleet back. Sorted, member order is not promised.
-        "stuck_members": sorted(stuck_members),
-        "members": members,
-    }
+    return _drop_absent(
+        {
+            # The four top-level pass-throughs: absent stays absent rather than
+            # becoming a 0 (`_as_int`) or a null. See the docstring.
+            "target_version": source.get("targetVersion", _MISSING),
+            "expected_members": source.get("expectedMembers", _MISSING),
+            "fleet_completed_at": source.get("fleetCompletedAt", _MISSING),
+            "cohort_pinned_at_hlc": source.get("cohortPinnedAtHlc", _MISSING),
+            "total": total,
+            "migrated": _as_int(rollup.get("migrated")),
+            "in_progress": in_progress,
+            "unknown": unknown,
+            "failed": failed,
+            # `rollup.allMigrated` is core's own answer to "did everyone
+            # converge", so it is reconciled against every non-converged signal
+            # rather than trusted (see docstring). An empty/no-record response
+            # yields false either way.
+            "all_migrated": (
+                bool(rollup.get("allMigrated", False))
+                and failed == 0
+                and in_progress == 0
+                and unknown == 0
+                and members_unconverged == 0
+            ),
+            "members_pending_signature": _as_int(rollup.get("membersPendingSignature")),
+            # Recomputed from the member rows, never from `rollup`. See docstring.
+            "reported_at_target": (
+                None if below_target is None else len(reported_versions) - below_target
+            ),
+            "reported_below_target": below_target,
+            "reported_missing": len(members) - len(reported_versions),
+            "min_reported_schema_version": (
+                min(reported_versions) if reported_versions else None
+            ),
+            "residue_total": residue_total,
+            "failure_reasons": sorted(failure_reasons),
+            # `.get`, not `[]`: a row omits the keys its node did not send.
+            "stuck_members": sorted(
+                str(member["peer"])
+                for member in members
+                if member.get("migration_failed") is not None
+                and member.get("peer") is not None
+            ),
+            "members": members if isinstance(raw_members, list) else _MISSING,
+        }
+    )
 
 
 class RegisterGroupSigningKeyStep(BaseStep):

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -22,7 +22,7 @@ from typing import Any
 import aiohttp
 from rich.markup import escape
 
-from merobox.commands.bootstrap.steps.base import _MISSING, BaseStep
+from merobox.commands.bootstrap.steps.base import _MISSING, BaseStep, lookup
 from merobox.commands.constants import DEFAULT_CONNECTION_TIMEOUT
 from merobox.commands.errors import UnresolvedPlaceholderError
 from merobox.commands.utils import console
@@ -535,7 +535,7 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
         for path, expected in match_spec.items():
             # Absent and present-and-null are different answers: without the
             # sentinel `match: {x: null}` is satisfied by a frame lacking x.
-            actual = self._get_value(frame, path, default=_MISSING)
+            actual = lookup(frame, path)
             if actual is _MISSING:
                 failures.append(f"{path}: expected {expected!r}, but the key is absent")
             elif actual != expected:

--- a/merobox/commands/bootstrap/steps/websocket.py
+++ b/merobox/commands/bootstrap/steps/websocket.py
@@ -526,7 +526,11 @@ class WebSocketEventAssertStep(_WebSocketStepBase):
     def _match_failures(
         self, frame: dict[str, Any], match_spec: dict[str, Any]
     ) -> list[str]:
-        """Per-path mismatches; empty means the frame satisfies ``match``."""
+        """Per-path mismatches; empty means the frame satisfies ``match``.
+
+        ``lookup``, not ``_get_value``: an absent path is not null, and a node's
+        literal ``"null"`` string must not be re-parsed into one.
+        """
         failures = []
         for path, expected in match_spec.items():
             # Absent and present-and-null are different answers: without the

--- a/merobox/tests/unit/test_cascade_status_steps.py
+++ b/merobox/tests/unit/test_cascade_status_steps.py
@@ -111,6 +111,15 @@ class TestSummarizeCascadeStatus:
         assert s["groups"] == resp["data"]
         assert "data" not in s
 
+    def test_an_empty_subtree_still_offers_an_empty_groups_list(self):
+        assert _summarize_cascade_status(_resp([]))["groups"] == []
+
+    def test_groups_is_omitted_when_the_response_carried_no_list(self):
+        # `groups: []` would claim core answered with an empty subtree, and a
+        # capture of it would bind rather than fail.
+        for bad in (None, {}, {"data": "nope"}, {"error": "boom"}):
+            assert "groups" not in _summarize_cascade_status(bad)
+
 
 # =============================================================================
 # GetCascadeStatusStep — validation

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -99,15 +99,16 @@ class TestSummarizeMigrationStatus:
         assert s["total"] == 1  # falls back to len(members)
         assert s["migrated"] == 0
         assert s["all_migrated"] is False
-        assert s["members"][0]["migration_failed"] is None
+        assert "migration_failed" not in s["members"][0]
 
     def test_garbage_response_is_empty_summary(self):
         s = _summarize_migration_status("not-a-dict")
         assert s["total"] == 0
         assert s["all_migrated"] is False
-        assert s["members"] == []
-        assert s["fleet_completed_at"] is None
-        assert s["cohort_pinned_at_hlc"] is None
+        # The counters degrade; the pass-throughs are absent rather than null.
+        assert "members" not in s
+        assert "fleet_completed_at" not in s
+        assert "cohort_pinned_at_hlc" not in s
 
     def test_fleet_completed_at_is_surfaced(self):
         # The durable evidence that convergence happened, which allMigrated
@@ -134,12 +135,13 @@ class TestSummarizeMigrationStatus:
         assert s["all_migrated"] is False
         assert s["fleet_completed_at"] == 1_700_002_000
 
-    def test_an_unconverged_namespace_reports_none_not_zero(self):
-        # Core omits the key entirely rather than sending 0, and 0 is a valid
-        # unix timestamp, so absent must not collapse into it.
+    def test_an_unconverged_namespace_omits_the_key_entirely(self):
+        # Core omits the key rather than sending 0, and 0 is a valid unix
+        # timestamp, so absent must not collapse into it — nor into a null,
+        # which a capture would happily bind.
         s = _summarize_migration_status({"rollup": _rollup(total=2)})
-        assert s["fleet_completed_at"] is None
-        assert s["cohort_pinned_at_hlc"] is None
+        assert "fleet_completed_at" not in s
+        assert "cohort_pinned_at_hlc" not in s
 
     def test_a_zero_fleet_timestamp_is_preserved(self):
         s = _summarize_migration_status(
@@ -376,7 +378,7 @@ class TestReportedSchemaVersions:
         assert s["reported_missing"] == 1
         assert s["reported_below_target"] == 0
         assert s["reported_at_target"] == 1
-        assert s["members"][1]["schema_version"] is None
+        assert "schema_version" not in s["members"][1]
 
     def test_absent_target_leaves_the_target_relative_counters_none(self):
         # Defaulting the target to 0 would classify every member as at-target
@@ -463,6 +465,82 @@ class TestReportedSchemaVersions:
             }
         )
         assert s["stuck_members"] == ["peerA", "peerB"]
+
+
+class TestAbsentReportFieldsStayOutOfTheAggregates:
+    """A report field core did not send must not reach a counter as a zero.
+
+    The aggregates are the only member-level evidence that can falsify the
+    rollup, so an unreported field arriving as 0 would put the false green back
+    in the one place there is nothing left to cross-check it against.
+    """
+
+    def test_an_unreported_version_is_missing_not_a_zero_at_target(self):
+        # A target of 0 is the sharp case: a version coerced to 0 would count a
+        # silent member as at-target and empty out `reported_missing`.
+        s = _summarize_migration_status(
+            {"targetVersion": 0, "members": [{"peer": "a", "state": "unknown"}]}
+        )
+        assert s["reported_missing"] == 1
+        assert s["reported_at_target"] == 0
+        assert s["reported_below_target"] == 0
+        assert s["min_reported_schema_version"] is None
+
+    def test_an_unreported_residue_leaves_the_total_to_those_that_did_report(self):
+        s = _summarize_migration_status(
+            {
+                "members": [
+                    _member("a", schemaVersion=2, residueAuto=3),
+                    {"peer": "b", "state": "unknown"},
+                ]
+            }
+        )
+        assert s["residue_total"] == 3
+        # `residue_total` alone cannot tell a drained cohort from a silent one;
+        # `reported_missing` is the companion signal that can, which is why a
+        # workflow asserting the drain has to assert both.
+        assert s["reported_missing"] == 1
+
+    def test_an_absent_failure_reason_is_not_stringified(self):
+        # The absence marker is not None, so an `is not None` guard alone would
+        # push its repr into the list and make failure_reasons unassertable.
+        s = _summarize_migration_status(
+            {
+                "members": [
+                    _member("a", schemaVersion=2),
+                    {"peer": "b", "state": "unknown"},
+                ]
+            }
+        )
+        assert s["failure_reasons"] == []
+
+    def test_a_null_report_field_is_kept_and_still_counts_as_missing(self):
+        # Present-and-null is core's answer, so the row keeps it; it is still
+        # not a usable state version.
+        s = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "members": [
+                    {
+                        "peer": "a",
+                        "state": "unknown",
+                        "report": {"schemaVersion": None, "migrationFailed": None},
+                    }
+                ],
+            }
+        )
+        row = s["members"][0]
+        assert row["schema_version"] is None
+        assert row["migration_failed"] is None
+        assert s["reported_missing"] == 1
+        assert s["failure_reasons"] == []
+
+    def test_an_empty_cohort_stays_distinct_from_an_unanswered_one(self):
+        assert (
+            _summarize_migration_status({"members": [], "rollup": _rollup()})["members"]
+            == []
+        )
+        assert "members" not in _summarize_migration_status({"rollup": _rollup()})
 
 
 # =============================================================================

--- a/merobox/tests/unit/test_migrations_v2_steps.py
+++ b/merobox/tests/unit/test_migrations_v2_steps.py
@@ -137,8 +137,8 @@ class TestSummarizeMigrationStatus:
 
     def test_an_unconverged_namespace_omits_the_key_entirely(self):
         # Core omits the key rather than sending 0, and 0 is a valid unix
-        # timestamp, so absent must not collapse into it — nor into a null,
-        # which a capture would happily bind.
+        # timestamp, so absent must not collapse into it, nor into a null that
+        # a capture would happily bind.
         s = _summarize_migration_status({"rollup": _rollup(total=2)})
         assert "fleet_completed_at" not in s
         assert "cohort_pinned_at_hlc" not in s
@@ -471,8 +471,8 @@ class TestAbsentReportFieldsStayOutOfTheAggregates:
     """A report field core did not send must not reach a counter as a zero.
 
     The aggregates are the only member-level evidence that can falsify the
-    rollup, so an unreported field arriving as 0 would put the false green back
-    in the one place there is nothing left to cross-check it against.
+    rollup, so a 0 standing in for an unreported field puts the false green
+    back where nothing is left to cross-check it against.
     """
 
     def test_an_unreported_version_is_missing_not_a_zero_at_target(self):
@@ -496,9 +496,8 @@ class TestAbsentReportFieldsStayOutOfTheAggregates:
             }
         )
         assert s["residue_total"] == 3
-        # `residue_total` alone cannot tell a drained cohort from a silent one;
-        # `reported_missing` is the companion signal that can, which is why a
-        # workflow asserting the drain has to assert both.
+        # `residue_total` alone cannot tell a drained cohort from a silent one,
+        # so a workflow asserting the drain has to assert both.
         assert s["reported_missing"] == 1
 
     def test_an_absent_failure_reason_is_not_stringified(self):

--- a/merobox/tests/unit/test_output_capture_strictness.py
+++ b/merobox/tests/unit/test_output_capture_strictness.py
@@ -14,6 +14,10 @@ import pytest
 from merobox.commands.bootstrap.steps.assertion import AssertStep
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.bootstrap.steps.execute import ExecuteStep
+from merobox.commands.bootstrap.steps.group_upgrade import (
+    _summarize_cascade_status,
+    _summarize_migration_status,
+)
 from merobox.commands.bootstrap.steps.json_assertion import JsonAssertStep
 from merobox.commands.errors import OutputCaptureError, UnresolvedPlaceholderError
 
@@ -134,6 +138,69 @@ class TestMissingCaptureFails:
         bound = _export({"r": "result", "t": "error_type"}, error_info)
         assert bound == {"t": "FunctionCallError"}
 
+
+class TestSummarizedResponseCapture:
+    """A step that exports its own dict, not the raw response, gets the same check.
+
+    The migration-status steps flatten the response first, so `.get()`-ing a
+    field core omitted put the key in the exported dict anyway: the capture bound
+    `None`, indistinguishable from a null core sent, and the check above had
+    nothing to raise about. The summarizers now omit what core did not send.
+    """
+
+    def test_capturing_fleet_completed_at_from_a_response_without_it_fails(self):
+        # The incident in the module docstring, end to end through the
+        # summarizer that made the fix above inert for it.
+        summary = _summarize_migration_status({"rollup": {"total": 2, "migrated": 0}})
+        with pytest.raises(OutputCaptureError, match="fleet_completed_at"):
+            _export({"fleet_completed_at": "fleet_completed_at"}, summary)
+
+    def test_the_failure_names_the_fields_the_response_did_carry(self):
+        summary = _summarize_migration_status({"rollup": {"total": 1}})
+        with pytest.raises(OutputCaptureError, match="all_migrated, failed"):
+            _export({"t": "cohort_pinned_at_hlc"}, summary)
+
+    def test_a_timestamp_core_sent_as_null_still_binds(self):
+        summary = _summarize_migration_status(
+            {"fleetCompletedAt": None, "rollup": {"total": 1}}
+        )
+        assert _export({"t": "fleet_completed_at"}, summary) == {"t": None}
+
+    def test_a_zero_timestamp_still_binds(self):
+        summary = _summarize_migration_status(
+            {"fleetCompletedAt": 0, "rollup": {"total": 1}}
+        )
+        assert _export({"t": "fleet_completed_at"}, summary) == {"t": 0}
+
+    def test_capturing_an_unreported_member_field_fails(self):
+        summary = _summarize_migration_status(
+            {"targetVersion": 2, "members": [{"peer": "a", "state": "unknown"}]}
+        )
+        with pytest.raises(OutputCaptureError, match="members.0.schema_version"):
+            _export({"v": "members.0.schema_version"}, summary)
+
+    def test_a_reported_member_field_still_binds(self):
+        summary = _summarize_migration_status(
+            {
+                "targetVersion": 2,
+                "members": [
+                    {"peer": "a", "state": "migrated", "report": {"schemaVersion": 2}}
+                ],
+            }
+        )
+        assert _export({"v": "members.0.schema_version"}, summary) == {"v": 2}
+
+    def test_capturing_cascade_groups_fails_when_core_sent_no_list(self):
+        with pytest.raises(OutputCaptureError, match="groups"):
+            _export({"g": "groups"}, _summarize_cascade_status({"error": "boom"}))
+
+    def test_an_empty_cascade_subtree_still_binds_an_empty_list(self):
+        assert _export({"g": "groups"}, _summarize_cascade_status({"data": []})) == {
+            "g": []
+        }
+
+
+class TestErrorPayloadCaptureContract:
     def test_every_documented_error_field_is_capturable(self):
         # A capture that binds for a JSON-RPC error but not a connection refusal
         # is unwritable, so all four fields are present, null where unknown.

--- a/merobox/tests/unit/test_output_capture_strictness.py
+++ b/merobox/tests/unit/test_output_capture_strictness.py
@@ -143,34 +143,20 @@ class TestSummarizedResponseCapture:
     """A step that exports its own dict, not the raw response, gets the same check.
 
     The migration-status steps flatten the response first, so `.get()`-ing a
-    field core omitted put the key in the exported dict anyway: the capture bound
-    `None`, indistinguishable from a null core sent, and the check above had
-    nothing to raise about. The summarizers now omit what core did not send.
+    field core omitted put the key in the exported dict anyway and the capture
+    bound `None`, which made the check above inert for them.
     """
 
     def test_capturing_fleet_completed_at_from_a_response_without_it_fails(self):
-        # The incident in the module docstring, end to end through the
-        # summarizer that made the fix above inert for it.
         summary = _summarize_migration_status({"rollup": {"total": 2, "migrated": 0}})
         with pytest.raises(OutputCaptureError, match="fleet_completed_at"):
             _export({"fleet_completed_at": "fleet_completed_at"}, summary)
-
-    def test_the_failure_names_the_fields_the_response_did_carry(self):
-        summary = _summarize_migration_status({"rollup": {"total": 1}})
-        with pytest.raises(OutputCaptureError, match="all_migrated, failed"):
-            _export({"t": "cohort_pinned_at_hlc"}, summary)
 
     def test_a_timestamp_core_sent_as_null_still_binds(self):
         summary = _summarize_migration_status(
             {"fleetCompletedAt": None, "rollup": {"total": 1}}
         )
         assert _export({"t": "fleet_completed_at"}, summary) == {"t": None}
-
-    def test_a_zero_timestamp_still_binds(self):
-        summary = _summarize_migration_status(
-            {"fleetCompletedAt": 0, "rollup": {"total": 1}}
-        )
-        assert _export({"t": "fleet_completed_at"}, summary) == {"t": 0}
 
     def test_capturing_an_unreported_member_field_fails(self):
         summary = _summarize_migration_status(

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -262,22 +262,9 @@ class TestPositiveAssertion:
         # The frame is compared verbatim: a field whose value is the string
         # "null" must not be coerced into the null that `match: {p: null}`
         # asserts, which would undo the absent-versus-null distinction above.
-        frame = _event("MigrationCompleted", {"toVersion": "2.0.0", "hlc": "null"})
         result, _ = _execute(
             _step(event="MigrationCompleted", match={"data.hlc": None}),
-            [_ack(), frame],
-        )
-        assert result is False
-        result, _ = _execute(
-            _step(event="MigrationCompleted", match={"data.hlc": "null"}),
             [_ack(), _event("MigrationCompleted", {"hlc": "null"})],
-        )
-        assert result is True
-
-    def test_a_numeric_string_is_not_coerced_to_a_number(self):
-        result, _ = _execute(
-            _step(event="MigrationCompleted", match={"data.hlc": 42}),
-            [_ack(), _event("MigrationCompleted", {"hlc": "42"})],
         )
         assert result is False
 

--- a/merobox/tests/unit/test_ws_event_assertion.py
+++ b/merobox/tests/unit/test_ws_event_assertion.py
@@ -258,6 +258,29 @@ class TestPositiveAssertion:
         )
         assert result is True
 
+    def test_a_string_that_looks_like_a_literal_is_compared_as_a_string(self):
+        # The frame is compared verbatim: a field whose value is the string
+        # "null" must not be coerced into the null that `match: {p: null}`
+        # asserts, which would undo the absent-versus-null distinction above.
+        frame = _event("MigrationCompleted", {"toVersion": "2.0.0", "hlc": "null"})
+        result, _ = _execute(
+            _step(event="MigrationCompleted", match={"data.hlc": None}),
+            [_ack(), frame],
+        )
+        assert result is False
+        result, _ = _execute(
+            _step(event="MigrationCompleted", match={"data.hlc": "null"}),
+            [_ack(), _event("MigrationCompleted", {"hlc": "null"})],
+        )
+        assert result is True
+
+    def test_a_numeric_string_is_not_coerced_to_a_number(self):
+        result, _ = _execute(
+            _step(event="MigrationCompleted", match={"data.hlc": 42}),
+            [_ack(), _event("MigrationCompleted", {"hlc": "42"})],
+        )
+        assert result is False
+
     def test_matching_is_a_subset_so_unlisted_fields_are_ignored(self):
         # Only toStateVersion is asserted; the frame carries three more fields.
         step = _step(match={"data.toStateVersion": 2})


### PR DESCRIPTION
Stacks on #328 — branched from `fix/fail-on-missing-output-capture`, so this diff includes that PR's commits until it merges. Review the top commit only.

## Summary

#328 made an `outputs:` capture that cannot bind raise instead of warn, but it only protects steps that export the raw response. The migration-status steps do not: `_summarize_migration_status` builds its own flat dict, so `source.get("fleetCompletedAt")` put the key there whatever the node answered. A field the node never sent bound `None`, indistinguishable from a null it did send, and the capture machinery had nothing left to raise about. `fleetCompletedAt` is absent from calimero-client-py 0.6.24's deserialized dict, so the one capture in core's suite that reads it is exactly this case — and the check written to catch it was inert on it.

That matters more than one workflow, because converting the suite's log assertions into rollup-field assertions makes every one of them run through this surface.

Both summarizers now mark an absent response field with the same `_MISSING` sentinel the capture path compares against, and `_drop_absent` removes those keys before returning. Capturing one fails naming the field and listing what the response did carry; a field the node sends as `null` still binds, as does a zero timestamp. The rule covers `target_version`, `expected_members`, `fleet_completed_at`, `cohort_pinned_at_hlc`, every per-member report field, and the `members` / `groups` lists themselves, so an empty cohort stays distinct from a node that answered with nothing.

**Keeping the recomputed aggregates honest.** `reported_at_target`, `reported_below_target`, `reported_missing`, `min_reported_schema_version`, `residue_total` and `failure_reasons` are the only member-level evidence that can falsify core's rollup, so the marker must never reach them as a zero. They keep reading the raw report values: `_opt_int` rejects the marker the way it rejects any non-int, so an unreported version lands in `reported_missing` rather than at target, and the `migrationFailed` collection tests for the marker explicitly rather than for `None` — an `is not None` guard alone would have stringified its repr into `failure_reasons`. Only `_MISSING` is ever dropped and never `None`, so the counters that are `None` because merobox could not compute them stay present; the assert poll loop reads `reported_below_target` unconditionally.

Unchanged from earlier passes: the `total_raw is not None` fallback, the `failed` max-reconciliation against member states, no `_as_int` on the optional timestamps, and #328's deliberate leniency on error payloads.

## Test plan

`make format-check` clean; `pytest merobox/tests/unit` 1315 passed, up from 1300 on #328's branch. No Docker.

Each new test proven a gate by breaking the behaviour and watching it fail:

| Break | Caught by |
| --- | --- |
| `_drop_absent` binds `None` instead of dropping (the pre-fix behaviour) | 10 failures, incl. `test_capturing_fleet_completed_at_from_a_response_without_it_fails` — the reported case |
| The marker becomes a zero version (`_opt_int(...) or 0`) | `test_an_unreported_version_is_missing_not_a_zero_at_target` and 3 more; a silent member counted as at-target against a target of 0 |
| `migrationFailed` guarded on `is not None` alone | `test_an_absent_failure_reason_is_not_stringified` — `failure_reasons == ['<object object at 0x...>']` |
| `_drop_absent` also drops `None` (over-eager) | `test_a_timestamp_core_sent_as_null_still_binds`, plus 5 `assert_migration_complete` execute tests that read the computed `None`s |
| Cascade always omits `groups` | `test_an_empty_cascade_subtree_still_binds_an_empty_list` |

Four existing tests asserted the old shape (`... is None`) and now assert absence.