### PR TITLE
fix(logs): capture why a node stopped, not just what it logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-node exit state alongside the logs: `data/container-logs/<name>.state.json`.**
+  Captures Docker's `status`, `exit_code`, `oom_killed`, `error` and start/finish
+  timestamps for every node, written at the same points the logs are. A node killed
+  by a signal writes no final log line — the log just ends — so the exit code is the
+  only evidence of the cause: 137 with `oom_killed` is memory, 139 is a segfault,
+  143 is an ordinary SIGTERM teardown, 0 is a node that chose to exit. Docker keeps
+  this only until the container is removed, so the stop path now reads it in the one
+  window where it exists: after `stop`, before `remove`.
+- **A node that stopped on its own is now announced.** `export_node_logs()` prints a
+  `💀 <node> is not running: <cause>` line naming what the exit code means, so the
+  reason a scenario failed is in the run output rather than only in an artifact
+  nobody downloads. This is what turns a bare
+  `Client error: error sending request for url (...)` — a transport failure, which
+  is what a dead node looks like from the client side — into a diagnosis.
+
+### Fixed
+
+- **`export_node_logs()` no longer skips nodes that have already exited.**
+  `containers.list()` defaults to running-only, so the one node worth looking at
+  when a scenario fails because a node died was precisely the one dropped from the
+  capture. It now lists with `all=True`.
+
 ## [0.6.53] - 2026-08-12
 
 ### Changed

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -2,6 +2,7 @@
 Calimero Manager - Core functionality for managing Calimero nodes in Docker containers.
 """
 
+import json
 import logging
 import os
 import re
@@ -129,6 +130,79 @@ def _dump_container_log(container, container_name: str, log_dir: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def _dump_container_state(
+    container, container_name: str, log_dir: str
+) -> Optional[dict]:
+    """Write a container's Docker-level exit state to ``<name>.state.json``.
+
+    The log says what the node did; this says how it stopped, and the two answer
+    different questions. A node killed by a signal writes no final line at all —
+    the log simply ends — so the exit code is the only evidence of the cause:
+    137 with ``oom_killed`` is memory, 139 is a segfault, 143 is the SIGTERM of
+    an ordinary teardown, and 0 is a clean exit the node chose. Without it, a
+    node that vanishes mid-scenario is indistinguishable from one that hung, and
+    the scenario failure reads as an application error.
+
+    Docker keeps this only until the container is removed, which is why every
+    capture site sits beside the log capture rather than after teardown.
+
+    Best-effort like the log dump: returns ``None`` rather than raising, so a
+    shutdown path never fails because state could not be read.
+    """
+    try:
+        # The container object may carry attrs cached from creation time, when it
+        # had not exited yet.
+        container.reload()
+        state = container.attrs.get("State") or {}
+        summary = {
+            "name": container_name,
+            "status": state.get("Status"),
+            "exit_code": state.get("ExitCode"),
+            "oom_killed": state.get("OOMKilled"),
+            "error": state.get("Error") or "",
+            "started_at": state.get("StartedAt"),
+            "finished_at": state.get("FinishedAt"),
+        }
+        state_file = os.path.join(log_dir, f"{container_name}.state.json")
+        with open(state_file, "w") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+        return summary
+    except Exception:
+        return None
+
+
+def _describe_unexpected_exit(summary: Optional[dict]) -> Optional[str]:
+    """Explain a node that is no longer running, or ``None`` when it is fine.
+
+    Kept separate from the capture so the console line and the JSON never drift,
+    and so the interpretation of the exit code lives in exactly one place.
+    """
+    if not summary or summary.get("status") == "running":
+        return None
+
+    exit_code = summary.get("exit_code")
+    if summary.get("oom_killed"):
+        cause = "out of memory (OOM-killed)"
+    elif exit_code == 137:
+        cause = "killed by SIGKILL — out of memory, or killed from outside"
+    elif exit_code == 139:
+        cause = "killed by SIGSEGV — the process crashed"
+    elif exit_code == 143:
+        cause = "stopped by SIGTERM"
+    elif exit_code == 0:
+        cause = "exited cleanly of its own accord"
+    else:
+        cause = f"exited {exit_code}"
+
+    detail = summary.get("error")
+    suffix = f" ({detail})" if detail else ""
+    return (
+        f"{summary['name']} is not running: {cause}{suffix}. "
+        f"Its log ends where the process died, so the last line is a symptom, "
+        f"not the cause."
+    )
 
 
 class DockerManager(CleanupMixin):
@@ -1868,6 +1942,12 @@ class DockerManager(CleanupMixin):
 
             try:
                 container.stop(timeout=stop_timeout)
+                # Between the stop and the remove is the only moment the exit
+                # code exists to be read: `stop` produces it, `remove` destroys
+                # it. Nothing is announced here — on this path the node stopped
+                # because it was told to. The export path is what flags a node
+                # that stopped on its own.
+                _dump_container_state(container, container_name, log_dir)
                 container.remove()
                 console.print(
                     f"[green]✓ Gracefully stopped and removed {container_name}[/green]"
@@ -2043,24 +2123,42 @@ class DockerManager(CleanupMixin):
         except Exception:
             return []
 
-    def export_node_logs(self, node_names: Optional[list[str]] = None) -> int:
-        """Persist logs for the given (or all running) Calimero nodes.
+    def get_all_nodes(self) -> list[str]:
+        """Return names of all Calimero node containers, exited ones included.
 
-        Writes ``data/container-logs/<name>.log`` for each node without
-        stopping it, so workflows that leave nodes running
+        ``containers.list()`` defaults to running-only, which silently excludes
+        the one node worth looking at when a scenario fails because a node died.
+        """
+        try:
+            containers = self.client.containers.list(
+                all=True, filters={"label": "calimero.node=true"}
+            )
+            return [c.name for c in containers]
+        except Exception:
+            return []
+
+    def export_node_logs(self, node_names: Optional[list[str]] = None) -> int:
+        """Persist logs and exit state for the given (or all) Calimero nodes.
+
+        Writes ``data/container-logs/<name>.log`` and ``<name>.state.json`` for
+        each node without stopping it, so workflows that leave nodes running
         (``stop_all_nodes: false``) still produce collectable log artifacts.
         The stop path captures logs of its own when nodes are torn down; this
         method covers the cases where they are not.
 
+        Nodes that have already exited are included on purpose: a node that died
+        mid-scenario is both the reason the scenario failed and the node a
+        running-only listing drops.
+
         Args:
             node_names: Explicit container names to dump. When ``None``, all
-                currently running Calimero nodes are used.
+                Calimero nodes are used, whether running or exited.
 
         Returns:
             The number of node logs successfully written.
         """
         if node_names is None:
-            node_names = self.get_running_nodes()
+            node_names = self.get_all_nodes()
         if not node_names:
             return 0
 
@@ -2075,6 +2173,14 @@ class DockerManager(CleanupMixin):
                     continue
             if _dump_container_log(container, name, CONTAINER_LOG_DIR):
                 written += 1
+            # Print, not just persist: a dead node explains the failure above it,
+            # and making that visible must not depend on anyone downloading the
+            # log artifact afterwards.
+            detail = _describe_unexpected_exit(
+                _dump_container_state(container, name, CONTAINER_LOG_DIR)
+            )
+            if detail:
+                console.print(f"[red]💀 {detail}[/red]")
         return written
 
     def list_nodes(self) -> None:

--- a/merobox/tests/unit/test_docker_manager.py
+++ b/merobox/tests/unit/test_docker_manager.py
@@ -1,3 +1,4 @@
+import json
 import signal
 import threading
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ from merobox.commands.manager import (
     CORS_ALLOWED_HEADERS,
     DEFAULT_CORS_ORIGINS,
     DockerManager,
+    _describe_unexpected_exit,
     _get_node_hostname,
     _validate_cors_origins,
 )
@@ -1306,24 +1308,51 @@ def test_drain_timeout_zero_skips_drain_phase(mock_docker):
 # --- export_node_logs (merobox#207): persist logs without stopping nodes -----
 
 
-def _logging_container(name, log_text):
-    """A MagicMock container whose `.logs()` returns `log_text` as bytes."""
+def _logging_container(name, log_text, state=None):
+    """A MagicMock container whose `.logs()` returns `log_text` as bytes.
+
+    `state` populates the Docker `State` block that the exit-state capture reads;
+    it defaults to a healthy running node.
+    """
     c = MagicMock()
     c.name = name
     c.logs.return_value = log_text.encode("utf-8")
+    c.attrs = {"State": state or _running_state()}
     return c
+
+
+def _running_state():
+    return {
+        "Status": "running",
+        "ExitCode": 0,
+        "OOMKilled": False,
+        "Error": "",
+        "StartedAt": "2026-08-17T08:25:51.7Z",
+        "FinishedAt": "0001-01-01T00:00:00Z",
+    }
+
+
+def _exited_state(exit_code, oom_killed=False, error=""):
+    return {
+        "Status": "exited",
+        "ExitCode": exit_code,
+        "OOMKilled": oom_killed,
+        "Error": error,
+        "StartedAt": "2026-08-17T08:25:51.7Z",
+        "FinishedAt": "2026-08-17T08:25:55.8Z",
+    }
 
 
 @patch("docker.from_env")
 def test_export_node_logs_writes_running_nodes(mock_docker, tmp_path, monkeypatch):
-    """With no explicit names, all running nodes are dumped to data/container-logs/."""
+    """With no explicit names, every node is dumped to data/container-logs/."""
     client = MagicMock()
     mock_docker.return_value = client
     manager = DockerManager(enable_signal_handlers=False)
 
     node = _logging_container("calimero-node-1", "hello from node-1")
-    # get_running_nodes() lists running calimero nodes; export then re-fetches
-    # each by name via containers.get().
+    # get_all_nodes() lists calimero nodes (exited ones included); export then
+    # re-fetches each by name via containers.get().
     client.containers.list.return_value = [node]
     client.containers.get.return_value = node
 
@@ -1341,7 +1370,7 @@ def test_export_node_logs_writes_running_nodes(mock_docker, tmp_path, monkeypatc
 
 @patch("docker.from_env")
 def test_export_node_logs_explicit_names(mock_docker, tmp_path, monkeypatch):
-    """Explicit names bypass get_running_nodes and are fetched directly."""
+    """Explicit names bypass node discovery and are fetched directly."""
     client = MagicMock()
     mock_docker.return_value = client
     manager = DockerManager(enable_signal_handlers=False)
@@ -1356,7 +1385,7 @@ def test_export_node_logs_explicit_names(mock_docker, tmp_path, monkeypatch):
     assert (
         tmp_path / "data" / "container-logs" / "calimero-node-2.log"
     ).read_text() == "node-2 logs"
-    # No running-node discovery when names are supplied.
+    # No node discovery when names are supplied.
     client.containers.list.assert_not_called()
 
 
@@ -1364,7 +1393,7 @@ def test_export_node_logs_explicit_names(mock_docker, tmp_path, monkeypatch):
 def test_export_node_logs_no_running_nodes_returns_zero(
     mock_docker, tmp_path, monkeypatch
 ):
-    """No running nodes -> nothing written, returns 0, no directory churn."""
+    """No nodes at all -> nothing written, returns 0, no directory churn."""
     client = MagicMock()
     mock_docker.return_value = client
     manager = DockerManager(enable_signal_handlers=False)
@@ -1400,3 +1429,156 @@ def test_export_node_logs_skips_missing_container(mock_docker, tmp_path, monkeyp
     assert not (
         tmp_path / "data" / "container-logs" / "calimero-node-missing.log"
     ).exists()
+
+
+# --- exit-state capture: why a node stopped, not just what it logged ----------
+
+
+@patch("docker.from_env")
+def test_export_node_logs_includes_exited_nodes(mock_docker, tmp_path, monkeypatch):
+    """A node that already died must still be captured.
+
+    `containers.list()` defaults to running-only, which used to drop exactly the
+    node worth looking at: the one whose death made the scenario fail.
+    """
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    dead = _logging_container(
+        "calimero-node-1", "log ends mid-compile", _exited_state(137, oom_killed=True)
+    )
+    client.containers.list.return_value = [dead]
+    client.containers.get.return_value = dead
+
+    monkeypatch.chdir(tmp_path)
+    assert manager.export_node_logs() == 1
+
+    # The listing must ask for exited containers too.
+    _, kwargs = client.containers.list.call_args
+    assert kwargs.get("all") is True
+
+    logs = tmp_path / "data" / "container-logs"
+    assert (logs / "calimero-node-1.log").read_text() == "log ends mid-compile"
+    state = json.loads((logs / "calimero-node-1.state.json").read_text())
+    assert state["status"] == "exited"
+    assert state["exit_code"] == 137
+    assert state["oom_killed"] is True
+
+
+@patch("docker.from_env")
+def test_export_node_logs_records_state_for_running_nodes(
+    mock_docker, tmp_path, monkeypatch
+):
+    """A healthy node gets a state file too, so its absence is never ambiguous."""
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    node = _logging_container("calimero-node-1", "healthy")
+    client.containers.list.return_value = [node]
+    client.containers.get.return_value = node
+
+    monkeypatch.chdir(tmp_path)
+    assert manager.export_node_logs() == 1
+
+    state = json.loads(
+        (
+            tmp_path / "data" / "container-logs" / "calimero-node-1.state.json"
+        ).read_text()
+    )
+    assert state["status"] == "running"
+    # Reading state must not disturb the node.
+    node.stop.assert_not_called()
+
+
+@patch("docker.from_env")
+def test_export_node_logs_survives_unreadable_state(mock_docker, tmp_path, monkeypatch):
+    """State capture is best-effort: a Docker error must not lose the log."""
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    node = _logging_container("calimero-node-1", "log survives")
+    node.reload.side_effect = docker.errors.APIError("daemon gone")
+    client.containers.list.return_value = [node]
+    client.containers.get.return_value = node
+
+    monkeypatch.chdir(tmp_path)
+    assert manager.export_node_logs() == 1
+
+    logs = tmp_path / "data" / "container-logs"
+    assert (logs / "calimero-node-1.log").read_text() == "log survives"
+    assert not (logs / "calimero-node-1.state.json").exists()
+
+
+@patch("docker.from_env")
+def test_stop_path_records_exit_state_before_removing(
+    mock_docker, tmp_path, monkeypatch
+):
+    """The stop path must read the exit code between `stop` and `remove`.
+
+    `stop` is what produces the exit code and `remove` is what destroys it, so a
+    capture on either side of that window records nothing useful.
+    """
+    client = MagicMock()
+    mock_docker.return_value = client
+    manager = DockerManager(enable_signal_handlers=False)
+
+    node = _logging_container("calimero-node-1", "bye")
+    calls = []
+    node.stop.side_effect = lambda **kwargs: (
+        calls.append("stop"),
+        node.attrs.__setitem__("State", _exited_state(143)),
+    )
+    node.reload.side_effect = lambda: calls.append("reload")
+    node.remove.side_effect = lambda: calls.append("remove")
+
+    monkeypatch.chdir(tmp_path)
+    success, failed = manager._graceful_stop_containers_batch(
+        [("calimero-node-1", node)], drain_timeout=0, stop_timeout=1
+    )
+
+    assert (success, failed) == (1, [])
+    assert calls == ["stop", "reload", "remove"]
+    state = json.loads(
+        (
+            tmp_path / "data" / "container-logs" / "calimero-node-1.state.json"
+        ).read_text()
+    )
+    assert state["exit_code"] == 143
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        (_running_state(), None),
+        (_exited_state(137, oom_killed=True), "out of memory"),
+        (_exited_state(137), "SIGKILL"),
+        (_exited_state(139), "SIGSEGV"),
+        (_exited_state(143), "SIGTERM"),
+        (_exited_state(0), "exited cleanly"),
+        (_exited_state(2), "exited 2"),
+    ],
+)
+def test_describe_unexpected_exit_names_the_cause(state, expected):
+    """The exit code is only evidence if it is translated into a cause."""
+    summary = {
+        "name": "calimero-node-1",
+        "status": state["Status"],
+        "exit_code": state["ExitCode"],
+        "oom_killed": state["OOMKilled"],
+        "error": state["Error"],
+    }
+    detail = _describe_unexpected_exit(summary)
+
+    if expected is None:
+        assert detail is None
+    else:
+        assert expected in detail
+        assert "calimero-node-1" in detail
+
+
+def test_describe_unexpected_exit_ignores_missing_state():
+    """No state captured -> nothing claimed about how the node stopped."""
+    assert _describe_unexpected_exit(None) is None


### PR DESCRIPTION
## The failure this could not explain

[core run 32009600527, `Test (blob-cross-node-sizes)`](https://github.com/calimero-network/core/actions/runs/32009600527/job/95327825548) failed like this:

```
Step 2: Creating context on rust-blob-size-1
Context creation failed: create_context failed: Client error: error sending
request for url (http://localhost:2528/admin-api/contexts)
❌ Step 'Create Mesh' failed
```

That reads as an application error. It was not: the node process was gone. Establishing that took correlating three things by hand, none of which merobox said out loud —

1. the error is a **transport** failure, not an HTTP status and not a timeout, so the connection went away rather than the request being refused;
2. the surviving peer's log shows **both** of its TCP connections to node 1 closing at one instant with `UnexpectedEof` / "peer closed connection without sending TLS close_notify" — a dead process, since a hung node keeps its sockets open;
3. node 1's log ends mid-sentence inside a wasm compile, 940 lines short of where a healthy compile ends.

Docker knew the answer the whole time and was never asked. `merobox stop` even printed `Stopping 1 Calimero nodes` for a two-node fleet and nobody noticed.

## What this adds

- **`data/container-logs/<name>.state.json`** per node — `status`, `exit_code`, `oom_killed`, `error`, `started_at`, `finished_at`. A node killed by a signal writes no final log line, so the exit code is the only evidence of the cause: **137 + `oom_killed`** is memory, **139** is a segfault, **143** is an ordinary SIGTERM teardown, **0** is a node that chose to exit.

  On the stop path this is read **between `stop` and `remove`** — `stop` is what produces the exit code and `remove` is what destroys it, so a capture on either side of that window records nothing useful. Nothing is announced there: on that path the node stopped because it was told to.

- **A loud line on the export path**: `💀 <node> is not running: <cause>`, so the reason a scenario failed is in the run output rather than only in an artifact nobody downloads.

- **`export_node_logs()` now lists with `all=True`.** `containers.list()` defaults to running-only, so the one node worth looking at — the one whose death failed the scenario — was exactly the one being skipped. In the run above the dead node's log was captured only because Docker's status lagged its exit by ~200ms; that is a coin flip, not a mechanism.

## Tests

`merobox/tests/unit/test_docker_manager.py`, 8 new cases:

- an already-exited node is listed and captured, and the listing is asserted to pass `all=True`;
- a running node still gets a state file, and reading state does not disturb it;
- state capture is best-effort — a Docker error loses the state file, never the log;
- the stop path reads state in the right window, asserted as the call order `stop → reload → remove`;
- the exit-code→cause mapping, parametrised over running / OOM / 137 / 139 / 143 / 0 / other, plus the no-state case.

```
1393 passed in 61.55s     # full unit suite
black --check: 140 files would be left unchanged
ruff check: All checks passed
```

## Deliberately not in scope

- **A dead node is still never stopped or removed.** `stop_all_nodes()` lists running-only too, so an exited container is left behind; `nuke` picks it up (it fetches by name), which is why CI is unaffected. Changing that listing changes what `merobox stop --all` removes, which deserves its own PR.
- **`assert_log` selects nodes via `get_running_nodes()`**, so a log assertion silently skips a node that has died. Same class of bug, same reasoning — separate change, because widening it could newly match leftover containers from an earlier run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)