### PR TITLE
chore(deps): require calimero-client-py 0.6.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,13 @@ dependencies = [
     # 0.6.21 is where `revoke_device` grew its `proof` argument. Below it the
     # account_revoke step's three-argument call is a TypeError at run time, not a
     # resolution failure at install time, so the floor has to say so.
-    # 0.6.26 decodes `join_namespace` into a master-only struct requiring
-    # `memberAccount`, which no released node sends. Lift once one does.
-    "calimero-client-py>=0.6.24,<0.6.26",
+    # The <0.6.26 cap was there because 0.6.26 decodes `join_namespace` into a
+    # struct requiring `memberAccount`, which no released node sent. 0.11.0-rc.21
+    # sends it (core#3391), so the cap is lifted.
+    # The floor is 0.6.28 because that is the first wheel built against a core
+    # carrying `revokedIn` on the revoke-device response; below it the
+    # account_revoke step cannot export the field a scenario captures.
+    "calimero-client-py>=0.6.28",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,11 @@ PyYAML>=6.0.0
 #     requires and a master node ignores. 0.6.22 and 0.6.23 omitted it and could
 #     not create a namespace on any released node — which is what turned this
 #     suite red when it was floored at 0.6.23.
-# 0.6.26 gives that up: it decodes `join_namespace` into a master-only struct
-# requiring `memberAccount`, which no released node sends. Lift once one does.
-calimero-client-py>=0.6.24,<0.6.26
+# The <0.6.26 cap was there because 0.6.26 decodes `join_namespace` into a struct
+# requiring `memberAccount`, which no released node sent. 0.11.0-rc.21 sends it
+# (core#3391), so the cap is lifted. The floor is 0.6.28: the first wheel built
+# against a core carrying `revokedIn` on the revoke-device response.
+calimero-client-py>=0.6.28
 aiohttp>=3.9.0
 toml>=0.10.2
 pydantic>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "docker>=6.0.0",
         "rich>=13.0.0",
         "PyYAML>=6.0.0",
-        "calimero-client-py>=0.6.21",
+        "calimero-client-py>=0.6.28",
         "aiohttp>=3.8.0",
         "toml>=0.10.2",
         "base58>=2.1.0",


### PR DESCRIPTION
## Summary

Lifts the `<0.6.26` cap and raises the floor to `0.6.28`. Two independent reasons.

**Blocked on calimero-network/calimero-client-py#90**, which cuts 0.6.28.

## Lifting the cap

The cap carried its own lift condition:

> `0.6.26` decodes `join_namespace` into a master-only struct requiring `memberAccount`, which no released node sends. **Lift once one does.**

That condition is now met. `0.11.0-rc.21`, cut today, carries `member_account` on `JoinGroupApiResponseData` (calimero-network/core#3391); `0.11.0-rc.20` does not. Verified against the tags rather than inferred from master:

```
$ git show 0.11.0-rc.21:crates/server/primitives/src/admin/mod.rs | grep -c member_account
1
$ git show 0.11.0-rc.20:crates/server/primitives/src/admin/mod.rs | grep -c member_account
0
```

## Raising the floor

0.6.28 is the first wheel built against a core carrying `revokedIn` on the revoke-device response. Below it the field is absent from what the binding returns, so a scenario capturing it gets:

```
⚠️  Export failed: 'revokedIn' not found
   Available: accountId, deviceId, keyRotated
```

That is what core's `account-facts-cross-namespace` scenario hit when it ran for the first time — it had shipped unregistered and had never executed. The placeholder stayed literal, so both assertions compared `{{revoked_in}}` against a namespace id.

**Nothing in this repo was at fault.** `_export_custom_outputs` reads arbitrary response fields, so `outputs: {revoked_in: revokedIn}` works as written the moment the wheel carries the field — no step change needed. The floor is what makes that guaranteed rather than incidental.

## Also

`setup.py` still said `>=0.6.21`, which neither `pyproject.toml` nor `requirements.txt` agreed with. Aligned to `>=0.6.28` rather than left to drift further.

## Verification

- `pyproject.toml` parses (`tomllib`)
- `make format-check` ✅ — `black` 137 files unchanged, `ruff check` all passed

## Sequencing

1. calimero-client-py#90 merges → 0.6.28 publishes to PyPI
2. this merges
3. core registers `account-facts-cross-namespace` in the e2e matrix, removing its entry from `scripts/scenario-coverage-baseline.json` (calimero-network/core#3463)

🤖 Generated with [Claude Code](https://claude.com/claude-code)