### PR TITLE
chore(release): 0.6.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `containers.list()` defaults to running-only, so the one node worth looking at
   when a scenario fails because a node died was precisely the one dropped from the
   capture. It now lists with `all=True`.
+- **The cluster connectivity gate no longer reads an authenticated peers endpoint
+  as zero peers.** `wait_for_cluster_peers` polled `/admin-api/peers` with no
+  credentials and scored every non-200 as "0 connected peers". On an embedded-auth
+  fleet that endpoint answers 401, so the gate reported 0 for every node however
+  well-connected the cluster was, burned its full timeout, and failed node
+  management — while the node logs showed the fleet fully meshed. A 401/403 now
+  triggers one login from the `MERO_AUTH_ADMIN_*` credentials merobox already
+  forwards into each node (`merod init` mints that root key before the node
+  listens, so this works at gate time, before any `login` step has run) and the
+  retry carries the bearer token.
+
+  The gate also stops treating "could not ask" as "answered zero". An unanswerable
+  probe leaves connectivity *unverified*, which warns and continues; a node that
+  really answers with too few peers still fails the run loudly, as before. When the
+  reason is missing credentials the gate returns immediately rather than polling to
+  a deadline that cannot change the verdict.
+
+  This unblocks `_wire_cluster_bootstrap_peers`, which sits behind the gate and was
+  therefore unreachable on any embedded-auth fleet. That wiring is the only
+  non-mDNS peer discovery the harness has, and with it an 8-node fleet converges
+  with `mdns: false` — see calimero-network/core#3525, where mDNS turned out to be
+  the sole discovery path in 80 of 88 e2e scenarios.
 
 ## [0.6.53] - 2026-08-12
 

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.56"
+__version__ = "0.6.57"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Releases the cluster-peers gate fix from #344.

`v0.6.56` was tagged from #341 on 2026-08-18, two days before #344 merged, so the gate fix currently sits on `master` in no published release. That matters because core's e2e suite installs merobox **only** from a published release, verified against its `.sha256` — `setup-merobox` deliberately has no "install an unreleased artifact" path, on the reasoning that an artifact installed by name is a binary every downstream step then executes with access to node data dirs. Its own comment spells out the consequence: *"Testing against an unshipped merobox means shipping it first, to a pre-release if need be."*

So this bump is what lets calimero-network/core#3525 proceed: its mDNS-free scenarios need `_wire_cluster_bootstrap_peers`, which was unreachable behind the broken gate.

Contents: `__version__` 0.6.56 → 0.6.57, plus the changelog entry for the fix. No code changes. The changelog entry goes under `[Unreleased]` alongside the entries 0.6.56 shipped with, matching how this repo has been keeping it rather than restructuring past sections.

Dependency pins checked while here: `requirements.txt` and `pyproject.toml` both still say `calimero-client-py>=0.6.28`, so the release binary (built from `requirements.txt`) and the wheel agree — no repeat of the 0.6.54 drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)