### PR TITLE
feat!: drop requester from every step that took it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **`requester` from every step that accepted it** — `set_member_auto_follow`,
+  `delete_group`, `delete_namespace`, `delete_context`, and the three
+  set-metadata steps. calimero-network/core#3492 deleted the field from the
+  admin request DTOs; the node resolves the acting identity from the
+  authenticated session, so the value had nowhere to go. Step configs allow
+  unknown keys, so leaving it would have meant a workflow that still names a
+  requester quietly acting as somebody else — a step that sets it now fails
+  validation with a message saying so, before anything runs. Requires
+  `calimero-client-py>=0.6.29`, which drops the same keyword
+
 ### Added
 
 - **Per-node exit state alongside the logs: `data/container-logs/<name>.state.json`.**

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.55"
+__version__ = "0.6.56"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1155,14 +1155,6 @@ class SetMemberAutoFollowStepConfig(BaseStepConfig):
     auto_follow_subgroups: bool = Field(
         ..., description="Self-admit into nested subgroups under this group"
     )
-    requester: Optional[str] = Field(
-        None,
-        description=(
-            "Optional public key of the identity to act on behalf of "
-            "(must be the group admin or the target itself); when omitted "
-            "the server resolves an admin signing key it holds."
-        ),
-    )
 
 
 class SetDefaultCapabilitiesStepConfig(BaseStepConfig):
@@ -1225,10 +1217,6 @@ class DeleteGroupStepConfig(BaseStepConfig):
     type: Literal["delete_group"] = "delete_group"
     node: str = Field(..., description="Target node")
     group_id: str = Field(..., description="Group ID to delete")
-    requester: Optional[str] = Field(
-        None,
-        description="Optional admin public key, required when deleting a group with admin-guarded state",
-    )
 
 
 class DeleteNamespaceStepConfig(BaseStepConfig):
@@ -1237,10 +1225,6 @@ class DeleteNamespaceStepConfig(BaseStepConfig):
     type: Literal["delete_namespace"] = "delete_namespace"
     node: str = Field(..., description="Target node")
     namespace_id: str = Field(..., description="Namespace ID to delete")
-    requester: Optional[str] = Field(
-        None,
-        description="Optional admin public key, required when deleting a namespace with admin-guarded state",
-    )
 
 
 class DeleteContextStepConfig(BaseStepConfig):
@@ -1249,10 +1233,6 @@ class DeleteContextStepConfig(BaseStepConfig):
     type: Literal["delete_context"] = "delete_context"
     node: str = Field(..., description="Target node")
     context_id: str = Field(..., description="Context ID to delete")
-    requester: Optional[str] = Field(
-        None,
-        description="Optional admin public key, required when deleting a context registered in a group",
-    )
 
 
 class UninstallApplicationStepConfig(BaseStepConfig):
@@ -1279,10 +1259,6 @@ class SetGroupMetadataStepConfig(BaseStepConfig):
     data: Optional[dict[str, str]] = Field(
         None, description="Arbitrary string->string metadata map"
     )
-    requester: Optional[str] = Field(
-        None,
-        description="Optional admin public key; required when the group is admin-guarded",
-    )
 
 
 class GetGroupMetadataStepConfig(BaseStepConfig):
@@ -1305,10 +1281,6 @@ class SetMemberMetadataStepConfig(BaseStepConfig):
     )
     data: Optional[dict[str, str]] = Field(
         None, description="Arbitrary string->string metadata map"
-    )
-    requester: Optional[str] = Field(
-        None,
-        description="Optional admin public key; required when the group is admin-guarded",
     )
 
 
@@ -1333,10 +1305,6 @@ class SetContextMetadataStepConfig(BaseStepConfig):
     )
     data: Optional[dict[str, str]] = Field(
         None, description="Arbitrary string->string metadata map"
-    )
-    requester: Optional[str] = Field(
-        None,
-        description="Optional admin public key; required when the group is admin-guarded",
     )
 
 

--- a/merobox/commands/bootstrap/steps/base.py
+++ b/merobox/commands/bootstrap/steps/base.py
@@ -139,6 +139,20 @@ class BaseStep:
     # Use them in subclass _validate_field_types() implementations.
     # =========================================================================
 
+    def _reject_removed_field(self, field: str, reason: str) -> None:
+        """Fail a step that still sets a field the node no longer accepts.
+
+        Step configs allow unknown keys, so a removed field would otherwise be
+        read by nobody and change nothing — and for a field that named who an
+        operation acted as, silently acting as somebody else is worse than
+        stopping. Errors here rather than at execution, so the workflow author
+        sees it before anything runs.
+        """
+        if field in self.config:
+            raise ValueError(
+                f"Step '{self._get_step_name()}': '{field}' was removed. {reason}"
+            )
+
     def _get_step_name(self) -> str:
         """Get the step name for error messages."""
         return self.config.get(

--- a/merobox/commands/bootstrap/steps/group_management.py
+++ b/merobox/commands/bootstrap/steps/group_management.py
@@ -14,6 +14,11 @@ from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.result import fail, ok
 from merobox.commands.utils import console
 
+REMOVED_REQUESTER = (
+    "The node resolves the acting identity from the authenticated session "
+    "(calimero-network/core#3492)."
+)
+
 
 class RemoveGroupMembersStep(BaseStep):
     """Remove members from a group."""
@@ -292,11 +297,7 @@ class SetMemberAutoFollowStep(BaseStep):
         for field in ("auto_follow_contexts", "auto_follow_subgroups"):
             if not isinstance(self.config.get(field), bool):
                 raise ValueError(f"Step '{step_name}': '{field}' must be a boolean")
-        requester = self.config.get("requester")
-        if requester is not None and not isinstance(requester, str):
-            raise ValueError(
-                f"Step '{step_name}': 'requester' must be a string when set"
-            )
+        self._reject_removed_field("requester", REMOVED_REQUESTER)
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -310,12 +311,6 @@ class SetMemberAutoFollowStep(BaseStep):
         )
         auto_follow_contexts = self.config["auto_follow_contexts"]
         auto_follow_subgroups = self.config["auto_follow_subgroups"]
-        raw_requester = self.config.get("requester")
-        requester = (
-            self._resolve_dynamic_value(raw_requester, workflow_results, dynamic_values)
-            if raw_requester is not None
-            else None
-        )
 
         try:
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
@@ -345,7 +340,6 @@ class SetMemberAutoFollowStep(BaseStep):
                 member_id=member_id,
                 auto_follow_contexts=auto_follow_contexts,
                 auto_follow_subgroups=auto_follow_subgroups,
-                requester=requester,
             )
             result = ok(api_result)
         except Exception as e:
@@ -693,10 +687,8 @@ class ListGroupContextsStep(BaseStep):
 class DeleteGroupStep(BaseStep):
     """Delete a group.
 
-    The optional `requester` field takes an admin public key. When deleting a
-    group that has members (or is in an admin-guarded state), the server
-    requires an explicit admin requester. Omit `requester` for groups that
-    don't require one.
+    Admin-guarded server-side. The node authorizes the call from the
+    authenticated session rather than from an identity named in the step.
     """
 
     def _get_required_fields(self) -> list[str]:
@@ -709,11 +701,7 @@ class DeleteGroupStep(BaseStep):
         for field in ("node", "group_id"):
             if not isinstance(self.config.get(field), str):
                 raise ValueError(f"Step '{step_name}': '{field}' must be a string")
-        requester = self.config.get("requester")
-        if requester is not None and not isinstance(requester, str):
-            raise ValueError(
-                f"Step '{step_name}': 'requester' must be a string if provided"
-            )
+        self._reject_removed_field("requester", REMOVED_REQUESTER)
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -722,16 +710,10 @@ class DeleteGroupStep(BaseStep):
         group_id = self._resolve_dynamic_value(
             self.config["group_id"], workflow_results, dynamic_values
         )
-        requester_raw = self.config.get("requester")
-        requester = (
-            self._resolve_dynamic_value(requester_raw, workflow_results, dynamic_values)
-            if requester_raw is not None
-            else None
-        )
         try:
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
             client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-            api_result = client.delete_group(group_id=group_id, requester=requester)
+            api_result = client.delete_group(group_id=group_id)
             result = ok(api_result)
         except Exception as e:
             result = fail("delete_group failed", error=e)
@@ -762,9 +744,8 @@ class DeleteGroupStep(BaseStep):
 class DeleteNamespaceStep(BaseStep):
     """Delete a namespace.
 
-    The optional `requester` field takes an admin public key. When deleting a
-    namespace with admin-guarded state, the server requires an explicit admin
-    requester.
+    Admin-guarded server-side. The node authorizes the call from the
+    authenticated session rather than from an identity named in the step.
     """
 
     def _get_required_fields(self) -> list[str]:
@@ -777,11 +758,7 @@ class DeleteNamespaceStep(BaseStep):
         for field in ("node", "namespace_id"):
             if not isinstance(self.config.get(field), str):
                 raise ValueError(f"Step '{step_name}': '{field}' must be a string")
-        requester = self.config.get("requester")
-        if requester is not None and not isinstance(requester, str):
-            raise ValueError(
-                f"Step '{step_name}': 'requester' must be a string if provided"
-            )
+        self._reject_removed_field("requester", REMOVED_REQUESTER)
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -790,18 +767,10 @@ class DeleteNamespaceStep(BaseStep):
         namespace_id = self._resolve_dynamic_value(
             self.config["namespace_id"], workflow_results, dynamic_values
         )
-        requester_raw = self.config.get("requester")
-        requester = (
-            self._resolve_dynamic_value(requester_raw, workflow_results, dynamic_values)
-            if requester_raw is not None
-            else None
-        )
         try:
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
             client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-            api_result = client.delete_namespace(
-                namespace_id=namespace_id, requester=requester
-            )
+            api_result = client.delete_namespace(namespace_id=namespace_id)
             result = ok(api_result)
         except Exception as e:
             result = fail("delete_namespace failed", error=e)
@@ -836,10 +805,9 @@ class DeleteNamespaceStep(BaseStep):
 class DeleteContextStep(BaseStep):
     """Delete a context.
 
-    The optional `requester` field takes an admin public key. Deleting a
-    context that is registered in a group requires an admin requester
-    (core/crates/context/src/handlers/delete_context.rs:54-68). Contexts
-    not attached to a group can be deleted without a requester.
+    Deleting a context registered in a group is admin-guarded; the node
+    authorizes the call from the authenticated session rather than from an
+    identity named in the step.
     """
 
     def _get_required_fields(self) -> list[str]:
@@ -852,11 +820,7 @@ class DeleteContextStep(BaseStep):
         for field in ("node", "context_id"):
             if not isinstance(self.config.get(field), str):
                 raise ValueError(f"Step '{step_name}': '{field}' must be a string")
-        requester = self.config.get("requester")
-        if requester is not None and not isinstance(requester, str):
-            raise ValueError(
-                f"Step '{step_name}': 'requester' must be a string if provided"
-            )
+        self._reject_removed_field("requester", REMOVED_REQUESTER)
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -865,18 +829,10 @@ class DeleteContextStep(BaseStep):
         context_id = self._resolve_dynamic_value(
             self.config["context_id"], workflow_results, dynamic_values
         )
-        requester_raw = self.config.get("requester")
-        requester = (
-            self._resolve_dynamic_value(requester_raw, workflow_results, dynamic_values)
-            if requester_raw is not None
-            else None
-        )
         try:
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)
             client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-            api_result = client.delete_context(
-                context_id=context_id, requester=requester
-            )
+            api_result = client.delete_context(context_id=context_id)
             result = ok(api_result)
         except Exception as e:
             result = fail("delete_context failed", error=e)

--- a/merobox/commands/bootstrap/steps/group_metadata.py
+++ b/merobox/commands/bootstrap/steps/group_metadata.py
@@ -19,14 +19,14 @@ from merobox.commands.utils import console
 _REQUIRED_CLIENT_VERSION = "0.6.10"
 
 
-def _build_metadata_body(name: Any, data: Any, requester: Any) -> str:
+def _build_metadata_body(name: Any, data: Any) -> str:
     """Build the JSON body for a set-metadata admin API call.
 
-    The server expects ``{"name": <str|null>, "data": {<str>:<str>...},
-    "requester": <pubkey|null>}``. ``requester`` is ``Option<PublicKey>``
-    server-side, so sending ``null`` when it's not provided is fine.
+    The server expects ``{"name": <str|null>, "data": {<str>:<str>...}}``. It
+    used to take a ``requester`` beside them; that field is gone, and the node
+    resolves the acting identity from the authenticated session.
     """
-    return json.dumps({"name": name, "data": data or {}, "requester": requester})
+    return json.dumps({"name": name, "data": data or {}})
 
 
 class _SetMetadataBase(BaseStep):
@@ -69,11 +69,11 @@ class _SetMetadataBase(BaseStep):
                     raise ValueError(
                         f"Step '{step_name}': 'data' must be a dict of string->string"
                     )
-        requester = self.config.get("requester")
-        if requester is not None and not isinstance(requester, str):
-            raise ValueError(
-                f"Step '{step_name}': 'requester' must be a string if provided"
-            )
+        self._reject_removed_field(
+            "requester",
+            "The node resolves the acting identity from the authenticated "
+            "session (calimero-network/core#3492).",
+        )
 
     def _log_target(self, group_id: str, extra_args: list[Any]) -> str:
         """Human-readable target description for the success log line.
@@ -121,13 +121,7 @@ class _SetMetadataBase(BaseStep):
             }
         else:
             data = data_raw
-        requester_raw = self.config.get("requester")
-        requester = (
-            self._resolve_dynamic_value(requester_raw, workflow_results, dynamic_values)
-            if isinstance(requester_raw, str)
-            else requester_raw
-        )
-        body = _build_metadata_body(name, data, requester)
+        body = _build_metadata_body(name, data)
 
         expected_failure = self._is_expected_failure()
 

--- a/merobox/tests/unit/test_group_steps.py
+++ b/merobox/tests/unit/test_group_steps.py
@@ -463,17 +463,37 @@ class TestMetadataSteps:
                 },
             )
 
-    def test_set_group_metadata_requester_wrong_type_raises(self):
+    def test_set_group_metadata_rejects_requester(self):
+        """`requester` is gone server-side, so setting it must stop the run.
+
+        Step configs allow unknown keys, so without an explicit rejection the
+        field would be read by nobody and the step would quietly act as
+        somebody else than the author asked for.
+        """
         from merobox.commands.bootstrap.steps.group_metadata import SetGroupMetadataStep
 
-        with pytest.raises(ValueError, match="requester"):
+        with pytest.raises(ValueError, match="'requester' was removed"):
             self._make(
                 SetGroupMetadataStep,
                 {
                     "type": "set_group_metadata",
                     "node": "n1",
                     "group_id": "g1",
-                    "requester": 5,
+                    "requester": "{{admin_key}}",
+                },
+            )
+
+    def test_delete_group_rejects_requester(self):
+        from merobox.commands.bootstrap.steps.group_management import DeleteGroupStep
+
+        with pytest.raises(ValueError, match="'requester' was removed"):
+            self._make(
+                DeleteGroupStep,
+                {
+                    "type": "delete_group",
+                    "node": "n1",
+                    "group_id": "g1",
+                    "requester": "{{admin_key}}",
                 },
             )
 

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -786,18 +786,6 @@ class TestBucketBStepSchemas:
         }
         assert config_module.validate_workflow_step(step, 0) == []
 
-    def test_valid_set_member_auto_follow_with_requester(self, config_module):
-        step = {
-            "type": "set_member_auto_follow",
-            "node": "calimero-node-1",
-            "group_id": "{{group_id}}",
-            "member_id": "{{p2_identity}}",
-            "auto_follow_contexts": False,
-            "auto_follow_subgroups": True,
-            "requester": "{{p1_identity}}",
-        }
-        assert config_module.validate_workflow_step(step, 0) == []
-
     def test_invalid_set_member_auto_follow_missing_flag(self, config_module):
         step = {
             "type": "set_member_auto_follow",
@@ -895,37 +883,6 @@ class TestBucketBStepSchemas:
         }
         assert config_module.validate_workflow_step(step, 0) == []
 
-    def test_valid_delete_context_with_requester(self, config_module):
-        step = {
-            "type": "delete_context",
-            "node": "calimero-node-1",
-            "context_id": "{{context_id}}",
-            "requester": "{{admin_key}}",
-        }
-        assert config_module.validate_workflow_step(step, 0) == []
-
-    def test_valid_delete_group_with_requester(self, config_module):
-        step = {
-            "type": "delete_group",
-            "node": "calimero-node-1",
-            "group_id": "{{group_id}}",
-            "requester": "{{admin_key}}",
-        }
-        assert config_module.validate_workflow_step(step, 0) == []
-
-    def test_valid_delete_namespace_with_requester(self, config_module):
-        step = {
-            "type": "delete_namespace",
-            "node": "calimero-node-1",
-            "namespace_id": "{{namespace_id}}",
-            "requester": "{{admin_key}}",
-        }
-        assert config_module.validate_workflow_step(step, 0) == []
-
-
-class TestMetadataStepSchemas:
-    """Schema validation for the *_metadata step types (core #2338)."""
-
     def test_valid_set_group_metadata(self, config_module):
         step = {
             # `name` is the step label; `record_name` is the metadata
@@ -981,7 +938,6 @@ class TestMetadataStepSchemas:
             "group_id": "{{group_id}}",
             "member_id": "{{p2_identity}}",
             "record_name": "Bob",
-            "requester": "{{admin_key}}",
         }
         assert config_module.validate_workflow_step(step, 0) == []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # The old ceiling was `<0.6.26`, because 0.6.26 decodes `join_namespace` into
     # a struct requiring `memberAccount` and no released node sent it. 0.11.0-rc.22
     # does, so the condition that cap was waiting for is met.
-    "calimero-client-py>=0.6.28",
+    "calimero-client-py>=0.6.29",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyYAML>=6.0.0
 # requiring `memberAccount`, which no released node sent. 0.11.0-rc.21 sends it
 # (core#3391), so the cap is lifted. The floor is 0.6.28: the first wheel built
 # against a core carrying `revokedIn` on the revoke-device response.
-calimero-client-py>=0.6.28
+calimero-client-py>=0.6.29
 aiohttp>=3.9.0
 toml>=0.10.2
 pydantic>=2.0.0

--- a/workflow-examples/workflow-cascade-namespace-example.yml
+++ b/workflow-examples/workflow-cascade-namespace-example.yml
@@ -116,13 +116,11 @@ steps:
     type: delete_group
     node: calimero-node-1
     group_id: '{{sub_id}}'
-    requester: '{{admin_key}}'
 
   - name: Delete Namespace
     type: delete_namespace
     node: calimero-node-1
     namespace_id: '{{ns_id}}'
-    requester: '{{admin_key}}'
 
   - name: Uninstall v1
     type: uninstall_application

--- a/workflow-examples/workflow-group-admin-example.yml
+++ b/workflow-examples/workflow-group-admin-example.yml
@@ -30,9 +30,7 @@ steps:
       namespace_id: namespaceId
 
   # Capture node 1's namespace-scoped public key. This is the admin
-  # identity for any subgroup created by node 1 inside this namespace,
-  # and the admin requester needed by delete_context / delete_group /
-  # delete_namespace during teardown.
+  # identity for any subgroup created by node 1 inside this namespace.
   - name: Get Node 1 Identity
     type: node_identity
     node: calimero-node-1
@@ -131,8 +129,8 @@ steps:
     outputs:
       group_meta: data
 
-  # Setting member metadata from node 2: the requester defaults to node 2's
-  # own namespace identity and targets its own account.
+  # Setting member metadata from node 2: the node acts as itself and
+  # targets its own account.
   - name: Set Member Metadata (from node 2)
     type: set_member_metadata
     node: calimero-node-2
@@ -241,29 +239,23 @@ steps:
     seconds: 10
 
   # Phase 7: Teardown
-  # Unlocked by calimero-client-py 0.6.2+, which exposes a `requester` field on
-  # delete_context/delete_group/delete_namespace. The server requires an admin
-  # requester to delete group-registered contexts and admin-guarded groups
-  # (core/crates/context/src/handlers/delete_context.rs:54-68). We pass p1_key,
-  # the public key node 1 holds in this subgroup — node 1 is the group admin
+  # Deleting group-registered contexts and admin-guarded groups is admin-only;
+  # node 1 is the group admin, and the node authorizes from its own session
   # because it created the subgroup.
   - name: Delete First Context
     type: delete_context
     node: calimero-node-1
     context_id: '{{ctx_id}}'
-    requester: '{{p1_admin_key}}'
 
   - name: Delete Subgroup
     type: delete_group
     node: calimero-node-1
     group_id: '{{group_id}}'
-    requester: '{{p1_admin_key}}'
 
   - name: Delete Namespace
     type: delete_namespace
     node: calimero-node-1
     namespace_id: '{{namespace_id}}'
-    requester: '{{p1_admin_key}}'
 
   - name: Uninstall Application
     type: uninstall_application

--- a/workflow-examples/workflow-group-upgrade-example.yml
+++ b/workflow-examples/workflow-group-upgrade-example.yml
@@ -11,7 +11,7 @@ description: >
   are needed to exercise the upgrade path.
 
   This workflow does not exercise register_group_signing_key because the
-  server auto-stores the node-held signing key when the requester is the
+  server auto-stores the node-held signing key when the caller is the
   node's own identity. That step type is still schema-validated and
   dispatched; a future key-rotation workflow can cover it end-to-end.
 
@@ -100,25 +100,20 @@ steps:
     expected_failure: true
 
   # Phase 5: Teardown
-  # Unlocked by calimero-client-py 0.6.2+ (requester field on
-  # delete_context/delete_group/delete_namespace).
   - name: Delete Context
     type: delete_context
     node: calimero-node-1
     context_id: '{{ctx_id}}'
-    requester: '{{p1_admin_key}}'
 
   - name: Delete Subgroup
     type: delete_group
     node: calimero-node-1
     group_id: '{{group_id}}'
-    requester: '{{p1_admin_key}}'
 
   - name: Delete Namespace
     type: delete_namespace
     node: calimero-node-1
     namespace_id: '{{namespace_id}}'
-    requester: '{{p1_admin_key}}'
 
   - name: Uninstall v1
     type: uninstall_application

--- a/workflow-examples/workflow-set-member-auto-follow-example.yml
+++ b/workflow-examples/workflow-set-member-auto-follow-example.yml
@@ -38,9 +38,8 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  # Both halves of node 1's identity: `account` names the member being changed,
-  # `publicKey` signs for the change. `requester` stayed a key when the member
-  # path moved to accounts, so the self-set step below needs one of each.
+  # Node 1's account names the member being changed. The node signs for the
+  # change itself, from the authenticated session.
   - name: Get Node 1 Identity
     type: node_identity
     node: calimero-node-1
@@ -141,14 +140,12 @@ steps:
     member_id: '{{p2_account}}'
     auto_follow_contexts: false
     auto_follow_subgroups: false
-    requester: '{{p2_identity}}'
 
   - name: Wait for Self-Set Gossip
     type: wait
     seconds: 5
 
-  # Phase 4: Admin acts on itself (explicit requester = admin identity).
-  # Exercises the optional `requester` field with a non-default value.
+  # Phase 4: Admin acts on itself.
 
   - name: Admin Self-Sets contexts-only on Self
     type: set_member_auto_follow
@@ -157,4 +154,3 @@ steps:
     member_id: '{{p1_admin_account}}'
     auto_follow_contexts: true
     auto_follow_subgroups: false
-    requester: '{{p1_admin_key}}'


### PR DESCRIPTION
Link 4 of the chain retiring `governanceOp` (calimero-network/core#3485). **Blocked on calimero-network/calimero-client-py#93** — the pin here moves to `calimero-client-py>=0.6.29`, which does not exist until that merges and publishes.

## Why

core#3492 deleted `requester` from every admin request DTO; the node resolves the acting identity from the authenticated session. client-py 0.6.29 drops the matching keyword, so the seven steps still passing it would raise `TypeError` on the next release.

Steps affected: `set_member_auto_follow`, `delete_group`, `delete_namespace`, `delete_context`, and the three set-metadata variants — the last of which hand-built `"requester": null` straight into its JSON body.

## Why it errors instead of just going away

`BaseStepConfig` is `extra="allow"`, so deleting the plumbing alone would leave a workflow that still sets `requester:` validating cleanly, running, and acting as **somebody other than the author named** — with nothing said. For a field that decided the acting identity, silent substitution is worse than stopping.

So a step that still sets it now fails validation up front:

```
Step 'delete a group': 'requester' was removed. The node resolves the acting
identity from the authenticated session (calimero-network/core#3492).
```

`_reject_removed_field` lives on `BaseStep`, so the next field retired this way inherits the behaviour rather than re-implementing it.

No scenario in core sets `requester` (the single grep hit is a comment about `GroupKeyRequest`), so nothing in the E2E suite needs editing.

## Pin

`calimero-client-py>=0.6.29` in **both** `requirements.txt` and `pyproject.toml` — the release binary resolves from requirements.txt, so bumping only one ships the old client. Version bumped to 0.6.56.

## Tests

The four schema tests that pinned `requester` as a valid key are deleted with the field; two rejection tests replace the type-check test that covered it.

Unit suite: **1351 passed, 38 failed** — and the same 38 fail on `master` with these changes stashed, so **no new failures**. `make format-check` and `ruff` clean.

## Sequence

1. calimero-network/core#3530 — serde shim ✅ merged
2. calimero-network/calimero-client-py#93 — catch-up, publishes 0.6.29
3. **this PR** → publishes 0.6.56
4. core: bump `MIN_MEROBOX` in `.github/actions/setup-merobox`
5. calimero-network/core#3528 — the removal, lands green

🤖 Generated with [Claude Code](https://claude.com/claude-code)