### PR TITLE
fix(workflows): name group members by account, not by signing key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,15 @@ jobs:
           # steps need a merod carrying `merod account export|import`
           # (calimero-network/core#3362, unmerged). Re-add to the docker matrix
           # once merod:edge carries those commands; binary mode can never run it.
+          # group-admin, group-metadata and set-member-auto-follow name members by
+          # ACCOUNT (64 hex), which merod now requires on every member-addressing
+          # endpoint. A released merod still names them by bs58 signing key and
+          # returns no account at all, so `memberAccount` / `account` capture
+          # nothing and the first member step is handed an unresolved
+          # placeholder. The two ids are unrelated values, so no single spelling
+          # satisfies both lanes; docker mode (merod:edge) keeps full coverage.
+          # Re-add here once a core release carries the account rename —
+          # 0.11.0-rc.20 and the pending rc.21 both predate it.
           BINARY=$(ls workflow-examples/*.yml | \
             grep -v account-identity | \
             grep -v fuzzy-kv-store | \
@@ -133,6 +142,9 @@ jobs:
             grep -v nat-topology | \
             grep -v cascade-namespace | \
             grep -v blob-cross-node-download | \
+            grep -v group-admin-example | \
+            grep -v group-metadata-example | \
+            grep -v set-member-auto-follow | \
             grep -v '/tee-' | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";"") | sub("^workflow-";""))})')
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
@@ -160,6 +172,12 @@ jobs:
           # against a merod built with --features mock-attestation (built by the
           # build-merod-mock job); the release binary and merod:edge are both
           # default-off (core#3269) and hard-error on `merod run --mock-tee`.
+          # build-merod-mock builds from the latest core RELEASE tag, so these
+          # still name members by signing key and are correct as written. They
+          # flip to accounts in the same move that re-adds the three workflows
+          # excluded from BINARY above: remove_group_members takes accounts, and
+          # assert_tee_member / assert_not_member match against a member list
+          # that becomes accounts.
           TEE=$(ls workflow-examples/tee-*.yml | \
             jq -R -s -c 'split("\n") | map(select(length > 0)) | map({file: ., name: (split("/")[-1] | sub("\\.yml$";""))})')
           echo "tee=$TEE" >> $GITHUB_OUTPUT

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -358,7 +358,12 @@ Join a namespace using an invitation. Deprecated alias: `join_group`.
   invitation: '{{invitation}}'
   outputs:
     member_identity: memberIdentity
+    member_account: memberAccount
 ```
+
+`memberIdentity` is the bs58 key the node signs with; `memberAccount` is the
+64-hex account governance rows are keyed by. They are different values and are
+not interchangeable — see [Naming a member](#naming-a-member).
 
 ### create_group_in_namespace
 
@@ -421,6 +426,17 @@ Read-only lookups. Each takes `node` plus the id shown.
 
 ## Membership & capabilities steps
 
+### Naming a member
+
+A node has two ids in a namespace and they are not interchangeable.
+Its **signing key** is bs58; its **account** is 64 hex characters, and that is the principal governance rows are keyed by.
+The encodings differ on purpose, so passing one where the other belongs is a `400` rather than a silent no-op.
+
+Read them from `join_namespace` (`memberIdentity` / `memberAccount`) or `get_namespace_identity` (`publicKey` / `account`).
+
+Use the **account** for `member_id` on every member-addressing step, and for `remove_group_members`.
+Use the **key** for `add_group_members`' `identity` and for any `requester` field.
+
 ### add_group_members
 
 Add members with roles to a group.
@@ -429,7 +445,7 @@ Add members with roles to a group.
 | --- | --- | --- | --- |
 | `node` | yes | string | Target node. |
 | `group_id` | yes | string | Group to add to. |
-| `members` | yes | list of `{identity, role}` | Members and their roles. |
+| `members` | yes | list of `{identity, role}` | Members and their roles. `identity` is a signing key, not an account. |
 
 ```yaml
 - type: add_group_members
@@ -442,14 +458,14 @@ Add members with roles to a group.
 
 ### remove_group_members
 
-Remove members. Fields: `node`, `group_id`, `members` (list of public keys).
+Remove members. Fields: `node`, `group_id`, `members` (list of accounts).
 
 ```yaml
 - type: remove_group_members
   node: calimero-node-1
   group_id: '{{group_id}}'
   members:
-    - '{{member_pub}}'
+    - '{{member_account}}'
 ```
 
 ### update_member_role
@@ -461,7 +477,7 @@ Change a member's role. Fields: `node`, `group_id`, `member_id`, `role`
 - type: update_member_role
   node: calimero-node-1
   group_id: '{{group_id}}'
-  member_id: '{{member_pub}}'
+  member_id: '{{member_account}}'
   role: Admin
 ```
 
@@ -474,7 +490,7 @@ Set a member's capability bitmask. Fields: `node`, `group_id`, `member_id`,
 - type: set_member_capabilities
   node: calimero-node-1
   group_id: '{{group_id}}'
-  member_id: '{{member_pub}}'
+  member_id: '{{member_account}}'
   capabilities: 7
 ```
 
@@ -498,7 +514,7 @@ Toggle a member's auto-follow flags for new contexts and nested subgroups.
 | --- | --- | --- | --- |
 | `node` | yes | string | Target node. |
 | `group_id` | yes | string | Group. |
-| `member_id` | yes | string | Target member public key. |
+| `member_id` | yes | string | Target member account (64 hex). |
 | `auto_follow_contexts` | yes | bool | Auto-join new contexts in this group. |
 | `auto_follow_subgroups` | yes | bool | Self-admit into nested subgroups. |
 | `requester` | no | string | Admin or self public key to act as. |
@@ -507,7 +523,7 @@ Toggle a member's auto-follow flags for new contexts and nested subgroups.
 - type: set_member_auto_follow
   node: calimero-node-1
   group_id: '{{group_id}}'
-  member_id: '{{member_pub}}'
+  member_id: '{{member_account}}'
   auto_follow_contexts: true
   auto_follow_subgroups: false
 ```

--- a/merobox/commands/bootstrap/steps/group_join.py
+++ b/merobox/commands/bootstrap/steps/group_join.py
@@ -44,6 +44,14 @@ class JoinNamespaceStep(BaseStep):
                 "namespace_member_identity_{node_name}",
                 "Member identity public key after joining",
             ),
+            # Member-addressing endpoints take this, not the key: governance rows
+            # are keyed by account, and the two encodings deliberately differ so
+            # one cannot be passed where the other belongs.
+            (
+                "memberAccount",
+                "namespace_member_account_{node_name}",
+                "Account the joining key speaks for (64 hex characters)",
+            ),
         ]
 
     def _auto_install_app_on_node(

--- a/merobox/commands/bootstrap/steps/join.py
+++ b/merobox/commands/bootstrap/steps/join.py
@@ -36,6 +36,7 @@ class JoinNamespaceStep(BaseStep):
         Available variables from join_namespace API response:
         - namespaceId: ID of the namespace joined
         - memberIdentity: Member identity public key after joining
+        - memberAccount: Account that key joined as
         """
         return [
             (
@@ -47,6 +48,14 @@ class JoinNamespaceStep(BaseStep):
                 "memberIdentity",
                 "join_member_identity_{node_name}",
                 "Member identity after joining the namespace",
+            ),
+            # Member-addressing endpoints take this, not the key: governance rows
+            # are keyed by account, and the two encodings deliberately differ so
+            # one cannot be passed where the other belongs.
+            (
+                "memberAccount",
+                "join_member_account_{node_name}",
+                "Account the joining key speaks for (64 hex characters)",
             ),
         ]
 

--- a/merobox/commands/bootstrap/steps/namespace.py
+++ b/merobox/commands/bootstrap/steps/namespace.py
@@ -78,6 +78,13 @@ class GetNamespaceIdentityStep(BaseStep):
                 "namespace_public_key_{node_name}",
                 "Namespace-scoped public key for this node (group admin)",
             ),
+            # What names this node as a *member*. `publicKey` still signs, so a
+            # step that both targets and signs for this node needs both.
+            (
+                "account",
+                "namespace_account_{node_name}",
+                "Account this node writes as in the namespace (64 hex characters)",
+            ),
             (
                 "namespaceId",
                 "namespace_id_echo_{node_name}",

--- a/workflow-examples/workflow-group-admin-example.yml
+++ b/workflow-examples/workflow-group-admin-example.yml
@@ -51,6 +51,9 @@ steps:
     type: wait
     seconds: 5
 
+  # Two ids, and they are not interchangeable. `memberIdentity` is the bs58 key
+  # node 2 signs with; `memberAccount` is the 64-hex account governance rows are
+  # keyed by. Adding a member names the key, everything after names the account.
   - name: Node 2 Joins Namespace
     type: join_namespace
     node: calimero-node-2
@@ -58,6 +61,7 @@ steps:
     invitation: '{{invitation}}'
     outputs:
       p2_identity: memberIdentity
+      p2_account: memberAccount
 
   - name: Create Subgroup
     type: create_group_in_namespace
@@ -129,19 +133,19 @@ steps:
       group_meta: data
 
   # Setting member metadata from node 2: the requester defaults to node 2's
-  # own namespace identity and targets its own p2_identity.
+  # own namespace identity and targets its own account.
   - name: Set Member Metadata (from node 2)
     type: set_member_metadata
     node: calimero-node-2
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     record_name: 'Bob'
 
   - name: Read Member Metadata
     type: get_member_metadata
     node: calimero-node-2
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
 
   # Phase 3: Default policy
   - name: Set Default Capabilities (create context + invite)
@@ -161,20 +165,20 @@ steps:
     type: get_member_capabilities
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
 
   - name: Grant Node 2 Full Manage Capabilities
     type: set_member_capabilities
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     capabilities: 15
 
   - name: Promote Node 2 to Admin
     type: update_member_role
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     role: Admin
 
   - name: List Members After Role Change
@@ -217,7 +221,7 @@ steps:
     node: calimero-node-1
     group_id: '{{group_id}}'
     members:
-      - '{{p2_identity}}'
+      - '{{p2_account}}'
 
   - name: List Members After Removal
     type: list_group_members

--- a/workflow-examples/workflow-group-metadata-example.yml
+++ b/workflow-examples/workflow-group-metadata-example.yml
@@ -102,6 +102,9 @@ steps:
     type: wait
     seconds: 5
 
+  # `memberIdentity` is the bs58 key node 2 signs with, `memberAccount` the
+  # 64-hex account governance rows are keyed by. add_group_members names the
+  # key; every member-addressing endpoint below names the account.
   - name: Node 2 Joins Namespace
     type: join_namespace
     node: calimero-node-2
@@ -109,6 +112,7 @@ steps:
     invitation: '{{invitation}}'
     outputs:
       node2_id: memberIdentity
+      node2_account: memberAccount
 
   - name: Assert Node 2 Joined
     type: assert
@@ -216,7 +220,7 @@ steps:
     type: set_member_capabilities
     node: calimero-node-1
     group_id: '{{sub}}'
-    member_id: '{{node2_id}}'
+    member_id: '{{node2_account}}'
     # CAN_MANAGE_METADATA = 1 << 8 = 256
     # (calimero-network/core: crates/context/config/src/lib.rs,
     #  MemberCapabilities::CAN_MANAGE_METADATA)
@@ -274,7 +278,7 @@ steps:
     type: set_member_metadata
     node: calimero-node-2
     group_id: '{{ns}}'
-    member_id: '{{node2_id}}'
+    member_id: '{{node2_account}}'
     record_name: 'node-two'
     data:
       status: online
@@ -297,7 +301,7 @@ steps:
     type: get_member_metadata
     node: calimero-node-1
     group_id: '{{ns}}'
-    member_id: '{{node2_id}}'
+    member_id: '{{node2_account}}'
     outputs:
       m2_name: name
       m2_status: data.status

--- a/workflow-examples/workflow-set-member-auto-follow-example.yml
+++ b/workflow-examples/workflow-set-member-auto-follow-example.yml
@@ -38,12 +38,16 @@ steps:
     outputs:
       namespace_id: namespaceId
 
+  # Both halves of node 1's identity: `account` names the member being changed,
+  # `publicKey` signs for the change. `requester` stayed a key when the member
+  # path moved to accounts, so the self-set step below needs one of each.
   - name: Get Node 1 Namespace Identity
     type: get_namespace_identity
     node: calimero-node-1
     namespace_id: '{{namespace_id}}'
     outputs:
       p1_admin_key: publicKey
+      p1_admin_account: account
 
   - name: Create Namespace Invitation
     type: create_namespace_invitation
@@ -63,6 +67,7 @@ steps:
     invitation: '{{invitation}}'
     outputs:
       p2_identity: memberIdentity
+      p2_account: memberAccount
 
   - name: Create Subgroup
     type: create_group_in_namespace
@@ -92,7 +97,7 @@ steps:
     type: set_member_auto_follow
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     auto_follow_contexts: true
     auto_follow_subgroups: false
 
@@ -105,7 +110,7 @@ steps:
     type: set_member_auto_follow
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     auto_follow_contexts: false
     auto_follow_subgroups: true
 
@@ -118,7 +123,7 @@ steps:
     type: set_member_auto_follow
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     auto_follow_contexts: true
     auto_follow_subgroups: true
 
@@ -134,7 +139,7 @@ steps:
     type: set_member_auto_follow
     node: calimero-node-2
     group_id: '{{group_id}}'
-    member_id: '{{p2_identity}}'
+    member_id: '{{p2_account}}'
     auto_follow_contexts: false
     auto_follow_subgroups: false
     requester: '{{p2_identity}}'
@@ -150,7 +155,7 @@ steps:
     type: set_member_auto_follow
     node: calimero-node-1
     group_id: '{{group_id}}'
-    member_id: '{{p1_admin_key}}'
+    member_id: '{{p1_admin_account}}'
     auto_follow_contexts: true
     auto_follow_subgroups: false
     requester: '{{p1_admin_key}}'


### PR DESCRIPTION
## Summary

Core replaced `parse_identity` with `parse_account` across the group admin-API handlers, so a member is now named by **account** (64 hex characters) rather than by **signing key** (bs58). The two encodings differ deliberately: passing one where the other belongs is a `400`, not a silent no-op. `merod:edge` carries this and the Docker lane force-pulls it, so `group-admin-example`, `group-metadata-example` and `set-member-auto-follow-example` have been failing on every PR and on master with:

```
HTTP 400: Invalid account format: expected 64 hex characters (32 bytes)
```

The node already returns both ids in the responses these workflows read, and the pinned `calimero-client-py` 0.6.24 passes both through. So the fix is to capture the account rather than translate a key into one:

- `join_namespace` gains a `memberAccount` capture beside `memberIdentity`.
- `get_namespace_identity` gains an `account` capture beside `publicKey`.
- Every `member_id` (member metadata, capabilities, role, auto-follow) and the `members` list on `remove_group_members` now take the account.

Not everything moved. `add_group_members`' `identity` and every `requester` field still take the signing key, so the auto-follow self-set step now passes one of each. This asymmetry is the easiest thing to get wrong, so it is stated in a comment at each capture site and once in the workflow docs. It is also not an oversight in core, which is worth spelling out because the diff otherwise looks inconsistent.

### Why those two stayed keys

The rule core follows is that a **key is a credential** and an **account is a principal**. A key is what you hold and prove: it signs, it is what an auth token carries, it is what someone hands you out of band. An account is what governance rows are keyed by. Both fields below take a key because the caller is presenting a credential rather than pointing at an existing row, and core resolves the key to an account itself.

**`add_group_members`** resolves the invitee before the op is written, so the stored row is an account either way (`crates/context/src/handlers/add_group_members.rs`):

```rust
// The caller names the invitee by KEY - that is what an
// operator holds and shares - but the op names the account
// it acts as.
let member_account = crate::member_account::require(&datastore, &group_id, identity)?;
GroupOp::MemberAdded { member: member_account, role }
```

A key is what you actually have when adding someone. You cannot know their account yet, because that binding is what the lookup produces.

**`requester`** has to stay a key because it is checked against the authenticated identity, and the auth token carries a `PublicKey` (`crates/server/src/admin/handlers/requester.rs`):

```rust
Some(body) if body != authenticated => Err(403 "requester in request body
    does not match the authenticated identity")
```

An account there would have nothing to compare against, and would let a caller name an account whose key they do not hold. The account is still what gets authorised, one layer down in `governance_preflight`:

```rust
// The caller presents a signing key; admin authority is held by the
// account it acts as.
let requester_account = member_account::require(&datastore, group_id, &requester)?;
MembershipRepository::new(...).require_admin(group_id, &requester_account)?;
```

The key is additionally the lookup key for the signing key itself (`SigningKeysRepository::resolve(group_id, &requester)`).

**`member_id` is different** because by that point the caller already holds the account: `GET .../members` returns accounts, so the flow is list, then address. Accepting keys there too would give one target two spellings, which is the ambiguity the distinct encodings exist to prevent. Core has a test named `parse_account_rejects_a_bs58_signing_key` for exactly this, reasoning that a shared encoding would let a key name "a principal that exists nowhere, and silently matching no member", and that the distinct encodings "are what make that a 400 instead of a no-op".

The one result that still reads oddly is in the workflow diff: a member is added by key and removed by account. That does follow the rule (at add time you hold a key, at remove time you have read the member list), but it is the sharpest edge of this API and the reason the comments call it out.

Also in this change:

- `join_namespace` / `get_namespace_identity` declare the new field in their exportable-variable lists, which is where a workflow author looks to find what they can capture.
- The docs said `member_id` was a "member public key" and showed `{{member_pub}}` in five examples; corrected, with a short **Naming a member** section covering which id goes where.
- The three workflows leave the **binary** matrix, with a comment naming the condition for re-adding them.

### Why the workflows and not the step wrappers

Translating a key to an account inside the step wrappers was the other option, and it does not hold up. The wrappers are transparent pass-throughs today. A translation would need the member's namespace, which a step only holding a `group_id` does not have, plus an extra round trip per call. More decisively, it is not definable against an older node at all: a released merod exposes no governance account, and the `accountId` its `/account` endpoint returns is not the principal its member list is keyed by (verified below). Capturing the id the node itself hands back costs nothing and is what core did when it migrated its own merobox-format e2e workflows in the same commit.

### Both lanes cannot pass at once

They cannot, and this PR makes that explicit rather than trading one red lane for another.

| | `merod:edge` | released `0.11.0-rc.20` |
| --- | --- | --- |
| `GET namespaces/<ns>/identity` | `publicKey` + `account` | `publicKey` only |
| `POST` join | `memberIdentity` + `memberAccount` | `memberIdentity` only |
| `GET groups/<g>/members` → `identity` | account (hex) | signing key (bs58) |
| `member_id` accepts | account only | signing key |

A released merod returns no account anywhere, and the two ids are unrelated values, so no single spelling satisfies both. The binary lane resolves the latest core release; `0.11.0-rc.20` and the pending `0.11.0-rc.21` both predate the rename. The three workflows therefore leave the binary matrix and keep full coverage in Docker, following the existing convention in `list-workflows` for release-versus-master skew. Re-add them once a release carries the rename.

The same flip is pending for the ten `tee-*.yml`, which use `remove_group_members` and `assert_tee_member` / `assert_not_member`. The TEE lane builds merod from the latest **release** tag, so they are correct as written today and move in the same commit that re-adds the three above. Noted next to the TEE matrix rather than changed now, since changing them now would redden that lane.

## Test plan

CI on this branch is green: 90 checks pass, 0 fail, 2 skipped (`Publish to PyPI` and `create-release`, which do not run on PRs). The three jobs this fixes pass against a freshly pulled `merod:edge`:

| job | result |
| --- | --- |
| `Docker (group-admin-example)` | pass (11m35s) |
| `Docker (group-metadata-example)` | pass (11m17s) |
| `Docker (set-member-auto-follow-example)` | pass (11m10s) |

Locally, `make format-check` and `pytest merobox/tests/unit` pass, and `docs` builds with the internal link check.

All six workflow runs were local, one at a time, against a dedicated `acctci-node` prefix.

**`ghcr.io/calimero-network/merod:edge` (Docker lane)** - all three green:

| workflow | exit |
| --- | --- |
| `group-admin-example` | 0 |
| `group-metadata-example` | 0 |
| `set-member-auto-follow-example` | 0 |

**`ghcr.io/calimero-network/merod:0.11.0-rc.20` (what the binary lane resolves)** - all three fail, as expected, which is why they leave that matrix:

| workflow | exit | first failing step |
| --- | --- | --- |
| `group-admin-example` | 1 | Set Member Metadata (from node 2) |
| `group-metadata-example` | 1 | Grant Node 2 CAN_MANAGE_METADATA |
| `set-member-auto-follow-example` | 1 | Admin Enables contexts-only auto-follow for Node 2 |

The rc.20 failure mode is `⚠️ Export failed: 'memberAccount' not found / Available: governanceOp, groupId, memberIdentity`, after which `{{p2_account}}` reaches the member step unresolved.

**Reproduction of the reported break.** Running the pre-change `group-admin-example` against `merod:edge` fails at `Set Member Metadata (from node 2)`, the same step reported failing in CI. The post-change run of that workflow passes on the same image.

**API contract**, read directly off both nodes rather than inferred:

```
edge   GET namespaces/<ns>/identity -> {"namespaceId":…,"publicKey":"HqQBUGGD…","account":"007ee0f9…"}
rc.20  GET namespaces/<ns>/identity -> {"namespaceId":…,"publicKey":"BJ42hgcQ…"}

edge   join -> {"memberIdentity":"5NWWJNUB…","memberAccount":"35f15455…", …}
rc.20  join -> {"memberIdentity":"8GkA6rRq…", …}

edge   GET groups/<ns>/members -> identity "007ee0f9…" / "35f15455…"  (accounts), selfIdentity "HqQBUGGD…"
rc.20  GET groups/<ns>/members -> identity "BJ42hgcQ…" / "8GkA6rRq…"  (keys)
```

On edge, `get_namespace_account`'s `accountId` equals the `account` from `get_namespace_identity`, confirming they name the same principal. On rc.20 it returns an `accountId` that the member list does not use, which is why it is not a version-neutral source.

### Pre-existing local test failures

`pytest merobox/tests/unit` reports 33 failures on this branch and **the same 33 on `origin/master`**; the failing sets are identical, so this change adds none. They are all `RuntimeError: There is no current event loop in thread 'MainThread'` from `asyncio.get_event_loop()` in tests that run after another test closes the loop, and every one passes in isolation. Unrelated to member identifiers and left for a separate change.
