### PR TITLE
fix(config)!: reject unknown step keys instead of silently dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documented as the fallback for a subject the node holds no account for yet.
 - `remove_group_members`' schema description said "member public keys". It has
   taken accounts since the client started parsing `Vec<AccountId>`.
+- **Step configs reject unknown keys.** `BaseStepConfig` allowed extras, so a
+  misspelled field validated and was then never read - the workflow stated an
+  intent, the harness ignored it, and the run went green. 21 scenarios in
+  calimero-network/core passed `group_alias` to `create_group_in_namespace`
+  (which declares `group_name`) across 27 occurrences, and every subgroup they
+  created was born unnamed. `create_mesh` took a `capability` in 29 more, left
+  over from the invite flow the namespace flow replaced. Both now fail
+  validation before any container starts, with a message naming the key and the
+  nearest valid field, so `group_alias` points at `group_name`. `bootstrap
+  validate` reports the same thing the runner does, instead of passing
+  workflows the runner then rejects. Every field the executors read is now
+  declared, including ones the schema had never listed: `path` on
+  `create_mesh`, `params` on `create_context`, `url` on `install_application`
+  (which was unusable, `path` being required), `args` on `script` and
+  `list_proposals`, `mode` / `failure_mode` on `parallel`, `retry_attempts` on
+  `wait_for_sync`, `exec_type` and the state-retry pair on `call`, the
+  fuzzy-test pacing fields, and the deprecated `group_id` alias the invite and
+  join steps already normalise
+- The workflow docs still described `requester` on the delete and
+  set-metadata steps. The field was removed last release, so following
+  those examples is now a validation failure rather than a silent no-op.
 
 ### Removed
 

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -271,8 +271,7 @@ Create a context bound to an application inside a namespace/group.
 
 ### delete_context
 
-Delete a context. Fields: `node`, `context_id`, optional `requester` (admin
-public key, required for a group-registered context).
+Delete a context. Fields: `node`, `context_id`. The node resolves the acting identity from the authenticated session.
 
 ```yaml
 - type: delete_context
@@ -536,7 +535,6 @@ Toggle a member's auto-follow flags for new contexts and nested subgroups.
 | `member_id` | yes | string | Target member account (64 hex). |
 | `auto_follow_contexts` | yes | bool | Auto-join new contexts in this group. |
 | `auto_follow_subgroups` | yes | bool | Self-admit into nested subgroups. |
-| `requester` | no | string | Admin or self public key to act as. |
 
 ```yaml
 - type: set_member_auto_follow
@@ -587,16 +585,15 @@ from a context, group, or namespace. Each takes `node` plus the relevant id.
 
 ### Metadata setters and getters
 
-Metadata records are string→string maps with an optional record name. Setters
-accept an optional `requester` (admin key) for admin-guarded groups.
+Metadata records are string→string maps with an optional record name. The node resolves the acting identity from the authenticated session.
 
 | Step | Fields |
 | --- | --- |
-| `set_group_metadata` | `node`, `group_id`, `record_name?`, `data?`, `requester?` |
+| `set_group_metadata` | `node`, `group_id`, `record_name?`, `data?` |
 | `get_group_metadata` | `node`, `group_id` |
-| `set_member_metadata` | `node`, `group_id`, `member_id`, `record_name?`, `data?`, `requester?` |
+| `set_member_metadata` | `node`, `group_id`, `member_id`, `record_name?`, `data?` |
 | `get_member_metadata` | `node`, `group_id`, `member_id` |
-| `set_context_metadata` | `node`, `group_id`, `context_id`, `record_name?`, `data?`, `requester?` |
+| `set_context_metadata` | `node`, `group_id`, `context_id`, `record_name?`, `data?` |
 | `get_context_metadata` | `node`, `group_id`, `context_id` |
 
 ```yaml
@@ -650,8 +647,7 @@ key material through git history.
 ### Delete steps
 
 `delete_group` and `delete_namespace` delete a group / namespace. Each takes
-`node`, the id (`group_id` / `namespace_id`), and an optional `requester`
-(admin public key) for admin-guarded state.
+`node` and the id (`group_id` / `namespace_id`). The node resolves the acting identity from the authenticated session.
 
 ```yaml
 - type: delete_namespace

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -5,6 +5,7 @@ Configuration management for bootstrap workflows.
 import math
 import os
 import re
+from difflib import get_close_matches
 from typing import Any, Literal, Optional, Union
 
 import yaml
@@ -205,12 +206,27 @@ class RemoteNodeConfig(BaseModel):
 class BaseStepConfig(BaseModel):
     """Base configuration for all workflow steps."""
 
-    model_config = ConfigDict(extra="allow")
+    # A key nothing reads is a step that silently does nothing while the run
+    # goes green, so an unknown one fails before any container starts.
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = Field(None, description="Name of the step")
     type: str = Field(..., description="Type of the step")
     outputs: Optional[dict[str, Any]] = Field(
         None, description="Output variable mappings"
+    )
+    description: Optional[str] = Field(
+        None, description="Free-form note; the run does not read it"
+    )
+    expected_failure: Optional[bool] = Field(
+        None, description="Treat the call failing as this step's pass condition"
+    )
+    expected_error: Optional[str] = Field(
+        None,
+        description="Substring the failure must carry; needs 'expected_failure: true'",
+    )
+    token: Optional[str] = Field(
+        None, description="JWT to attach instead of the cached one"
     )
 
     @model_validator(mode="after")
@@ -229,8 +245,15 @@ class InstallApplicationStep(BaseStepConfig):
 
     type: Literal["install_application"] = "install_application"
     node: str = Field(..., description="Target node for installation")
-    path: str = Field(..., description="Path to the WASM file")
+    path: Optional[str] = Field(None, description="Path to the WASM file")
+    url: Optional[str] = Field(None, description="URL to install the WASM from")
     dev: Optional[bool] = Field(False, description="Install in dev mode")
+
+    @model_validator(mode="after")
+    def validate_source(self) -> "InstallApplicationStep":
+        if not self.path and not self.url:
+            raise ValueError("either 'path' or 'url' must be specified")
+        return self
 
 
 class CreateContextStep(BaseStepConfig):
@@ -240,6 +263,7 @@ class CreateContextStep(BaseStepConfig):
     node: str = Field(..., description="Target node")
     application_id: str = Field(..., description="Application ID to use")
     group_id: str = Field(..., description="Namespace/group ID for the context")
+    params: Optional[str] = Field(None, description="Initialization params JSON string")
     service_name: Optional[str] = Field(
         None, description="Optional service name for context creation"
     )
@@ -264,6 +288,9 @@ class InviteStep(BaseStepConfig):
     namespace_id: Optional[str] = Field(
         None, description="Namespace ID to create invitation for"
     )
+    group_id: Optional[str] = Field(
+        None, description="Deprecated alias for 'namespace_id'"
+    )
     recursive: Optional[bool] = Field(False, description="Create recursive invitation")
 
     @model_validator(mode="after")
@@ -285,6 +312,9 @@ class JoinStep(BaseStepConfig):
     type: Literal["join", "join_open"] = "join"
     node: str = Field(..., description="Target node")
     namespace_id: Optional[str] = Field(None, description="Namespace ID to join")
+    group_id: Optional[str] = Field(
+        None, description="Deprecated alias for 'namespace_id'"
+    )
     invitation: str = Field(..., description="Namespace invitation data")
 
     @model_validator(mode="after")
@@ -330,6 +360,15 @@ class CallStep(BaseStepConfig):
     context_id: str = Field(..., description="Context ID")
     method: str = Field(..., description="Method to call")
     args: Optional[dict[str, Any]] = Field(None, description="Arguments for the call")
+    exec_type: Optional[str] = Field(
+        None, description="Execution kind; defaults to 'function_call'"
+    )
+    state_retry_attempts: Optional[int] = Field(
+        None, gt=0, description="Attempts before giving up on a state read"
+    )
+    state_retry_delay: Optional[Union[int, float]] = Field(
+        None, ge=0, description="Seconds between state-read attempts"
+    )
     executor_public_key: Optional[str] = Field(
         None, description="Public key of executor"
     )
@@ -484,6 +523,9 @@ class WaitForSyncStep(BaseStepConfig):
     )
     nodes: list[str] = Field(..., description="Nodes to wait for sync")
     timeout: Optional[int] = Field(60, ge=1, description="Timeout in seconds")
+    retry_attempts: Optional[int] = Field(
+        None, gt=0, description="Polls before giving up; unbounded until the timeout"
+    )
     check_interval: Optional[float] = Field(
         2, gt=0, description="Steady-state polling cap in seconds (backoff ceiling)"
     )
@@ -536,6 +578,13 @@ class ParallelStep(BaseStepConfig):
     groups: list[ParallelGroupConfig] = Field(
         ..., description="Groups of steps to run in parallel"
     )
+    mode: Optional[Literal["burst", "sustained", "mixed"]] = Field(
+        None, description="Load shape across the groups; defaults to 'burst'"
+    )
+    failure_mode: Optional[str] = Field(
+        None,
+        description="Whether a failing group stops the rest; defaults to 'fail-slow'",
+    )
 
 
 class ScriptStep(BaseStepConfig):
@@ -544,7 +593,9 @@ class ScriptStep(BaseStepConfig):
     type: Literal["script"] = "script"
     script: str = Field(..., description="Path to the script")
     target: Optional[str] = Field("nodes", description="Target: 'image' or 'nodes'")
-    description: Optional[str] = Field(None, description="Description of the script")
+    args: Optional[list[Any]] = Field(
+        None, description="Arguments passed to the script"
+    )
 
 
 class PauseContainerStepConfig(BaseStepConfig):
@@ -755,6 +806,7 @@ class ListProposalsStep(BaseStepConfig):
     type: Literal["list_proposals"] = "list_proposals"
     node: str = Field(..., description="Target node")
     context_id: str = Field(..., description="Context ID")
+    args: Optional[str] = Field(None, description="Pagination args as a JSON string")
 
 
 class GetProposalApproversStep(BaseStepConfig):
@@ -886,6 +938,9 @@ class CreateNamespaceInvitationStepConfig(BaseStepConfig):
     )
     node: str = Field(..., description="Target node")
     namespace_id: Optional[str] = Field(None, description="Namespace ID to invite to")
+    group_id: Optional[str] = Field(
+        None, description="Deprecated alias for 'namespace_id'"
+    )
     recursive: Optional[bool] = Field(False, description="Create recursive invitation")
 
     @model_validator(mode="after")
@@ -907,6 +962,9 @@ class JoinNamespaceStepConfig(BaseStepConfig):
     type: Literal["join_namespace", "join_group"] = "join_namespace"
     node: str = Field(..., description="Target node")
     namespace_id: Optional[str] = Field(None, description="Namespace ID to join")
+    group_id: Optional[str] = Field(
+        None, description="Deprecated alias for 'namespace_id'"
+    )
     invitation: str = Field(..., description="Namespace invitation data")
 
     @model_validator(mode="after")
@@ -1561,6 +1619,9 @@ class CreateMeshStep(BaseStepConfig):
     application_id: str = Field(..., description="Application ID")
     nodes: list[str] = Field(..., description="List of nodes to include in mesh")
     params: Optional[str] = Field(None, description="Initialization params JSON string")
+    path: Optional[str] = Field(
+        None, description="WASM path to pre-install on the joining nodes"
+    )
 
 
 class FuzzyTestStep(BaseStepConfig):
@@ -1569,6 +1630,15 @@ class FuzzyTestStep(BaseStepConfig):
     type: Literal["fuzzy_test"] = "fuzzy_test"
     duration_minutes: Union[int, float] = Field(
         ..., gt=0, description="Duration in minutes for the fuzzy test"
+    )
+    summary_interval_seconds: Optional[int] = Field(
+        None, gt=0, description="Seconds between progress summaries"
+    )
+    operation_delay_ms: Optional[int] = Field(
+        None, ge=0, description="Pause between operations, in milliseconds"
+    )
+    success_threshold: Optional[Union[int, float]] = Field(
+        None, ge=0, le=100, description="Pass rate percentage the run must reach"
     )
     context_id: str = Field(..., description="Context ID")
     nodes: list[dict[str, Any]] = Field(
@@ -1916,46 +1986,65 @@ class WorkflowConfig(BaseModel):
     )
 
 
-def _format_pydantic_error(error: dict[str, Any]) -> str:
+def _format_pydantic_error(
+    error: dict[str, Any], model_class: Optional[type[BaseModel]] = None
+) -> str:
     """Format a single Pydantic validation error into a readable message."""
     loc = ".".join(str(x) for x in error.get("loc", []))
     msg = error.get("msg", "Unknown error")
+
+    if error.get("type") == "extra_forbidden" and model_class is not None:
+        valid = sorted(model_class.model_fields)
+        near = get_close_matches(loc, valid, n=1, cutoff=0.6)
+        hint = f" Did you mean '{near[0]}'?" if near else ""
+        return (
+            f"unknown field '{loc}' - the step would ignore it.{hint} "
+            f"Valid fields: {', '.join(valid)}"
+        )
 
     if loc:
         return f"{loc}: {msg}"
     return msg
 
 
-def validate_workflow_step(step: dict[str, Any], step_index: int) -> list[str]:
+def validate_workflow_step(
+    step: dict[str, Any], step_index: int, unknown_keys_only: bool = False
+) -> list[str]:
     """
     Validate a single workflow step and return a list of validation errors.
 
     Args:
         step: The step configuration dictionary
         step_index: The index of the step (for error messages)
+        unknown_keys_only: Report only unrecognised keys. The `bootstrap
+            validate` CLI runs its own required-field checks and would print
+            every complaint twice otherwise.
 
     Returns:
         List of validation error messages (empty if valid)
     """
     # Guard against non-dict steps (e.g., null or scalar values in YAML)
     if not isinstance(step, dict):
+        if unknown_keys_only:
+            return []
         return [f"Step {step_index}: Expected a mapping but got {type(step).__name__}"]
 
     errors = []
     step_name = step.get("name", f"Step {step_index + 1}")
     step_type = step.get("type")
 
-    if not step_type:
-        errors.append(
-            f"Step '{step_name}' (index {step_index}): Missing required field 'type'"
-        )
-        return errors
-
-    if step_type not in VALID_STEP_TYPES:
-        errors.append(
-            f"Step '{step_name}' (index {step_index}): Invalid step type '{step_type}'. "
-            f"Valid types are: {', '.join(sorted(VALID_STEP_TYPES))}"
-        )
+    if not step_type or step_type not in VALID_STEP_TYPES:
+        if unknown_keys_only:
+            return errors
+        if not step_type:
+            errors.append(
+                f"Step '{step_name}' (index {step_index}): Missing required field 'type'"
+            )
+        else:
+            errors.append(
+                f"Step '{step_name}' (index {step_index}): Invalid step type "
+                f"'{step_type}'. Valid types are: {', '.join(sorted(VALID_STEP_TYPES))}"
+            )
         return errors
 
     # Type-specific validation using module-level mapping
@@ -1966,17 +2055,20 @@ def validate_workflow_step(step: dict[str, Any], step_index: int) -> list[str]:
         except ValidationError as e:
             # Use structured error access for reliable parsing
             for err in e.errors():
-                formatted = _format_pydantic_error(err)
+                if unknown_keys_only and err.get("type") != "extra_forbidden":
+                    continue
+                formatted = _format_pydantic_error(err, model_class)
                 errors.append(f"Step '{step_name}' (index {step_index}): {formatted}")
         except Exception as e:
-            errors.append(f"Step '{step_name}' (index {step_index}): {str(e)}")
+            if not unknown_keys_only:
+                errors.append(f"Step '{step_name}' (index {step_index}): {str(e)}")
 
     # Recursively validate nested steps (for repeat and parallel)
     if step_type == "repeat":
         # Use `or []` to handle null values when key exists with no value
         nested_steps = step.get("steps") or []
         for i, nested_step in enumerate(nested_steps):
-            nested_errors = validate_workflow_step(nested_step, i)
+            nested_errors = validate_workflow_step(nested_step, i, unknown_keys_only)
             for err in nested_errors:
                 errors.append(f"Step '{step_name}' (index {step_index}) -> {err}")
 
@@ -1995,7 +2087,9 @@ def validate_workflow_step(step: dict[str, Any], step_index: int) -> list[str]:
             # Use `or []` for nested steps as well
             nested_steps = group.get("steps") or []
             for i, nested_step in enumerate(nested_steps):
-                nested_errors = validate_workflow_step(nested_step, i)
+                nested_errors = validate_workflow_step(
+                    nested_step, i, unknown_keys_only
+                )
                 for err in nested_errors:
                     errors.append(
                         f"Step '{step_name}' (index {step_index}) -> {group_name} -> {err}"

--- a/merobox/commands/bootstrap/validate/validator.py
+++ b/merobox/commands/bootstrap/validate/validator.py
@@ -5,6 +5,9 @@ This module provides comprehensive validation for workflow configurations
 without requiring full workflow execution.
 """
 
+from merobox.commands.bootstrap.config import (
+    validate_workflow_step as schema_validate_step,
+)
 from merobox.commands.bootstrap.steps.account import (
     AccountCreateStep,
     AccountPairStep,
@@ -207,6 +210,10 @@ def validate_workflow_config(config: dict, verbose: bool = False) -> dict:
                 # Validate step-specific requirements
                 step_errors = validate_step_config(step, step_name, step_type)
                 errors.extend(step_errors)
+
+                # The schema layer owns unknown keys; without this the CLI
+                # passes workflows the runner then rejects.
+                errors.extend(schema_validate_step(step, i, unknown_keys_only=True))
 
     return {"valid": len(errors) == 0, "errors": errors}
 

--- a/merobox/tests/unit/test_unknown_step_keys_rejected.py
+++ b/merobox/tests/unit/test_unknown_step_keys_rejected.py
@@ -1,0 +1,206 @@
+"""A step key nothing reads must fail validation, not be silently dropped.
+
+`create_group_in_namespace` declares `group_name`; 21 scenarios in
+calimero-network/core spelled it `group_alias`, and every one of those
+subgroups was born unnamed while the YAML read as though it were named. No run
+failed, which is the problem - the harness ignored a stated intent and went
+green. `extra="forbid"` on `BaseStepConfig` closes that, and the error names
+the nearest valid field so the typo points at its fix.
+"""
+
+import pytest
+
+from merobox.commands.bootstrap.config import (
+    STEP_TYPE_MODELS,
+    validate_workflow_step,
+)
+
+
+def _errors(step):
+    return validate_workflow_step(step, 0)
+
+
+class TestUnknownKeysRejected:
+    def test_group_alias_is_rejected_and_points_at_group_name(self):
+        errors = _errors(
+            {
+                "type": "create_group_in_namespace",
+                "name": "Create sub",
+                "node": "n1",
+                "namespace_id": "ns-hex",
+                "group_alias": "private-channel",
+            }
+        )
+        assert len(errors) == 1
+        assert "unknown field 'group_alias'" in errors[0]
+        assert "Did you mean 'group_name'?" in errors[0]
+
+    def test_a_key_with_no_near_match_still_fails(self):
+        errors = _errors(
+            {
+                "type": "create_group_in_namespace",
+                "node": "n1",
+                "namespace_id": "ns-hex",
+                "banana_field": "x",
+            }
+        )
+        assert len(errors) == 1
+        assert "unknown field 'banana_field'" in errors[0]
+        assert "Did you mean" not in errors[0]
+
+    def test_capability_on_create_mesh_is_rejected(self):
+        """Dead since the namespace flow replaced the capability-bearing invite."""
+        errors = _errors(
+            {
+                "type": "create_mesh",
+                "context_node": "n1",
+                "application_id": "app",
+                "nodes": ["n1", "n2"],
+                "capability": "member",
+            }
+        )
+        assert any("unknown field 'capability'" in e for e in errors)
+
+    def test_nested_steps_are_checked_too(self):
+        errors = _errors(
+            {
+                "type": "repeat",
+                "count": 2,
+                "steps": [
+                    {
+                        "type": "create_group_in_namespace",
+                        "node": "n1",
+                        "namespace_id": "ns-hex",
+                        "group_alias": "x",
+                    }
+                ],
+            }
+        )
+        assert any("unknown field 'group_alias'" in e for e in errors)
+
+
+class TestKeysTheExecutorsActuallyRead:
+    """Every field an executor reads has to be declared, or forbidding unknown
+    keys turns a working workflow into a validation error."""
+
+    @pytest.mark.parametrize(
+        "step",
+        [
+            {
+                "type": "create_mesh",
+                "context_node": "n1",
+                "application_id": "app",
+                "nodes": ["n1", "n2"],
+                "path": "res/app.wasm",
+            },
+            {
+                "type": "create_context",
+                "node": "n1",
+                "application_id": "app",
+                "group_id": "g",
+                "params": "{}",
+            },
+            {
+                "type": "install_application",
+                "node": "n1",
+                "url": "https://example.test/app.wasm",
+            },
+            {
+                "type": "join_namespace",
+                "node": "n1",
+                "group_id": "ns-hex",
+                "invitation": "{}",
+            },
+            {
+                "type": "wait_for_sync",
+                "context_id": "c",
+                "nodes": ["n1"],
+                "retry_attempts": 3,
+            },
+            {
+                "type": "call",
+                "node": "n1",
+                "context_id": "c",
+                "method": "get",
+                "exec_type": "function_call",
+                "state_retry_attempts": 2,
+                "state_retry_delay": 0.5,
+            },
+            {"type": "script", "script": "s.sh", "args": ["a"]},
+            {
+                "type": "parallel",
+                "groups": [{"name": "g", "steps": []}],
+                "mode": "burst",
+                "failure_mode": "fail-fast",
+            },
+            {"type": "list_proposals", "node": "n1", "context_id": "c", "args": "{}"},
+            {"type": "wait", "seconds": 1, "description": "settle the DAG"},
+            {
+                "type": "get_group_info",
+                "node": "n1",
+                "group_id": "g",
+                "expected_failure": True,
+                "expected_error": "not found",
+            },
+        ],
+    )
+    def test_step_validates(self, step):
+        assert _errors(step) == []
+
+    def test_install_application_still_needs_a_source(self):
+        errors = _errors({"type": "install_application", "node": "n1"})
+        assert any("'path' or 'url'" in e for e in errors)
+
+
+def test_the_validate_cli_agrees_with_the_runner():
+    """Two independent validators: the schema layer the runner uses, and the
+    elif chain behind `bootstrap validate`. A CLI that passes what the runner
+    rejects is worse than no CLI."""
+    from merobox.commands.bootstrap.validate.validator import (
+        validate_workflow_config as cli_validate,
+    )
+
+    result = cli_validate(
+        {
+            "name": "probe",
+            "nodes": {"count": 1},
+            "steps": [
+                {
+                    "type": "create_group_in_namespace",
+                    "name": "Create sub",
+                    "node": "n1",
+                    "namespace_id": "ns",
+                    "group_alias": "private-channel",
+                }
+            ],
+        }
+    )
+    assert result["valid"] is False
+    assert any("unknown field 'group_alias'" in e for e in result["errors"])
+
+
+def test_the_validate_cli_does_not_double_report():
+    """The CLI runs its own required-field checks; the schema layer must
+    contribute only the unknown keys or every complaint prints twice."""
+    from merobox.commands.bootstrap.validate.validator import (
+        validate_workflow_config as cli_validate,
+    )
+
+    result = cli_validate(
+        {
+            "name": "probe",
+            "nodes": {"count": 1},
+            "steps": [{"type": "create_group_in_namespace", "name": "Create sub"}],
+        }
+    )
+    assert len(result["errors"]) == len(set(result["errors"]))
+
+
+def test_every_step_model_forbids_extras():
+    """A model that opts back into extras reopens the same hole."""
+    permissive = [
+        t
+        for t, model in STEP_TYPE_MODELS.items()
+        if model.model_config.get("extra") != "forbid"
+    ]
+    assert permissive == []

--- a/workflow-examples/workflow-fault-injection-convergence-example.yml
+++ b/workflow-examples/workflow-fault-injection-convergence-example.yml
@@ -58,7 +58,6 @@ steps:
     nodes:
       - calimero-node-2
       - calimero-node-3
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/workflow-examples/workflow-fault-injection-partition-peers-example.yml
+++ b/workflow-examples/workflow-fault-injection-partition-peers-example.yml
@@ -52,7 +52,6 @@ steps:
     nodes:
       - calimero-node-2
       - calimero-node-3
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/workflow-examples/workflow-mesh-example.yml
+++ b/workflow-examples/workflow-mesh-example.yml
@@ -25,7 +25,6 @@ steps:
     nodes:
       - calimero-node-2
       - calimero-node-3
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/workflow-examples/workflow-propagation-monitoring.yml
+++ b/workflow-examples/workflow-propagation-monitoring.yml
@@ -33,7 +33,6 @@ steps:
       - dag-node-3
       - dag-node-4
       - dag-node-5
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/workflow-examples/workflow-snapshot-finalize-regression-3252.yml
+++ b/workflow-examples/workflow-snapshot-finalize-regression-3252.yml
@@ -79,7 +79,6 @@ steps:
     nodes:
       - snapshot-node-2
       - snapshot-node-3
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey


### PR DESCRIPTION
Closes #349

## Summary

`BaseStepConfig` set `extra="allow"`, so a misspelled or non-existent step field was accepted and then never read. No run failed, which is the problem: the workflow states an intent, the harness ignores it, and the run goes green.

Two live instances in `calimero-network/core`:

- `create_group_in_namespace` declares `group_name`; **21 scenarios pass `group_alias`, 27 occurrences**, every one discarded. Those subgroups are all unnamed while the YAML reads as though they are named.
- `create_mesh` takes a **`capability` in 29 more**, left over from the invite flow the namespace flow replaced. Five of merobox's own shipped examples carried it too; those are fixed here.

### What changed

- `BaseStepConfig` is `extra="forbid"`. Validation runs at config load, before any container starts.
- The error names the offending key and the nearest valid field, so `group_alias` reads `unknown field 'group_alias' - the step would ignore it. Did you mean 'group_name'?`
- `bootstrap validate` now reports the same unknown keys the runner does. It is a second, independent validator and was green-lighting workflows the runner rejects. It contributes only unknown keys, so its own required-field checks are not printed twice.
- Every field the executors actually read is declared, so forbidding extras breaks nothing that worked. Several had never been listed: `path` on `create_mesh`, `params` on `create_context`, `args` on `script` and `list_proposals`, `mode` / `failure_mode` on `parallel`, `retry_attempts` on `wait_for_sync`, `exec_type` and the state-retry pair on `call`, the fuzzy-test pacing fields, and the deprecated `group_id` alias the invite and join steps already normalise via `getattr` (which only worked under `extra="allow"`).
- `install_application`'s `url` was declared nowhere and unusable, because `path` was required alongside it. `path` is now optional with a validator requiring one of the two.
- The `requester` references in the workflow docs are removed. The field was dropped last release; following those examples is now a hard failure rather than a silent no-op.

### Breaking

A workflow carrying a key no step reads now fails validation. That is the point, and it is what lets core raise `MIN_MEROBOX` so a future stray key fails in CI. Core's `group_alias` and `capability` occurrences need replacing in the same release.

## Test plan

- `merobox/tests/unit/test_unknown_step_keys_rejected.py`: `group_alias` is rejected and suggests `group_name`; a key with no near match still fails without a bogus suggestion; `capability` on `create_mesh` is rejected; nested steps inside `repeat` are checked; the `validate` CLI agrees with the runner and does not double-report; no step model opts back into extras. A parametrised case pins each previously-undeclared field as still valid.
- Verified the gate is real: reverting to `extra="allow"` fails 5 of the tests.
- Validated the whole corpus under strict mode - merobox's 59 shipped workflows are clean, and the only keys core's 85 scenarios trip on are `group_alias`, `capability`, and one `comment`.
- Full unit suite: no new failures. 28 failures are pre-existing on `master` and come from a stale `calimero-client-py` in the local venv (0.3.0 vs the `>=0.6.29` pin), not from this change.
- `black --check` and `ruff check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking schema change: existing workflows with unread keys fail at load time. Validation is the harness gate for core e2e, so a misspelled or undeclared field now blocks runs rather than going green.
> 
> **Overview**
> **Unknown step fields now fail before any container starts.** `BaseStepConfig` switches from `extra="allow"` to `extra="forbid"`, so a misspelled or leftover key (e.g. `group_alias` vs `group_name`, dead `capability` on `create_mesh`) is a validation error instead of a silent no-op that still goes green.
> 
> Errors name the key and the closest valid field. `bootstrap validate` uses the same schema check (unknown keys only, so required-field messages are not duplicated).
> 
> Executor-read fields that were never on the models are declared so real workflows keep loading: `path` on `create_mesh`, `params` on `create_context`, `url` on `install_application` (path is no longer required if url is set), `args`, parallel `mode`/`failure_mode`, sync/call/fuzzy knobs, and the deprecated `group_id` alias on invite/join. Docs drop the already-removed `requester` field. Shipped examples lose unused `capability`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14252d99a62ae779d41f86e798f4fe52dade1f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->