### PR TITLE
feat(mesh): export the namespace and per-node accounts create_mesh already holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `remove_group_members`' schema description said "member public keys". It has
   taken accounts since the client started parsing `Vec<AccountId>`.
 
+### Added
+
+- **`create_mesh` hands back the namespace and per-node accounts it already
+  holds.** The step does the whole bootstrap - namespace, context, invitations,
+  joins - but exported only `contextId` and `memberPublicKey`. Without the
+  namespace id no workflow could create a subgroup under the namespace it had
+  just made; without the account no step could address a member by the id
+  `list_group_members` returns. `namespaceId` is now capturable via `outputs:`
+  alongside the context fields, and each join exports
+  `member_account_<node>` beside the existing `member_identity_<node>`
+
 ### Removed
 
 - **`requester` from every step that accepted it** — `set_member_auto_follow`,

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1537,6 +1537,23 @@ step.
 | `params` | no | string | Init params as a JSON string. |
 | `path` | no | string | WASM path to pre-install on joining nodes. |
 
+`outputs:` captures from the context response, plus `namespaceId` folded in:
+
+| Source | Meaning |
+| --- | --- |
+| `contextId` | The context the mesh was built around. |
+| `memberPublicKey` | The context node's member key. |
+| `namespaceId` | The namespace the context lives under - needed by `create_group_in_namespace`. |
+
+The per-node ids the joins produce are set directly, since `outputs:` sees one
+response and there is one join per node:
+
+| Variable | Meaning |
+| --- | --- |
+| `{{namespace_id}}` | Same namespace id, for workflows not using `outputs:`. |
+| `{{member_account_<node>}}` | Account the node's key speaks for - what `list_group_members` returns and what every member-addressing step takes. |
+| `{{member_identity_<node>}}` | The node's member public key. |
+
 ```yaml
 - type: create_mesh
   context_node: calimero-node-1
@@ -1547,6 +1564,20 @@ step.
   outputs:
     context_id: contextId
     member_public_key: memberPublicKey
+    namespace_id: namespaceId
+
+- type: create_group_in_namespace
+  node: calimero-node-1
+  namespace_id: '{{namespace_id}}'
+  group_name: private-channel
+  outputs:
+    subgroup_id: groupId
+
+- type: update_member_role
+  node: calimero-node-1
+  group_id: '{{subgroup_id}}'
+  member_id: '{{member_account_calimero-node-2}}'
+  role: Member
 ```
 
 ### fuzzy_test

--- a/merobox/commands/bootstrap/steps/mesh.py
+++ b/merobox/commands/bootstrap/steps/mesh.py
@@ -81,6 +81,11 @@ class CreateMeshStep(BaseStep):
                 "context_member_public_key_{node_name}",
                 "Public key of the context member",
             ),
+            (
+                "namespaceId",
+                "namespace_id_{node_name}",
+                "Namespace the mesh was created under",
+            ),
         ]
 
     def _is_binary_mode(self) -> bool:
@@ -338,7 +343,14 @@ class CreateMeshStep(BaseStep):
 
         step_key = f"context_{context_node}"
         workflow_results[step_key] = context_data
-        self._export_variables(context_data, context_node, dynamic_values)
+        # The namespace and the context come from two calls; `outputs:` sees one
+        # payload, so the namespace id is folded into the context response.
+        self._export_variables(
+            {**context_data, "namespaceId": namespace_id},
+            context_node,
+            dynamic_values,
+        )
+        dynamic_values.setdefault(f"namespace_id_{context_node}", namespace_id)
 
         if "outputs" not in self.config:
             if "context_id" not in dynamic_values:
@@ -542,6 +554,19 @@ class CreateMeshStep(BaseStep):
                 if nodes_to_process_count == 1:
                     dynamic_values["memberIdentity"] = member_identity
                 console.print(f"  [green]✓ Member identity: {member_identity}[/green]")
+
+            # Member-addressing endpoints take the account, not the key: the two
+            # encodings deliberately differ so one cannot stand in for the other.
+            member_account = (
+                join_nested.get("memberAccount")
+                if isinstance(join_nested, dict)
+                else None
+            )
+            if member_account:
+                dynamic_values[f"member_account_{node_name}"] = member_account
+                if nodes_to_process_count == 1:
+                    dynamic_values.setdefault("member_account", member_account)
+                console.print(f"  [green]✓ Member account: {member_account}[/green]")
 
             connected_nodes.append(node_name)
 

--- a/merobox/commands/bootstrap/steps/mesh.py
+++ b/merobox/commands/bootstrap/steps/mesh.py
@@ -344,12 +344,16 @@ class CreateMeshStep(BaseStep):
         step_key = f"context_{context_node}"
         workflow_results[step_key] = context_data
         # The namespace and the context come from two calls; `outputs:` sees one
-        # payload, so the namespace id is folded into the context response.
-        self._export_variables(
-            {**context_data, "namespaceId": namespace_id},
-            context_node,
-            dynamic_values,
+        # payload, so the namespace id is folded into the context response. It
+        # has to go into the unwrapped body: a success payload nests under
+        # `data`, and the export pass reads that level, not the envelope.
+        _, context_body = self._unwrap_response(context_data)
+        export_payload = (
+            {**context_body, "namespaceId": namespace_id}
+            if isinstance(context_body, dict)
+            else context_data
         )
+        self._export_variables(export_payload, context_node, dynamic_values)
         dynamic_values.setdefault(f"namespace_id_{context_node}", namespace_id)
 
         if "outputs" not in self.config:

--- a/merobox/tests/unit/test_mesh_exports.py
+++ b/merobox/tests/unit/test_mesh_exports.py
@@ -1,11 +1,15 @@
 """`create_mesh` has to hand back the ids it already holds.
 
 The step does the whole bootstrap - namespace, context, invitations, joins -
-but used to export only the context id and member public key. Without the
-namespace id no workflow can create a subgroup under the namespace it just
-made, and without the per-node account no step can address a member by the id
+but exported only the context id and member public key. Without the namespace
+id no workflow can create a subgroup under the namespace it just made, and
+without the per-node account no step can address a member by the id
 `list_group_members` returns. Both values pass through the step's own calls, so
 dropping them forced scenarios back onto a hand-rolled nine-step preamble.
+
+A real node nests a success payload under `data`, and the export pass reads
+that level rather than the envelope. Both shapes are exercised here: a mock
+that only ever returned the flat one hid a capture failure CI then caught.
 """
 
 import asyncio
@@ -21,26 +25,27 @@ ACCOUNT_2 = "a" * 64
 ACCOUNT_3 = "b" * 64
 MESH = "merobox.commands.bootstrap.steps.mesh"
 
-
-def _config(**overrides):
-    cfg = {
-        "type": "create_mesh",
-        "name": "Create mesh",
-        "context_node": "n1",
-        "application_id": "app-id",
-        "nodes": ["n1", "n2", "n3"],
-    }
-    cfg.update(overrides)
-    return cfg
-
-
-def _client():
-    client = MagicMock()
-    client.create_namespace.return_value = {"data": {"namespaceId": NAMESPACE_ID}}
-    client.create_context.return_value = {
+# The keys a real merod returns from create_context, per the CI run that caught
+# the envelope bug: nested under `data`, and naming the namespace `groupId`.
+NESTED_CONTEXT_RESPONSE = {
+    "data": {
         "contextId": CONTEXT_ID,
         "memberPublicKey": "ctx-key",
+        "groupId": NAMESPACE_ID,
+        "groupCreated": False,
     }
+}
+FLAT_CONTEXT_RESPONSE = {"contextId": CONTEXT_ID, "memberPublicKey": "ctx-key"}
+CONTEXT_SHAPES = [
+    pytest.param(NESTED_CONTEXT_RESPONSE, id="nested-under-data"),
+    pytest.param(FLAT_CONTEXT_RESPONSE, id="flat"),
+]
+
+
+def _client(context_response):
+    client = MagicMock()
+    client.create_namespace.return_value = {"data": {"namespaceId": NAMESPACE_ID}}
+    client.create_context.return_value = context_response
     return client
 
 
@@ -53,14 +58,24 @@ def _join_result(account):
     }
 
 
-@pytest.fixture
-def dynamic_values():
+def _run_mesh(context_response, outputs=None, nodes=("n1", "n2", "n3")):
+    """Drive execute() with every API call mocked; returns dynamic_values."""
     accounts = iter([ACCOUNT_2, ACCOUNT_3])
-    step = CreateMeshStep(_config())
+    config = {
+        "type": "create_mesh",
+        "name": "Create mesh",
+        "context_node": "n1",
+        "application_id": "app-id",
+        "nodes": list(nodes),
+    }
+    if outputs is not None:
+        config["outputs"] = outputs
+
+    step = CreateMeshStep(config)
     step._resolve_node_for_client = MagicMock(side_effect=lambda n: (f"http://{n}", n))
 
     with (
-        patch(f"{MESH}.get_client_for_rpc_url", return_value=_client()),
+        patch(f"{MESH}.get_client_for_rpc_url", return_value=_client(context_response)),
         patch(
             f"{MESH}.generate_identity_via_admin_api",
             new=AsyncMock(return_value={"success": True, "data": {"publicKey": "pk"}}),
@@ -84,47 +99,35 @@ def dynamic_values():
         return values
 
 
-def test_namespace_id_is_exported(dynamic_values):
-    assert dynamic_values["namespace_id"] == NAMESPACE_ID
-    assert dynamic_values["namespace_id_n1"] == NAMESPACE_ID
+@pytest.mark.parametrize("context_response", CONTEXT_SHAPES)
+def test_namespace_id_is_exported(context_response):
+    values = _run_mesh(context_response)
+    assert values["namespace_id"] == NAMESPACE_ID
+    assert values["namespace_id_n1"] == NAMESPACE_ID
 
 
-def test_member_account_is_exported_per_node(dynamic_values):
-    assert dynamic_values["member_account_n2"] == ACCOUNT_2
-    assert dynamic_values["member_account_n3"] == ACCOUNT_3
+@pytest.mark.parametrize("context_response", CONTEXT_SHAPES)
+def test_member_account_is_exported_per_node(context_response):
+    values = _run_mesh(context_response)
+    assert values["member_account_n2"] == ACCOUNT_2
+    assert values["member_account_n3"] == ACCOUNT_3
 
 
-def test_existing_exports_are_unchanged(dynamic_values):
-    assert dynamic_values["context_id"] == CONTEXT_ID
-    assert dynamic_values["member_public_key"] == "ctx-key"
+@pytest.mark.parametrize("context_response", CONTEXT_SHAPES)
+def test_existing_exports_are_unchanged(context_response):
+    values = _run_mesh(context_response)
+    assert values["context_id"] == CONTEXT_ID
+    assert values["member_public_key"] == "ctx-key"
 
 
-def test_outputs_can_capture_the_namespace_id():
-    step = CreateMeshStep(_config(outputs={"ns": "namespaceId", "ctx": "contextId"}))
-    step._resolve_node_for_client = MagicMock(side_effect=lambda n: (f"http://{n}", n))
-
-    with (
-        patch(f"{MESH}.get_client_for_rpc_url", return_value=_client()),
-        patch(
-            f"{MESH}.generate_identity_via_admin_api",
-            new=AsyncMock(return_value={"success": True, "data": {"publicKey": "pk"}}),
-        ),
-        patch(
-            f"{MESH}.create_namespace_invitation_via_admin_api",
-            new=AsyncMock(
-                return_value={
-                    "success": True,
-                    "data": {"data": {"inviter_signature": "sig"}},
-                }
-            ),
-        ),
-        patch(
-            f"{MESH}.join_namespace_via_admin_api",
-            new=AsyncMock(return_value=_join_result(ACCOUNT_2)),
-        ),
-    ):
-        values: dict = {}
-        assert asyncio.run(step.execute({}, values)) is True
-
+@pytest.mark.parametrize("context_response", CONTEXT_SHAPES)
+def test_outputs_can_capture_the_namespace_id(context_response):
+    """The capture CI caught: folding namespaceId into the envelope instead of
+    the body left it invisible to the export pass on a real response."""
+    values = _run_mesh(
+        context_response,
+        outputs={"ns": "namespaceId", "ctx": "contextId"},
+        nodes=("n1", "n2"),
+    )
     assert values["ns"] == NAMESPACE_ID
     assert values["ctx"] == CONTEXT_ID

--- a/merobox/tests/unit/test_mesh_exports.py
+++ b/merobox/tests/unit/test_mesh_exports.py
@@ -1,0 +1,130 @@
+"""`create_mesh` has to hand back the ids it already holds.
+
+The step does the whole bootstrap - namespace, context, invitations, joins -
+but used to export only the context id and member public key. Without the
+namespace id no workflow can create a subgroup under the namespace it just
+made, and without the per-node account no step can address a member by the id
+`list_group_members` returns. Both values pass through the step's own calls, so
+dropping them forced scenarios back onto a hand-rolled nine-step preamble.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.mesh import CreateMeshStep
+
+NAMESPACE_ID = "ns-hex"
+CONTEXT_ID = "ctx-hex"
+ACCOUNT_2 = "a" * 64
+ACCOUNT_3 = "b" * 64
+MESH = "merobox.commands.bootstrap.steps.mesh"
+
+
+def _config(**overrides):
+    cfg = {
+        "type": "create_mesh",
+        "name": "Create mesh",
+        "context_node": "n1",
+        "application_id": "app-id",
+        "nodes": ["n1", "n2", "n3"],
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _client():
+    client = MagicMock()
+    client.create_namespace.return_value = {"data": {"namespaceId": NAMESPACE_ID}}
+    client.create_context.return_value = {
+        "contextId": CONTEXT_ID,
+        "memberPublicKey": "ctx-key",
+    }
+    return client
+
+
+def _join_result(account):
+    return {
+        "success": True,
+        "data": {
+            "data": {"memberIdentity": f"id-{account[:4]}", "memberAccount": account}
+        },
+    }
+
+
+@pytest.fixture
+def dynamic_values():
+    accounts = iter([ACCOUNT_2, ACCOUNT_3])
+    step = CreateMeshStep(_config())
+    step._resolve_node_for_client = MagicMock(side_effect=lambda n: (f"http://{n}", n))
+
+    with (
+        patch(f"{MESH}.get_client_for_rpc_url", return_value=_client()),
+        patch(
+            f"{MESH}.generate_identity_via_admin_api",
+            new=AsyncMock(return_value={"success": True, "data": {"publicKey": "pk"}}),
+        ),
+        patch(
+            f"{MESH}.create_namespace_invitation_via_admin_api",
+            new=AsyncMock(
+                return_value={
+                    "success": True,
+                    "data": {"data": {"inviter_signature": "sig"}},
+                }
+            ),
+        ),
+        patch(
+            f"{MESH}.join_namespace_via_admin_api",
+            new=AsyncMock(side_effect=lambda *a, **k: _join_result(next(accounts))),
+        ),
+    ):
+        values: dict = {}
+        assert asyncio.run(step.execute({}, values)) is True
+        return values
+
+
+def test_namespace_id_is_exported(dynamic_values):
+    assert dynamic_values["namespace_id"] == NAMESPACE_ID
+    assert dynamic_values["namespace_id_n1"] == NAMESPACE_ID
+
+
+def test_member_account_is_exported_per_node(dynamic_values):
+    assert dynamic_values["member_account_n2"] == ACCOUNT_2
+    assert dynamic_values["member_account_n3"] == ACCOUNT_3
+
+
+def test_existing_exports_are_unchanged(dynamic_values):
+    assert dynamic_values["context_id"] == CONTEXT_ID
+    assert dynamic_values["member_public_key"] == "ctx-key"
+
+
+def test_outputs_can_capture_the_namespace_id():
+    step = CreateMeshStep(_config(outputs={"ns": "namespaceId", "ctx": "contextId"}))
+    step._resolve_node_for_client = MagicMock(side_effect=lambda n: (f"http://{n}", n))
+
+    with (
+        patch(f"{MESH}.get_client_for_rpc_url", return_value=_client()),
+        patch(
+            f"{MESH}.generate_identity_via_admin_api",
+            new=AsyncMock(return_value={"success": True, "data": {"publicKey": "pk"}}),
+        ),
+        patch(
+            f"{MESH}.create_namespace_invitation_via_admin_api",
+            new=AsyncMock(
+                return_value={
+                    "success": True,
+                    "data": {"data": {"inviter_signature": "sig"}},
+                }
+            ),
+        ),
+        patch(
+            f"{MESH}.join_namespace_via_admin_api",
+            new=AsyncMock(return_value=_join_result(ACCOUNT_2)),
+        ),
+    ):
+        values: dict = {}
+        assert asyncio.run(step.execute({}, values)) is True
+
+    assert values["ns"] == NAMESPACE_ID
+    assert values["ctx"] == CONTEXT_ID

--- a/workflow-examples/workflow-mesh-example.yml
+++ b/workflow-examples/workflow-mesh-example.yml
@@ -29,6 +29,17 @@ steps:
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey
+      namespace_id: namespaceId
+
+  # The namespace the mesh built. Creating a subgroup under it is what the
+  # export exists for, so the workflow does it rather than only asserting.
+  - name: Create a Subgroup Under the Mesh Namespace
+    type: create_group_in_namespace
+    node: calimero-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: mesh-example-subgroup
+    outputs:
+      subgroup_id: groupId
 
   - name: Execute Contract Call - Set Key-Value from Node 1
     type: call
@@ -111,8 +122,11 @@ steps:
       - "is_set({{member_public_key}})"
       - "is_set({{public_key_calimero-node-2}})"
       - "is_set({{public_key_calimero-node-3}})"
+      - "is_set({{namespace_id}})"
+      - "is_set({{subgroup_id}})"
       - "{{context_id}} != ''"
       - "{{member_public_key}} != ''"
+      - "{{subgroup_id}} != {{namespace_id}}"
 
   - name: Assert Cross-Node Operations
     type: assert

--- a/workflow-examples/workflow-mesh-exports-example.yml
+++ b/workflow-examples/workflow-mesh-exports-example.yml
@@ -1,0 +1,96 @@
+description: >
+  Pins the ids create_mesh exports. The step runs the whole namespace bootstrap
+  internally, so the namespace id and each joiner's account reach a workflow
+  only through its exports - a capture that quietly returns nothing surfaces as
+  an unresolved placeholder several steps later, or not at all.
+name: Create Mesh Exports Example
+
+force_pull_image: true
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: mesh-exports-node
+
+steps:
+  - name: Install Application on Node 1
+    type: install_application
+    node: mesh-exports-node-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Mesh
+    type: create_mesh
+    context_node: mesh-exports-node-1
+    application_id: "{{app_id}}"
+    path: ./workflow-examples/res/kv_store.wasm
+    nodes:
+      - mesh-exports-node-2
+      - mesh-exports-node-3
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+      namespace_id: namespaceId
+
+  - name: Assert the mesh exported its ids
+    type: assert
+    statements:
+      - "is_set({{context_id}})"
+      - "is_set({{namespace_id}})"
+      # 64 hex rather than merely non-empty: an account handed back in the
+      # key's encoding would still be "set" and fail only much later.
+      - "regex({{member_account_mesh-exports-node-2}}, ^[0-9a-f]{64}$)"
+      - "regex({{member_account_mesh-exports-node-3}}, ^[0-9a-f]{64}$)"
+
+  # Nothing below the namespace root is reachable without this id, which is the
+  # whole reason it has to come out of the step.
+  - name: Create a subgroup under the exported namespace
+    type: create_group_in_namespace
+    node: mesh-exports-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: mesh-exports-subgroup
+    outputs:
+      subgroup_id: groupId
+
+  - name: Assert the subgroup was born under the namespace
+    type: assert
+    statements:
+      - "is_set({{subgroup_id}})"
+      - "{{subgroup_id}} != {{namespace_id}}"
+
+  - name: Wait for namespace governance to settle
+    type: wait_for_sync
+    group_id: "{{namespace_id}}"
+    nodes:
+      - mesh-exports-node-1
+      - mesh-exports-node-2
+    timeout: 60
+    check_interval: 2
+
+  # The real test of the account capture: member-addressing endpoints reject a
+  # signing key, so this step only passes if a genuine account was exported.
+  - name: Address node 2 by its exported account
+    type: update_member_role
+    node: mesh-exports-node-1
+    group_id: "{{namespace_id}}"
+    member_id: "{{member_account_mesh-exports-node-2}}"
+    role: Admin
+
+  - name: Read the namespace membership back
+    type: list_group_members
+    node: mesh-exports-node-1
+    group_id: "{{namespace_id}}"
+    outputs:
+      ns_members: members
+
+  - name: Assert membership is keyed by the exported account
+    type: assert
+    statements:
+      - "contains({{ns_members}}, {{member_account_mesh-exports-node-2}})"
+      - "contains({{ns_members}}, {{member_account_mesh-exports-node-3}})"
+
+stop_all_nodes: true
+restart: false
+wait_timeout: 60


### PR DESCRIPTION
Closes #348

## Summary

`create_mesh` does the whole namespace bootstrap in one step - create namespace, create context, pre-install on joiners, invite each node, join - but exported only `contextId` and `memberPublicKey`. Two ids its own calls already produce were dropped:

- **`namespaceId`** - without it a workflow cannot create a subgroup under the namespace it just made, so anything below the namespace root was out of reach.
- **`memberAccount`** - `join_namespace` returns and exports it; `create_mesh` performs the same joins internally and discarded it. It is the id `list_group_members` returns and the one every member-addressing step takes.

Both are now available:

- `namespaceId` is folded into the payload `outputs:` captures from, so it sits beside `contextId` and `memberPublicKey`. `{{namespace_id}}` and `{{namespace_id_<context_node>}}` are set for workflows not using `outputs:`.
- Each join exports `member_account_<node>` alongside the existing `member_identity_<node>`, following the per-node naming the other steps use.

Accounts are per-node, so they are not `outputs:` captures - `outputs:` sees a single response and there is one join per node. Asking for `memberAccount` there fails loudly with `OutputCaptureError` rather than binding nothing.

Purely additive - no existing export changes, and no coordination with `calimero-client-py` is needed since `create_mesh` already receives both values internally.

## Test plan

**Real workflows in CI**, since a mocked join response cannot show that a node returns `memberAccount` in that shape:

- `workflow-examples/workflow-mesh-exports-example.yml` (new) captures `namespaceId`, creates a subgroup with it, and addresses a member by the exported account via `update_member_role`, then reads membership back and asserts it contains that account. An export returning nothing fails the run instead of passing an unresolved placeholder onward. Account assertions match `^[0-9a-f]{64}$` rather than `is_set`, so an account handed back in the key's encoding is caught.
- `workflow-mesh-example.yml` gains the `namespaceId` capture and the subgroup it unlocks.
- Both run in **both matrices**. `0.11.0-rc.24` carries the account rename (core#3391) and its namespace join handler returns `member_account`, which is the call `create_mesh` drives internally - so the released merod the binary lane downloads is new enough. Verified both matrix expressions resolve as intended.

Unit coverage alongside it:

- `merobox/tests/unit/test_mesh_exports.py` drives `execute()` with the API calls mocked and asserts `namespace_id`, `namespace_id_<node>`, and `member_account_<node>` land in `dynamic_values`, that the existing `context_id` / `member_public_key` exports are unchanged, and that `outputs: { ns: namespaceId }` binds.
- Verified the tests fail against the unpatched step: 3 of 4 fail without the change, pass with it.
- Full unit suite: no new failures. 28 failures are pre-existing on `master` and come from a stale `calimero-client-py` in the local venv (0.3.0 vs the pinned floor), not from this change.
- `black --check` and `ruff check` clean.