### PR TITLE
fix(manager): stop the cluster-peers gate reading 401 as zero peers

### DIFF
--- a/merobox/commands/auth.py
+++ b/merobox/commands/auth.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import aiohttp
+import requests
 from calimero_client_py import get_token_cache_dir, get_token_cache_path
 from rich.console import Console
 
@@ -48,6 +49,78 @@ AUTH_METHOD_NONE = "none"
 
 # Token expiry buffer (refresh if token expires within this many seconds)
 TOKEN_EXPIRY_BUFFER_SECONDS = 60
+
+
+def build_token_request_payload(
+    node_url: str,
+    username: str,
+    password: str,
+    bootstrap_secret: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build the ``POST /auth/token`` body for a username/password login.
+
+    Shared by the async :meth:`AuthManager.authenticate` and the blocking
+    :func:`fetch_access_token_blocking` so the server contract lives in one
+    place. ``bootstrap_secret`` defaults from ``MERO_AUTH_BOOTSTRAP_SECRET`` and
+    is omitted from the payload when unset — logins for existing users never
+    need it.
+    """
+    if bootstrap_secret is None:
+        bootstrap_secret = os.environ.get("MERO_AUTH_BOOTSTRAP_SECRET")
+
+    provider_data = {"username": username, "password": password}
+    if bootstrap_secret:
+        provider_data["bootstrap_secret"] = bootstrap_secret
+
+    return {
+        "auth_method": AUTH_METHOD_USER_PASSWORD,
+        "public_key": username,
+        "client_name": node_url.rstrip("/"),
+        "timestamp": int(time.time()),
+        "provider_data": provider_data,
+    }
+
+
+def extract_access_token(response_data: Any) -> Optional[str]:
+    """Pull the access token out of a wrapped or unwrapped token response."""
+    if not isinstance(response_data, dict):
+        return None
+    data = response_data.get("data")
+    if not isinstance(data, dict):
+        data = response_data
+    token = data.get("access_token") or data.get("accessToken")
+    return token if isinstance(token, str) and token else None
+
+
+def fetch_access_token_blocking(
+    node_url: str,
+    username: str,
+    password: str,
+    timeout: float = DEFAULT_READ_TIMEOUT,
+) -> Optional[str]:
+    """Mint an access token with a blocking ``POST /auth/token``.
+
+    The async :meth:`AuthManager.authenticate` is the normal path. This exists
+    for callers that run outside an event loop — node startup, before any step
+    has executed — where ``asyncio.run`` is not safe to assume. Returns ``None``
+    on any failure; callers are expected to treat that as "could not
+    authenticate", never as "the node said no".
+    """
+    normalized_url = node_url.rstrip("/")
+    try:
+        resp = requests.post(
+            f"{normalized_url}{AUTH_TOKEN_ENDPOINT}",
+            json=build_token_request_payload(normalized_url, username, password),
+            timeout=timeout,
+        )
+    except Exception:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        return extract_access_token(resp.json())
+    except ValueError:
+        return None
 
 
 @dataclass
@@ -237,21 +310,9 @@ class AuthManager:
         # Normalize node URL (remove trailing slash)
         normalized_url = node_url.rstrip("/")
 
-        if bootstrap_secret is None:
-            bootstrap_secret = os.environ.get("MERO_AUTH_BOOTSTRAP_SECRET")
-
-        provider_data = {"username": username, "password": password}
-        if bootstrap_secret:
-            provider_data["bootstrap_secret"] = bootstrap_secret
-
-        # Build the authentication payload per server contract
-        payload = {
-            "auth_method": AUTH_METHOD_USER_PASSWORD,
-            "public_key": username,
-            "client_name": normalized_url,
-            "timestamp": int(time.time()),
-            "provider_data": provider_data,
-        }
+        payload = build_token_request_payload(
+            normalized_url, username, password, bootstrap_secret
+        )
 
         auth_endpoint = f"{normalized_url}{AUTH_TOKEN_ENDPOINT}"
 

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -11,13 +11,14 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import docker
 import requests
 from rich.console import Console
 from rich.table import Table
 
+from merobox.commands.auth import fetch_access_token_blocking
 from merobox.commands.cleanup_mixin import CleanupMixin
 from merobox.commands.config_utils import (
     apply_bootstrap_nodes,
@@ -205,6 +206,19 @@ def _describe_unexpected_exit(summary: Optional[dict]) -> Optional[str]:
     )
 
 
+class PeersProbe(NamedTuple):
+    """Outcome of asking one node for its connected-peer count.
+
+    ``count`` is ``None`` when the probe could not get an answer. ``auth_blocked``
+    marks the subset of those where the endpoint demanded credentials we do not
+    have: that verdict will not change by waiting, so a caller polling for
+    connectivity can stop early instead of burning its whole timeout.
+    """
+
+    count: Optional[int]
+    auth_blocked: bool = False
+
+
 class DockerManager(CleanupMixin):
     """Manages Calimero nodes in Docker containers."""
 
@@ -218,6 +232,10 @@ class DockerManager(CleanupMixin):
                 signals externally.
         """
         self._init_cleanup_state()
+
+        # node name -> admin-API bearer token, populated lazily by the
+        # connected-peers probe so a polling gate authenticates once per node.
+        self._peers_probe_tokens: dict[str, str] = {}
 
         try:
             self.client = docker.from_env()
@@ -1780,18 +1798,67 @@ class DockerManager(CleanupMixin):
             data = data.get("peers")
         return len(data) if isinstance(data, list) else 0
 
-    def _node_connected_peers(self, node_name: str) -> int:
-        """Best-effort connected-peer count for a node (0 on any error)."""
+    def _mint_peers_probe_token(self, node_name: str, port: int) -> Optional[str]:
+        """Log in for a fresh admin-API token, or ``None`` if we cannot.
+
+        Uses the admin credentials merobox forwards into every node: `merod init`
+        creates that root key before the node listens, so this works even though
+        no workflow step has run yet. The token is cached per node so a polling
+        gate logs in once rather than once per tick; cache invalidation is the
+        caller's business.
+        """
+        username = os.getenv("MERO_AUTH_ADMIN_USER")
+        password = os.getenv("MERO_AUTH_ADMIN_PASSWORD")
+        if not username or not password:
+            return None
+
+        token = fetch_access_token_blocking(
+            f"http://localhost:{port}", username, password
+        )
+        if token:
+            self._peers_probe_tokens[node_name] = token
+        return token
+
+    def _probe_connected_peers(self, node_name: str) -> "PeersProbe":
+        """Ask a node how many peers it is connected to.
+
+        Returns a :class:`PeersProbe` whose ``count`` is ``None`` whenever the
+        question could not be answered — the endpoint is authenticated and we
+        hold no usable token, the node is not listening yet, the request timed
+        out. That is deliberately distinct from a node that answered "0": only
+        the latter is evidence about connectivity.
+        """
         port = self.get_node_rpc_port(node_name)
         if not port:
-            return 0
-        try:
-            resp = requests.get(f"http://localhost:{port}/admin-api/peers", timeout=5)
+            return PeersProbe(None)
+
+        url = f"http://localhost:{port}/admin-api/peers"
+        token = self._peers_probe_tokens.get(node_name)
+        for attempt in range(2):
+            headers = {"Authorization": f"Bearer {token}"} if token else None
+            try:
+                resp = requests.get(url, timeout=5, headers=headers)
+            except Exception:
+                return PeersProbe(None)
+
             if resp.status_code == 200:
-                return self._peers_count_from_response(resp.json())
-        except Exception:
-            pass
-        return 0
+                try:
+                    return PeersProbe(self._peers_count_from_response(resp.json()))
+                except ValueError:
+                    return PeersProbe(None)
+
+            if resp.status_code not in (401, 403):
+                return PeersProbe(None)
+
+            # Authenticated endpoint. Try once to obtain a token; if we cannot,
+            # waiting will not help — say so instead of polling to the deadline.
+            if attempt == 0:
+                self._peers_probe_tokens.pop(node_name, None)
+                token = self._mint_peers_probe_token(node_name, port)
+                if not token:
+                    return PeersProbe(None, auth_blocked=True)
+
+        return PeersProbe(None, auth_blocked=True)
 
     def wait_for_cluster_peers(
         self,
@@ -1802,13 +1869,20 @@ class DockerManager(CleanupMixin):
     ) -> bool:
         """Block until every node reports at least ``expected_peers`` peers.
 
-        This is the merobox-side precondition check for #231: with siblings
-        wired as bootstrap peers before ``merod run`` subscribes to topics, full
-        connectivity is a strong predictor of a non-empty gossipsub mesh. If the
-        cluster never connects, return ``False`` so the caller can fail the run
-        — a deterministic startup failure instead of a half-connected cluster
-        limping through a load test. (Gossipsub mesh peer count is not exposed
-        via the admin API; connected-peer count is the observable proxy.)
+        With siblings wired as bootstrap peers before ``merod run`` subscribes to
+        topics, full connectivity is a strong predictor of a non-empty gossipsub
+        mesh. If the cluster demonstrably never connects, return ``False`` so the
+        caller can fail the run — a deterministic startup failure instead of a
+        half-connected cluster limping through a load test. (Gossipsub mesh peer
+        count is not exposed via the admin API; connected-peer count is the
+        observable proxy.)
+
+        Only a node that *answers* with too few peers counts as a failure. A node
+        we could not question — authenticated endpoint with no usable token, not
+        listening yet, timed out — leaves connectivity unverified, which is
+        reported as a warning and does not fail the run. Conflating the two once
+        made this gate unpassable on every embedded-auth fleet: the 401 scored as
+        "zero peers" for every node while the cluster was in fact fully meshed.
 
         ``timeout`` defaults to :data:`DEFAULT_CLUSTER_PEER_TIMEOUT`, overridable
         via the ``MEROBOX_CLUSTER_PEER_TIMEOUT`` env var.
@@ -1829,23 +1903,54 @@ class DockerManager(CleanupMixin):
         )
         deadline = time.monotonic() + timeout
         while True:
-            short = {
-                name: n
-                for name in node_names
-                if (n := self._node_connected_peers(name)) < expected_peers
-            }
-            if not short:
+            short: dict[str, int] = {}
+            unknown: list[str] = []
+            auth_blocked = False
+            for name in node_names:
+                probe = self._probe_connected_peers(name)
+                if probe.count is None:
+                    unknown.append(name)
+                    auth_blocked = auth_blocked or probe.auth_blocked
+                elif probe.count < expected_peers:
+                    short[name] = probe.count
+
+            if not short and not unknown:
                 console.print("[green]✓ Cluster fully connected[/green]")
                 return True
+
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
+            # A node that answered with too few peers is real evidence and is
+            # worth waiting on. A node that could not answer is not evidence
+            # either way, and when the reason is missing credentials no amount
+            # of waiting fixes it.
+            nothing_left_to_learn = auth_blocked and not short
+            if remaining > 0 and not nothing_left_to_learn:
+                time.sleep(min(interval, remaining))
+                continue
+
+            if short:
                 detail = ", ".join(f"{name}={n}" for name, n in short.items())
                 console.print(
                     f"[red]✗ Cluster did not reach {expected_peers} peer(s) per "
                     f"node within {int(timeout)}s (short: {detail})[/red]"
                 )
                 return False
-            time.sleep(min(interval, remaining))
+
+            # Nothing contradicted the cluster being connected; we just could
+            # not see it. Say so and let the workflow's own steps be the judge,
+            # rather than failing a run on an unanswered question.
+            reason = (
+                "the peers endpoint requires credentials that are not available"
+                if auth_blocked
+                else "the peers endpoint did not respond"
+            )
+            console.print(
+                f"[yellow]⚠️  Cluster connectivity unverified for "
+                f"{len(unknown)}/{len(node_names)} node(s) — {reason}. "
+                f"Continuing; workflow steps will surface a disconnected "
+                f"cluster.[/yellow]"
+            )
+            return True
 
     def _graceful_stop_container(
         self,

--- a/merobox/tests/unit/test_docker_manager.py
+++ b/merobox/tests/unit/test_docker_manager.py
@@ -1,6 +1,7 @@
 import json
 import signal
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import docker
@@ -1059,6 +1060,114 @@ def test_wait_for_cluster_peers_false_on_timeout(mock_docker, mock_requests):
         )
         is False
     )
+
+
+def _manager_with_two_nodes():
+    manager = DockerManager(enable_signal_handlers=False)
+    manager.node_rpc_ports = {"calimero-node-1": 2528, "calimero-node-2": 2529}
+    return manager
+
+
+def _response(status_code, payload=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("merobox.commands.manager.requests")
+@patch("docker.from_env")
+def test_wait_for_cluster_peers_does_not_fail_on_401(mock_docker, mock_requests):
+    """An authenticated peers endpoint we cannot open leaves connectivity
+    unverified — it is not evidence that the cluster is disconnected."""
+    mock_docker.return_value = MagicMock()
+    mock_requests.get.return_value = _response(401)
+
+    manager = _manager_with_two_nodes()
+
+    assert (
+        manager.wait_for_cluster_peers(
+            ["calimero-node-1", "calimero-node-2"],
+            expected_peers=1,
+            timeout=5.0,
+            interval=0.01,
+        )
+        is True
+    )
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("merobox.commands.manager.requests")
+@patch("docker.from_env")
+def test_wait_for_cluster_peers_returns_early_when_auth_blocked(
+    mock_docker, mock_requests
+):
+    """With no credentials to obtain a token, waiting cannot change the verdict,
+    so the gate must not sit on its timeout."""
+    mock_docker.return_value = MagicMock()
+    mock_requests.get.return_value = _response(403)
+
+    manager = _manager_with_two_nodes()
+
+    started = time.monotonic()
+    assert (
+        manager.wait_for_cluster_peers(
+            ["calimero-node-1"], expected_peers=1, timeout=30.0, interval=5.0
+        )
+        is True
+    )
+    assert time.monotonic() - started < 5.0
+
+
+@patch.dict(
+    "os.environ",
+    {"MERO_AUTH_ADMIN_USER": "dev", "MERO_AUTH_ADMIN_PASSWORD": "dev-password"},
+    clear=True,
+)
+@patch("merobox.commands.manager.fetch_access_token_blocking")
+@patch("merobox.commands.manager.requests")
+@patch("docker.from_env")
+def test_peers_probe_authenticates_then_reads_count(
+    mock_docker, mock_requests, mock_fetch_token
+):
+    """A 401 triggers one login from the forwarded admin credentials, and the
+    retry carries the bearer token."""
+    mock_docker.return_value = MagicMock()
+    mock_fetch_token.return_value = "token-abc"
+    mock_requests.get.side_effect = [_response(401), _response(200, {"count": 3})]
+
+    manager = _manager_with_two_nodes()
+    probe = manager._probe_connected_peers("calimero-node-1")
+
+    assert probe.count == 3
+    assert probe.auth_blocked is False
+    assert mock_requests.get.call_args_list[0].kwargs["headers"] is None
+    assert mock_requests.get.call_args_list[1].kwargs["headers"] == {
+        "Authorization": "Bearer token-abc"
+    }
+    # cached, so a polling gate logs in once rather than once per tick
+    assert manager._peers_probe_tokens["calimero-node-1"] == "token-abc"
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("merobox.commands.manager.requests")
+@patch("docker.from_env")
+def test_peers_probe_distinguishes_zero_from_unknown(mock_docker, mock_requests):
+    """`count == 0` is an answer; an unreachable node is not."""
+    mock_docker.return_value = MagicMock()
+    manager = _manager_with_two_nodes()
+
+    mock_requests.get.return_value = _response(200, {"count": 0})
+    assert manager._probe_connected_peers("calimero-node-1").count == 0
+
+    mock_requests.get.side_effect = OSError("connection refused")
+    probe = manager._probe_connected_peers("calimero-node-1")
+    assert probe.count is None
+    assert probe.auth_blocked is False
+
+    # a node with no known RPC port cannot be asked either
+    assert manager._probe_connected_peers("calimero-node-9").count is None
 
 
 @patch.dict("os.environ", {"MEROBOX_LEGACY_CLUSTER_NETWORKING": "1"})


### PR DESCRIPTION
Fixes #342.

## What was wrong

`wait_for_cluster_peers` — the startup gate that blocks until every cluster node reports `count - 1` connected peers — polled `/admin-api/peers` with no `Authorization` header and scored any non-200 as zero peers. On an embedded-auth fleet that endpoint answers `401`, so the gate read `0` for every node however well-connected the cluster actually was, burned its full 60s timeout, and failed node management.

Measured on a live 2-node fleet: unauthenticated `401`; with a bearer token `200 {"count":1}`; `/admin-api/health` needs no auth. On an 8-node fleet the gate reported `0` for all eight while the node logs over the same window showed 232 connections established, 232 identify exchanges and no `Mesh low` — every node had its 7 peers.

## The fix, in two halves

Authenticating alone would have left the same trap armed for the next auth change, so both halves matter:

**Ask with credentials.** A `401`/`403` now triggers one login from the admin credentials merobox already forwards into every node (`MERO_AUTH_ADMIN_USER` / `MERO_AUTH_ADMIN_PASSWORD`), and the retry carries the bearer token. `merod init` mints that root key before the node listens, so this works at gate time — which is *before* any `login` step has run, and is why the on-disk token cache cannot be relied on here. The login is a blocking `POST /auth/token` because the gate runs outside any event loop; the payload is built by a helper now shared with the async `AuthManager.authenticate` so the server contract stays in one place.

**Stop scoring "could not ask" as "answered zero".** The probe returns `PeersProbe(count=None)` when the question could not be answered — authenticated endpoint with no usable token, node not listening yet, request timed out — which is distinct from a node that answered `0`. The gate still fails a run on a real `200` reporting too few peers, unchanged and loud. An unverifiable cluster now warns and continues, letting the workflow's own steps be the judge rather than failing a run on an unanswered question. When the reason is missing credentials the gate returns immediately instead of polling to a deadline that cannot change the verdict.

## Verification on real nodes

The scenario that could not previously get past node management — core's `mesh-soak-8node` with `mdns: false` and `restart: true`, 8 embedded-auth nodes — now runs green end to end:

```
✓ Wired bootstrap peers and restarted 8 cluster node(s)
Waiting for cluster connectivity (≥7 peer(s) per node, up to 60s)...
✓ Cluster fully connected
...
🎉 Workflow 'E2E KV Store - 8-Node Gossipsub Mesh Soak' completed successfully!
```

Before this change, the same workflow: `✗ Cluster did not reach 7 peer(s) per node within 60s (short: e2e-node-1=0, e2e-node-2=0, … e2e-node-8=0)` → `❌ Node management failed`.

The fleet's live `config.toml` carried `mdns = false`, and all 8 node logs show **zero** mDNS dials with 15–26 kad `RoutingUpdated` each — so the gate was reading genuine bootstrap-derived connectivity, not multicast.

## Why this matters beyond the gate

This gate sits in front of `_wire_cluster_bootstrap_peers`, the only non-mDNS discovery wiring the harness has, making that path unreachable on any embedded-auth fleet. Unblocking it is what let calimero-network/core#3525 demonstrate an 8-node scenario converging with mDNS disabled — the evidence that issue needed for its third resolution criterion.

## Tests

- `merobox/tests/unit/test_docker_manager.py`: **70 passed**, including 4 new cases — a `401` does not fail the gate; an auth-blocked gate returns without burning its timeout; the login-then-retry path carries the bearer token and caches it per node; `count == 0` stays distinct from unknown and from a node with no known RPC port.
- Full unit suite: **1375 passed, 18 failed**. The 18 are pre-existing and unrelated — `assert_migration_complete requires calimero-client-py >= 0.6.19` in `test_migrations_v2_steps.py`, a local dependency-version mismatch. Verified as an identical failure set on the pristine tree at the same commit (1371 passed, same 18 failed), so this branch adds 4 passing tests and changes nothing else.
- `black --check merobox/` and `ruff check merobox/` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
