### PR TITLE
chore(deps): lift the client-py ceiling to >=0.6.27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ kv-store-benchmark-report.txt
 workflow-examples/res/kv_store.wasm
 workflow-examples/res/blobs.wasm
 workflow-examples/.core-repo/
+.claude/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,13 @@ dependencies = [
     # 0.6.21 is where `revoke_device` grew its `proof` argument. Below it the
     # account_revoke step's three-argument call is a TypeError at run time, not a
     # resolution failure at install time, so the floor has to say so.
-    # 0.6.26 decodes `join_namespace` into a master-only struct requiring
-    # `memberAccount`, which no released node sends. Lift once one does.
-    "calimero-client-py>=0.6.24,<0.6.26",
+    # 0.6.27 is where `get_node_identity` lands, which the `node_identity` step
+    # calls — below it that step is an AttributeError at run time.
+    #
+    # The old ceiling was `<0.6.26`, because 0.6.26 decodes `join_namespace` into
+    # a struct requiring `memberAccount` and no released node sent it. 0.11.0-rc.22
+    # does, so the condition that cap was waiting for is met.
+    "calimero-client-py>=0.6.27",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",


### PR DESCRIPTION
Without this, `node_identity` cannot work for anyone.

#333 added the step; it calls `get_node_identity`, which lands in calimero-client-py **0.6.27**. The pin capped at `<0.6.26`, so merobox could never install a wheel that has it — the step is an `AttributeError` at run time, both for direct users and for core's e2e, which installs merobox and inherits its dependency resolution.

## The old ceiling said when to lift it

> `0.6.26 decodes join_namespace into a master-only struct requiring memberAccount, which no released node sends. Lift once one does.`

**0.11.0-rc.22 sends it** (`JoinGroupApiResponseData::member_account`), so the condition that cap was waiting for is met.

## Verified against the wheel, not the version number

| binding | in 0.6.28 |
| --- | --- |
| `get_node_identity` | ✅ present |
| `get_namespace_account` | ✅ gone (removed in calimero-client-py#89) |

Unit suite under 0.6.28 lands on the **same failures as before the lift** — no new breakage from raising it.

## Worth knowing

client-py still exposes a `create_account` binding. core#3470 deletes the endpoint behind it, so it will 404; removing the binding is a follow-up there, not a blocker here.

## Order

This should land **before** #331 releases 0.6.54 — otherwise the release ships a step its own dependency pin forbids from working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)