### PR TITLE
chore(release): 0.6.55, and stop the two dependency pins drifting

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.54"
+__version__ = "0.6.55"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/tests/unit/test_dependency_pins_agree.py
+++ b/merobox/tests/unit/test_dependency_pins_agree.py
@@ -1,0 +1,56 @@
+"""`pyproject.toml` and `requirements.txt` must pin the same client-py.
+
+Both exist and only one governs the release binary: the PyPI wheel resolves
+`pyproject.toml`, while the standalone binary is built with `pip install -r
+requirements.txt`. Nothing tied them together, so they drifted — and the drift
+was invisible until a scenario failed.
+
+0.6.54 shipped exactly that. `pyproject.toml` had been lifted to `>=0.6.27` for
+the `node_identity` step, `requirements.txt` still said `<0.6.26`, and the
+binary core's CI downloads embedded a client-py with no `get_node_identity`.
+Every `node_identity` step failed, and the step reported it as a generic read
+failure rather than the AttributeError it was.
+
+A version test guards the same class in calimero-client-py, where three files
+declare a version. This is that test, for the two files that declare a
+dependency.
+"""
+
+import re
+from pathlib import Path
+
+import tomllib
+
+_ROOT = Path(__file__).resolve().parents[3]
+_PKG = "calimero-client-py"
+
+
+def _from_pyproject() -> str:
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+    for dep in data["project"]["dependencies"]:
+        if dep.replace("_", "-").startswith(_PKG):
+            return dep.strip()
+    raise AssertionError(f"{_PKG} missing from pyproject.toml dependencies")
+
+
+def _from_requirements() -> str:
+    for line in (_ROOT / "requirements.txt").read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line.replace("_", "-").startswith(_PKG):
+            return line
+    raise AssertionError(f"{_PKG} missing from requirements.txt")
+
+
+def _spec(dep: str) -> str:
+    """The version constraint, with the name and any whitespace stripped."""
+    return re.sub(r"\s+", "", dep[len(_PKG) :]) if dep.startswith(_PKG) else dep
+
+
+def test_client_py_pin_is_the_same_in_both_files():
+    pyproject, requirements = _from_pyproject(), _from_requirements()
+    assert _spec(pyproject) == _spec(requirements), (
+        f"client-py pin drift: pyproject.toml={pyproject!r}, "
+        f"requirements.txt={requirements!r}. The wheel resolves pyproject and "
+        f"the release BINARY is built from requirements, so a lift applied to "
+        f"only one ships a binary that cannot do what the wheel can."
+    )


### PR DESCRIPTION
Releases the client-py requirement fix from #334, and guards the class that made it necessary.

## What 0.6.54 shipped

A binary that could not run the step it was cut for.

I lifted the client-py ceiling in `pyproject.toml` (#336) and **not** in `requirements.txt`. The standalone binary — the one core's CI downloads — is built with `pip install -r requirements.txt`:

| file | at v0.6.54 | governs |
| --- | --- | --- |
| `pyproject.toml` | `>=0.6.27` | the PyPI wheel |
| `requirements.txt` | `>=0.6.24,<0.6.26` | **the release binary** |

So the binary embedded client-py 0.6.25, which has no `get_node_identity`, and every `node_identity` step failed — taking five core scenarios in calimero-network/core#3470 with it. #334 has since corrected the requirement; this releases it.

## The test is the durable half

Two files declare the same dependency, only one governs the binary, and nothing tied them together — so the drift was invisible until a scenario failed. It also failed **opaquely**: the step catches the `AttributeError` and reports "node identity read failed", which sent me looking at the endpoint rather than the binding. Worth fixing separately.

**Verified by reproducing the bug**: with `requirements.txt` set back to `<0.6.26` the test fails and names both values; restored, it passes.

The sibling class is already guarded in calimero-client-py, where three files declare a version and `test_all_three_version_declarations_agree` says so — that test caught the same mistake for me two days ago, which is why this one exists.

## Verification

`black`, `ruff` clean. Full unit suite lands on the same 38 failures as master's baseline on this machine (a local Python/asyncio artifact, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)