### PR TITLE
chore(release): 0.6.58

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.57"
+__version__ = "0.6.58"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Ships `calimero-network/merobox#346`: a released binary whose bundled `calimero-client-py` is >= 0.6.30, so `add_group_members` can finally be given an account.

That is the only commit since 0.6.57 (`23c087ba`), so this release contains exactly that change.

## Why it needs a release, not just the merge

`#346` moved the floor in `requirements.txt` and `pyproject.toml`, but the distributed binary is built with `pip install -r requirements.txt` then PyInstaller. Until a release runs, every consumer still gets the binary built at 0.6.57 - and that one resolved `calimero-client-py` before 0.6.30 existed on PyPI (0.6.57 was published at 10:50 UTC on 2026-08-20, 0.6.30 landed at 11:13), so it carries 0.6.29.

At 0.6.29 and below the binding parsed the field as:

```rust
.parse::<identity::PublicKey>()
.expect("invalid identity");
```

A 64-hex account is not valid bs58-over-32-bytes, so that `.expect` panics the extension module before any request is sent. A panic there is not a step failure, so no `expected_failure` can absorb it and a workflow cannot express the call at all. 0.6.30 parses `MemberIdentity`, which reads either encoding and raises `ValueError` on a malformed one.

## Downstream

`calimero-network/core#3581` adds an e2e scenario that adds a member to a Restricted subgroup by account. Its `MIN_MEROBOX` is set to 0.6.58, so it is currently red on the floor check by design and goes green once this ships.

## Note on the changelog

Deliberately not rolled here. `CHANGELOG.md` has no headings for 0.6.54, 0.6.55, 0.6.56 or 0.6.57 - those four releases were cut with their notes left under `## [Unreleased]`, so opening a `## [0.6.58]` heading over that block now would attribute four releases' worth of changes to this one. #346's entries are already in `[Unreleased]` and need nothing added, and the pipeline sources its notes from `generate_release_notes: true` rather than this file, so nothing here blocks the release.

Untangling it is worth a separate pass, ideally as a release-pipeline step rather than a convention people have to remember.

## What merging does

`release.yml` diffs `__version__` against `HEAD~1`, so merging this auto-tags `v0.6.58`, builds the binaries, creates the GitHub release, and publishes to PyPI. The PyPI publish cannot be undone or the version reused.