### PR TITLE
fix: name the cause when the client cannot decode a node response

### DIFF
--- a/merobox/commands/result.py
+++ b/merobox/commands/result.py
@@ -53,6 +53,29 @@ def fail(
     return result
 
 
+# A response the node ACCEPTED but the client could not parse almost always
+# means calimero-client-py is older than the node's admin API — not that the
+# call itself failed. The raw text ("Client error: error decoding response
+# body") reads like a node or network fault and sends people digging through
+# node logs that show the operation succeeding, so name the usual cause here.
+_DECODE_FAILURE_MARKER = "error decoding response body"
+
+_DECODE_FAILURE_HINT = (
+    "hint: the node answered, but calimero-client-py could not parse the "
+    "response — usually because the client is older than the node's admin API. "
+    "Check the installed version with `pip show calimero-client-py`, then "
+    "upgrade merobox (`pipx upgrade merobox`, or `pip install -U merobox`), "
+    "which raises the client floor with it."
+)
+
+
+def explain_client_error(message: str) -> str:
+    """Append a cause hint to error messages that are opaque on their own."""
+    if _DECODE_FAILURE_MARKER in message:
+        return f"{message}\n{_DECODE_FAILURE_HINT}"
+    return message
+
+
 def format_error(error: Exception) -> dict[str, Any]:
     """Format an exception with type, message, and traceback string.
 
@@ -71,7 +94,7 @@ def format_error(error: Exception) -> dict[str, Any]:
     """
     result = {
         "type": type(error).__name__,
-        "message": str(error),
+        "message": explain_client_error(str(error)),
         "traceback": "".join(
             traceback.format_exception(type(error), error, error.__traceback__)
         ),

--- a/merobox/tests/unit/test_result_hints.py
+++ b/merobox/tests/unit/test_result_hints.py
@@ -1,0 +1,31 @@
+"""The client/node version-skew hint on otherwise opaque errors."""
+
+from merobox.commands.result import explain_client_error, fail
+
+
+class TestClientDecodeHint:
+    def test_decode_failure_gets_a_cause_hint(self):
+        # The node ACCEPTS the request and logs success; only the client's
+        # parse of the response fails. Without a hint this reads like a node
+        # fault and sends people into node logs that show it working.
+        msg = explain_client_error("Client error: error decoding response body")
+        assert "error decoding response body" in msg, "must keep the original text"
+        assert "calimero-client-py" in msg
+        assert "older than the node" in msg
+
+    def test_unrelated_errors_are_untouched(self):
+        for msg in [
+            "Connection refused",
+            "Invalid invitation JSON: key must be a string at line 1 column 2",
+            "",
+        ]:
+            assert explain_client_error(msg) == msg
+
+    def test_hint_reaches_the_message_steps_actually_print(self):
+        # Steps render exception["message"], so the hint has to survive fail()
+        # rather than only existing in the helper.
+        result = fail(
+            "join_namespace failed",
+            error=RuntimeError("Client error: error decoding response body"),
+        )
+        assert "calimero-client-py" in result["exception"]["message"]

--- a/setup.py
+++ b/setup.py
@@ -45,20 +45,15 @@ setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.9",
-    install_requires=[
-        "click>=8.0.0",
-        "docker>=6.0.0",
-        "rich>=13.0.0",
-        "PyYAML>=6.0.0",
-        "calimero-client-py>=0.6.28",
-        "aiohttp>=3.8.0",
-        "toml>=0.10.2",
-        "base58>=2.1.0",
-        "ed25519>=1.5",
-        "py-near>=1.1.0",
-        "requests>=2.31.0",
-        "tqdm>=4.65.0",
-    ],
+    # Dependencies are declared ONLY in pyproject.toml.
+    #
+    # This file used to carry a second copy in `install_requires`, which the
+    # build backend ignores (PEP 621: with a [project] table, pyproject wins).
+    # The copy drifted anyway — at the 0.6.41 release it pinned
+    # calimero-client-py>=0.6.11 while pyproject said >=0.6.19, and it still
+    # listed ed25519 and py-near, which nothing imports and no release has
+    # shipped since the move to pyproject. Dead metadata that disagrees with
+    # the real thing is worse than none: it invites a fix to the wrong file.
     extras_require={
         "dev": [
             "build",


### PR DESCRIPTION
## What happened

A workflow against **merod 0.11.0-rc.24** failed its `join_namespace` step with:

```
Join namespace failed on node-2: Client error: error decoding response body
```

The node had **accepted** the join and logged `Joined namespace successfully`. Only the client's parse of the reply failed, because the installed `calimero-client-py` was 0.6.19 and predated the response shape:

```json
{"data":{"groupId":"…","memberIdentity":"…","memberAccount":"…","governanceOp":""}}
```

Upgrading the client to 0.6.29 made the identical workflow pass, with nothing else changed.

**No version constraint is changed here.** master's `calimero-client-py>=0.6.29` floor is already correct and already released in 0.6.56 — a current install is fine. What this fixes is what a *stale* install tells you.

## Why the message deserves fixing

It names neither the client nor a version, and reads like a node or network fault. Following it leads into node logs that show the operation succeeding, which makes it look like a merobox or merod bug. The actual fix is a one-line upgrade.

`format_error` is the chokepoint every step's failure passes through, so the hint is added there and covers every step rather than just the join:

```
Client error: error decoding response body
hint: the node answered, but calimero-client-py could not parse the response —
usually because the client is older than the node's admin API. Check the
installed version with `pip show calimero-client-py`, then upgrade merobox
(`pipx upgrade merobox`, or `pip install -U merobox`), which raises the client
floor with it.
```

Matching is narrow (the `error decoding response body` marker); unrelated errors pass through untouched, which is covered by a test.

## The second change: dead dependency metadata in `setup.py`

While diagnosing the above I fixed the wrong file first, because `setup.py` carried a **second copy** of the dependency list that the build backend ignores — with a `[project]` table, pyproject.toml wins (PEP 621).

It had drifted accordingly. At the 0.6.41 release:

| | `setup.py` | `pyproject.toml` | published wheel |
|---|---|---|---|
| `calimero-client-py` | `>=0.6.11` | `>=0.6.19` | **`>=0.6.19`** |

The wheel followed pyproject, confirming `setup.py`'s list never shipped. It also still listed `ed25519` and `py-near`, which nothing in `merobox/` imports, and omitted `pydantic` and `filelock`, which it does.

A second copy that disagrees with the real one invites a fix to the file that does not ship, so the list is removed and a comment explains where dependencies live.

**Verified**: built the wheel before and after — `Requires-Dist` is byte-identical, still `calimero-client-py>=0.6.29`, with `pydantic`/`filelock` present and no `ed25519`/`py-near`.

## Verification

- `python3 -m pytest merobox/tests/unit` — **1392 passed**
- `ruff check` — clean; `black --check` — clean (142 files unchanged)
- The originally-failing two-node workflow now completes on merobox 0.6.56 + client 0.6.29
