### PR TITLE
feat(account): node_identity, replacing account_show

### DIFF
--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -50,7 +50,7 @@ VALID_STEP_TYPES = frozenset(
         "account_create",
         "account_pair",
         "account_revoke",
-        "account_show",
+        "node_identity",
         "node_exec",
         "create_group_in_namespace",
         "list_namespace_groups",
@@ -1014,12 +1014,11 @@ class AccountRevokeStepConfig(BaseStepConfig):
     )
 
 
-class AccountShowStepConfig(BaseStepConfig):
-    """Configuration for account_show step."""
+class NodeIdentityStepConfig(BaseStepConfig):
+    """Configuration for node_identity step."""
 
-    type: Literal["account_show"] = "account_show"
+    type: Literal["node_identity"] = "node_identity"
     node: str = Field(..., description="Node to ask")
-    namespace_id: str = Field(..., description="Namespace to report on")
 
 
 class CreateGroupInNamespaceStepConfig(BaseStepConfig):
@@ -1662,7 +1661,7 @@ STEP_TYPE_MODELS: dict[str, type[BaseStepConfig]] = {
     "account_create": AccountCreateStepConfig,
     "account_pair": AccountPairStepConfig,
     "account_revoke": AccountRevokeStepConfig,
-    "account_show": AccountShowStepConfig,
+    "node_identity": NodeIdentityStepConfig,
     "node_exec": NodeExecStepConfig,
     "create_group_in_namespace": CreateGroupInNamespaceStepConfig,
     "list_namespace_groups": ListNamespaceGroupsStepConfig,

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -2120,20 +2120,20 @@ class WorkflowExecutor:
             "account_create",
             "account_pair",
             "account_revoke",
-            "account_show",
+            "node_identity",
         ):
             from merobox.commands.bootstrap.steps.account import (
                 AccountCreateStep,
                 AccountPairStep,
                 AccountRevokeStep,
-                AccountShowStep,
+                NodeIdentityStep,
             )
 
             return {
                 "account_create": AccountCreateStep,
                 "account_pair": AccountPairStep,
                 "account_revoke": AccountRevokeStep,
-                "account_show": AccountShowStep,
+                "node_identity": NodeIdentityStep,
             }[step_type](step_config, **common_kwargs)
         if step_type == "node_exec":
             from merobox.commands.bootstrap.steps.node_exec import NodeExecStep

--- a/merobox/commands/bootstrap/steps/account.py
+++ b/merobox/commands/bootstrap/steps/account.py
@@ -340,28 +340,54 @@ class AccountRevokeStep(_AccountStepBase):
         return self._finish(node_name, "revoke", data, workflow_results, dynamic_values)
 
 
-class AccountShowStep(_AccountStepBase):
-    """Report which account a node speaks for in a namespace, and its device.
+class NodeIdentityStep(_AccountStepBase):
+    """Report who a node is — account, device, signing key, account root.
 
-    A read, so it mints nothing: the account id is derived from the node's root
-    and the namespace, and exists whether or not a device has been enrolled. A
-    `deviceId` of `null` is a real answer — "this node holds no device here" —
-    which is what makes it usable to assert that a revocation stuck.
+    A read; it mints nothing. Enrolment is implicit on every join path, so by
+    the time a node has joined anything it already has an account and a device,
+    and this reports them.
+
+    Takes NO namespace, because none of what it reports varies by one: a node
+    has one root key, therefore one account, and one device per installation.
+    It replaces `account_show`, which asked per namespace and could not answer
+    `accountRootPublicKey` at all.
+
+    Why this exists rather than reusing `account_create`: scenarios were calling
+    that step purely for its outputs, after the join had already enrolled them —
+    a mutation used as a getter, because there was no getter. `deviceId` and the
+    account root had no other source.
+
+    Requires calimero-client-py >= 0.6.27 (the `get_node_identity` binding) and
+    a node exposing `GET /admin-api/identity`.
     """
 
     def _get_required_fields(self) -> list[str]:
-        return ["node", "namespace_id"]
+        return ["node"]
 
     def _validate_field_types(self) -> None:
-        self._require_strings(("node", "namespace_id"))
+        self._require_strings(("node",))
 
     def _get_exportable_variables(self):
         return [
-            ("accountId", "shown_account_id_{node_name}", "Account this node owns"),
+            (
+                "accountId",
+                "identity_account_id_{node_name}",
+                "Account this node writes as",
+            ),
             (
                 "deviceId",
-                "shown_device_id_{node_name}",
-                "Device it holds there, or null if none",
+                "identity_device_id_{node_name}",
+                "This node's device — its replica id within the account",
+            ),
+            (
+                "publicKey",
+                "identity_public_key_{node_name}",
+                "The DEVICE's signing key, which is what op signatures verify against",
+            ),
+            (
+                "accountRootPublicKey",
+                "identity_account_root_{node_name}",
+                "Public half of the account root — what a second device pairs against",
             ),
         ]
 
@@ -369,26 +395,25 @@ class AccountShowStep(_AccountStepBase):
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
     ) -> bool:
         node_name = self._resolved("node", dynamic_values)
-        namespace_id = self._resolved("namespace_id", dynamic_values)
 
         try:
             client = self._client(node_name)
-            result = ok(self._data(client.get_namespace_account(namespace_id)))
+            result = ok(self._data(client.get_node_identity()))
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
-            result = fail(f"account show failed: {e}", error=e)
+            result = fail("node identity read failed", error=e)
 
         if not result["success"]:
             console.print(
-                f"[red]Failed to read {node_name}'s account: "
-                f"{escape(str(result.get('error')))}[/red]"
+                f"[red]Failed to read {node_name}'s identity: "
+                f"{result.get('error')}[/red]"
             )
             return False
 
         data = result["data"]
         console.print(
-            f"[green]✓[/green] {node_name} owns account {data.get('accountId')} "
+            f"[green]✓[/green] {node_name} is account {data.get('accountId')} "
             f"(device: {data.get('deviceId')})"
         )
         return self._finish(
-            node_name, "shown_account", data, workflow_results, dynamic_values
+            node_name, "identity", data, workflow_results, dynamic_values
         )

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -9,7 +9,7 @@ from merobox.commands.bootstrap.steps.account import (
     AccountCreateStep,
     AccountPairStep,
     AccountRevokeStep,
-    AccountShowStep,
+    NodeIdentityStep,
 )
 from merobox.commands.bootstrap.steps.api_assertion import AssertApiResponseStep
 from merobox.commands.bootstrap.steps.assert_log import (
@@ -289,8 +289,8 @@ def validate_step_config(step: dict, step_name: str, step_type: str) -> list:
             step_class = AccountPairStep
         elif step_type == "account_revoke":
             step_class = AccountRevokeStep
-        elif step_type == "account_show":
-            step_class = AccountShowStep
+        elif step_type == "node_identity":
+            step_class = NodeIdentityStep
         elif step_type == "node_exec":
             step_class = NodeExecStep
         elif step_type == "create_group_in_namespace":

--- a/merobox/tests/unit/test_account_steps.py
+++ b/merobox/tests/unit/test_account_steps.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the account-identity workflow steps.
 
-Covers: AccountCreateStep, AccountPairStep, AccountRevokeStep, AccountShowStep —
+Covers: AccountCreateStep, AccountPairStep, AccountRevokeStep, NodeIdentityStep —
 validation, the client calls they make, and the two behaviours that are the reason
 these exist as steps rather than shell scripts: values flow out through `outputs`,
 and pairing's confirmation code is checked rather than passed along.
@@ -24,7 +24,7 @@ from merobox.commands.bootstrap.steps.account import (
     AccountCreateStep,
     AccountPairStep,
     AccountRevokeStep,
-    AccountShowStep,
+    NodeIdentityStep,
 )
 
 NAMESPACE = "ab" * 32
@@ -340,39 +340,55 @@ class TestAccountRevokeStep:
 
 
 # =============================================================================
-# AccountShowStep
+# NodeIdentityStep
 # =============================================================================
 
 
-class TestAccountShowStep:
+class TestNodeIdentityStep:
     def setup_method(self):
         self.config = {
-            "type": "account_show",
-            "name": "Show",
+            "type": "node_identity",
+            "name": "Who am I",
             "node": "calimero-node-2",
-            "namespace_id": NAMESPACE,
         }
 
     def test_valid_config_passes_validation(self):
-        _step(AccountShowStep, self.config)
+        _step(NodeIdentityStep, self.config)
 
-    def test_reads_the_account_and_keeps_a_null_device_as_an_answer(self):
-        """`deviceId: None` is meaningful — it is how "no device here" is said.
+    def test_takes_no_namespace(self):
+        """A namespace would be a parameter the answer cannot depend on.
+
+        One root key is one account and one device, whatever namespaces the node
+        happens to be in — so accepting a `namespace_id` would invite a caller to
+        believe the reply varied by it.
+        """
+        assert (
+            "namespace_id"
+            not in NodeIdentityStep(self.config, MagicMock())._get_required_fields()
+        )
+
+    def test_reads_the_identity_and_keeps_a_null_device_as_an_answer(self):
+        """`deviceId: None` is meaningful — it is how "not enrolled yet" is said.
 
         A step that treated it as missing data could not be used to assert that a
         revocation stuck.
         """
         client = MagicMock()
-        client.get_namespace_account.return_value = _envelope(
-            {"accountId": "aa" * 32, "deviceId": None}
+        client.get_node_identity.return_value = _envelope(
+            {
+                "accountId": "aa" * 32,
+                "deviceId": None,
+                "publicKey": "z" * 44,
+                "accountRootPublicKey": "bb" * 32,
+            }
         )
-        step = _step(AccountShowStep, self.config, client)
+        step = _step(NodeIdentityStep, self.config, client)
 
         results = {}
         assert _run(step.execute(results, {})) is True
 
-        client.get_namespace_account.assert_called_once_with(NAMESPACE)
-        assert results["shown_account_calimero-node-2"]["deviceId"] is None
+        client.get_node_identity.assert_called_once_with()
+        assert results["identity_calimero-node-2"]["deviceId"] is None
 
 
 class TestOutputsAreActuallyExported:
@@ -479,22 +495,38 @@ class TestOutputsAreActuallyExported:
         assert _run(step.execute({}, dynamic_values)) is True
         assert dynamic_values["rotated"] is True
 
-    def test_account_show_exports_the_account(self):
+    def test_node_identity_exports_what_account_create_used_to(self):
+        """The three ids scenarios were calling `account_create` to obtain.
+
+        That step was a mutation used as a getter — the join had already enrolled
+        the node — and `deviceId` and the account root had no other source. This
+        is the source.
+        """
         client = MagicMock()
-        client.get_namespace_account.return_value = _envelope(
-            {"accountId": "aa" * 32, "deviceId": None}
+        client.get_node_identity.return_value = _envelope(
+            {
+                "accountId": "aa" * 32,
+                "deviceId": "cc" * 32,
+                "publicKey": "z" * 44,
+                "accountRootPublicKey": "bb" * 32,
+            }
         )
         step = _step(
-            AccountShowStep,
+            NodeIdentityStep,
             {
-                "type": "account_show",
-                "name": "Show",
+                "type": "node_identity",
+                "name": "Who am I",
                 "node": "calimero-node-2",
-                "namespace_id": NAMESPACE,
-                "outputs": {"shown": "accountId"},
+                "outputs": {
+                    "acct": "accountId",
+                    "dev": "deviceId",
+                    "root": "accountRootPublicKey",
+                },
             },
             client,
         )
         dynamic_values = {}
         assert _run(step.execute({}, dynamic_values)) is True
-        assert dynamic_values["shown"] == "aa" * 32
+        assert dynamic_values["acct"] == "aa" * 32
+        assert dynamic_values["dev"] == "cc" * 32
+        assert dynamic_values["root"] == "bb" * 32

--- a/workflow-examples/account-identity.yml
+++ b/workflow-examples/account-identity.yml
@@ -22,8 +22,9 @@ description: >
        without the id and both keys. The step also compares the confirmation code
        both sides derive, which is the check a human is meant to make.
 
-    4. `account_show` on both nodes proves the payoff: same account, different
-       devices. One person, two replicas.
+    4. `node_identity` on both nodes proves the payoff: same account, different
+       devices. One person, two replicas. It takes no namespace, because none of
+       what it reports varies by one.
 
     5. node-1 revokes node-3's device (`account_revoke`) and the scope key
        rotates.
@@ -170,16 +171,14 @@ steps:
   # ── Phase 4: one account, two devices ─────────────────────────────
 
   - name: What the laptop speaks for
-    type: account_show
+    type: node_identity
     node: account-demo-2
-    namespace_id: '{{namespace_id}}'
     outputs:
       laptop_account: accountId
 
   - name: What the phone speaks for
-    type: account_show
+    type: node_identity
     node: account-demo-3
-    namespace_id: '{{namespace_id}}'
     outputs:
       phone_account: accountId
 
@@ -259,9 +258,8 @@ steps:
 
   # The root round-tripped: the account it presents is the one it had before.
   - name: The restored root still owns the same account
-    type: account_show
+    type: node_identity
     node: account-demo-2
-    namespace_id: '{{namespace_id}}'
     outputs:
       recovered_account: accountId
 


### PR DESCRIPTION
Adds a `node_identity` step and retires `account_show`.

## Why `account_show` had to go

It asked *"which account does this node speak for in namespace X"* and took a `namespace_id` **it could not use** — one root key is one account and one device, whatever namespaces the node happens to be in. It also called `get_namespace_account`, which calimero-client-py removes in 0.6.27 because core deleted the endpoint behind it, so the step was about to break regardless.

## What `node_identity` reports

`GET /admin-api/identity`, with no namespace:

| field | |
| --- | --- |
| `accountId` | the account this node writes as |
| `deviceId` | its replica id within that account |
| `publicKey` | the **device's** signing key — what op signatures verify against, not the account root |
| `accountRootPublicKey` | public half of the account root, what a second device pairs against |

## Why the last two matter beyond a rename

Core scenarios call the `account_create` step purely for its `outputs:`, **after** a join has already enrolled the node. Enrolment is implicit on every join path, so that step creates nothing — it is a mutation used as a getter, because there was no getter. `deviceId` and the account root had **no other source**: `GET /namespaces/:ns/identity` returns only `account` and `publicKey`.

This is that source. With it, core can delete `POST /namespaces/:ns/account` and repoint five e2e scenarios.

## Ordering

Requires **calimero-client-py >= 0.6.27** for the `get_node_identity` binding (calimero-client-py#89). Merge and release that first; this is inert without it.

## Verification

- `merobox/tests/unit/test_account_steps.py` — 39 pass, including a test that the step accepts no `namespace_id`, and one asserting it exports the three ids `account_create` was being used for
- `test_shipped_workflows_validate.py` — 60 pass; the shipped `account-identity.yml` moves with the step, three call sites each losing a `namespace_id` that never shaped the answer
- `black --check` and `ruff check` clean
- Full unit suite shows **38 failures, identical to master's baseline on this machine** (a local Python/asyncio artifact, not this change) — I had one extra before fixing the shipped workflow, and it is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)