### PR TITLE
build(deps): require a client that can send an account to add_group_members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`add_group_members` accepts an ACCOUNT in `identity`.** Requires
+  `calimero-client-py>=0.6.30`. Below that the bundled client parsed the field
+  as a bs58 key with `.expect`, so an account - the only id
+  `list_group_members` returns, and what every other member-addressing step
+  takes - panicked the extension module before any request was sent. The step
+  itself passes the value through untouched, so nothing here changed but the
+  floor. Core accepts both encodings as of calimero-network/core#3573; they
+  cannot collide, since an account is 64 hex characters and bs58 over 32 bytes
+  reaches at most 44.
+- The workflow docs said to use a key for `add_group_members` and an account
+  everywhere else. They now say to use an account everywhere, with the key
+  documented as the fallback for a subject the node holds no account for yet.
+- `remove_group_members`' schema description said "member public keys". It has
+  taken accounts since the client started parsing `Vec<AccountId>`.
+
 ### Removed
 
 - **`requester` from every step that accepted it** — `set_member_auto_follow`,

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -453,8 +453,8 @@ The encodings differ on purpose, so passing one where the other belongs is a `40
 
 Read them from `join_namespace` (`memberIdentity` / `memberAccount`) or `node_identity` (`publicKey` / `accountId`).
 
-Use the **account** for `member_id` on every member-addressing step, and for `remove_group_members`.
-Use the **key** for `add_group_members`' `identity` and for any `requester` field.
+Use the **account** everywhere: `member_id` on every member-addressing step, `remove_group_members`, and `add_group_members`' `identity`.
+That last one also accepts a **key**, for a subject the node holds no account for yet; it is resolved to an account on apply and refused if bound to none.
 
 ### add_group_members
 
@@ -464,14 +464,14 @@ Add members with roles to a group.
 | --- | --- | --- | --- |
 | `node` | yes | string | Target node. |
 | `group_id` | yes | string | Group to add to. |
-| `members` | yes | list of `{identity, role}` | Members and their roles. `identity` is a signing key, not an account. |
+| `members` | yes | list of `{identity, role}` | Members and their roles. `identity` is an account, or a signing key for a subject with no account here yet. |
 
 ```yaml
 - type: add_group_members
   node: calimero-node-1
   group_id: '{{group_id}}'
   members:
-    - identity: '{{member_pub}}'
+    - identity: '{{member_account}}'
       role: Member
 ```
 

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1067,7 +1067,9 @@ class AddGroupMembersStepConfig(BaseStepConfig):
     node: str = Field(..., description="Target node")
     group_id: str = Field(..., description="Group ID to add members to")
     members: list[dict[str, str]] = Field(
-        ..., description="List of members with identity and role"
+        ...,
+        description="List of members with identity and role. identity is an "
+        "account, or a signing key for a subject with no account here yet",
     )
 
 
@@ -1077,7 +1079,7 @@ class RemoveGroupMembersStepConfig(BaseStepConfig):
     type: Literal["remove_group_members"] = "remove_group_members"
     node: str = Field(..., description="Target node")
     group_id: str = Field(..., description="Group ID to remove members from")
-    members: list[str] = Field(..., description="List of member public keys to remove")
+    members: list[str] = Field(..., description="List of member accounts to remove")
 
 
 class ListGroupMembersStepConfig(BaseStepConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # The old ceiling was `<0.6.26`, because 0.6.26 decodes `join_namespace` into
     # a struct requiring `memberAccount` and no released node sent it. 0.11.0-rc.22
     # does, so the condition that cap was waiting for is met.
-    "calimero-client-py>=0.6.29",
+    "calimero-client-py>=0.6.30",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyYAML>=6.0.0
 # requiring `memberAccount`, which no released node sent. 0.11.0-rc.21 sends it
 # (core#3391), so the cap is lifted. The floor is 0.6.28: the first wheel built
 # against a core carrying `revokedIn` on the revoke-device response.
-calimero-client-py>=0.6.29
+calimero-client-py>=0.6.30
 aiohttp>=3.9.0
 toml>=0.10.2
 pydantic>=2.0.0


### PR DESCRIPTION
## Summary

`add_group_members`' `identity` was parsed by the bundled `calimero-client-py` as a bs58 public key with `.expect("invalid identity")`. An account is 64 hex, so it failed that parse and took the extension module down before any request was sent:

```
thread '<unnamed>' panicked at src/client.rs:2213:22:
invalid identity: InvalidPublicKey(DecodeError(BufferTooSmall))
```

That matters because an account is the only id `list_group_members` returns, and it is what every other member-addressing step already takes (`member_id` on role, capabilities, metadata and auto-follow is a pass-through string). So no workflow could express "add somebody I just read out of the member listing to a sub-scope" - the shape of every nested-membership feature.

Core accepts both encodings as of calimero-network/core#3573, and calimero-client-py 0.6.30 (calimero-network/calimero-client-py#94) reads whichever it is given. The encodings cannot collide: an account is 64 hex characters and bs58 over 32 bytes reaches at most 44.

### Changes

- `calimero-client-py>=0.6.29` -> `>=0.6.30`, in **both** `requirements.txt` and `pyproject.toml`. The released binary is built from `requirements.txt`, so the two deciding separately is how they drifted before (#337).
- `AddGroupMembersStep` needs no change - it already passes `identity` through untouched.
- Docs: the id-space guidance said to use a key for `add_group_members` and an account everywhere else. It now says account everywhere, with the key documented as the fallback for a subject the node holds no account for yet. The example uses an account.
- `RemoveGroupMembersStepConfig.members` described "member public keys". It takes accounts.

## Test plan

- `calimero-client-py` 0.6.30 is published and installable from PyPI.
- 0.6.30 verified directly before this bump: built with `maturin develop`, `add_group_members` called against a dead URL so only the parse is exercised. A 64-hex account and a bs58 key both get past it and fail on the network; a malformed id raises `ValueError` naming the string. The account case is the one that previously panicked.
- `config.py` parses; the remaining changes are prose and a schema description.

## Follow-up

A release is needed before this reaches anyone: core pins a `MIN_MEROBOX` floor and will raise it to whatever version carries this, which unblocks an e2e scenario there for adding a member to a restricted subgroup by account.