### PR TITLE
chore: release 0.6.54

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.53"
+__version__ = "0.6.54"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
## Summary

Bumps `__version__` 0.6.53 -> 0.6.54. Nothing else - the diff is one line.

**Draft on purpose: this must merge LAST, after #325 and #318.** Merging it early cuts a release that is missing part of the stack.

The branch is named `chore/release-0.6.54`, which matches again.

## Why this PR has to exist

None of the stacked PRs bump the version, and the release pipeline only tags and publishes when `__version__` differs from the previous commit on master:

```
PREVIOUS_VERSION=$(git show HEAD~1:merobox/__init__.py ...)
if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then bumped=true
```

Without this, the whole migration-suite stack lands on master still calling itself `0.6.53` - a version already published to PyPI pointing at entirely different code. Nothing fails; it just silently never releases.

That matters downstream: core gates on `MIN_MEROBOX` by version comparison. Raising that floor to a version whose published artifact contains none of `assert_api_response`, `stuck_members`, strict output captures or the absent-vs-null summaries would leave the gate looking satisfied while the steps it requires are absent - the same false-green shape this stack exists to remove.

Because `check-version` compares HEAD against HEAD~1, one bump merged last covers every PR already on master.

## What ships in it

- #324 `assert_ws_event`
- #326 per-member migration reports, `stuck_members`, and `expected_failure` able to fail
- #327 `assert_api_response`, which reads the admin API without the typed client's lossy DTOs
- #328 output captures and unresolved placeholders now fail instead of warning
- #329 summaries omit what a node did not send, so absent stays distinct from null
- #325 status-field drift detection
- #318 drops the `update_group_settings` step, whose client-py binding no longer exists

Consumer-visible behaviour change worth calling out in the release notes: workflows that passed on 0.6.53 with an unbindable capture, an unresolved placeholder, or an `expected_failure` step that unexpectedly succeeded will now fail. That is the intended fix - those were passing vacuously.

## Test plan

- `check-version` runs in PR dry-run mode and reports `bumped=true` for any PR, so this PR's own green does not prove the bump. The real proof is on merge: `create-release` fires only when `version-bumped == 'true'` on a master push, then tags `v0.6.54` and publishes to PyPI.
- Verify after merging: `gh release list` shows `v0.6.54`, and the PyPI JSON resolves 0.6.54.
- Then bump `MIN_MEROBOX` in core (`.github/actions/setup-merobox/action.yml`) from 0.6.52 to 0.6.54 and confirm #3408's app-migration workflows stop reporting `Unknown placeholder`.

## Before merging

A CHANGELOG entry belongs here by convention (the previous release commit `bd71bd1` hand-wrote one), but I do not edit CHANGELOG.md. Please add it.