### PR TITLE
test(workflows): pin subgroup birth visibility in both CI lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `remove_group_members`' schema description said "member public keys". It has
   taken accounts since the client started parsing `Vec<AccountId>`.
 
+### Added
+
+- **`workflow-examples/workflow-subgroup-visibility-example.yml`** — pins
+  subgroup birth visibility against a real node. `create_group_in_namespace`
+  has taken an optional `visibility` since core#2771, but the only shipped
+  workflow exercising it was `tee-r2-open-no-direct-row.yml`, which rides the
+  TEE lane and needs a merod built with `--features mock-attestation`; the two
+  lanes that run on every PR never touched the field. The new workflow creates
+  three subgroups — born `open`, born `restricted`, and one naming no
+  visibility at all — and reads each back with `get_group_info`. `restricted`
+  had never been written explicitly anywhere, and the third case is what
+  catches a change to the server default, which is otherwise only ever assumed.
+  One node, both matrices
+
 ### Removed
 
 - **`requester` from every step that accepted it** — `set_member_auto_follow`,

--- a/workflow-examples/workflow-subgroup-visibility-example.yml
+++ b/workflow-examples/workflow-subgroup-visibility-example.yml
@@ -1,0 +1,93 @@
+description: >
+  Pins subgroup birth visibility. `create_group_in_namespace` takes an optional
+  `visibility`, and an absent one means the server default - so a node that
+  stops reading the field, and a change to what the default is, both surface
+  here rather than in whichever scenario happens to lean on them.
+name: Subgroup Birth Visibility Example
+
+force_pull_image: true
+
+nodes:
+  count: 1
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: visibility-node
+
+steps:
+  - name: Install Application
+    type: install_application
+    node: visibility-node-1
+    path: ./workflow-examples/res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace
+    type: create_namespace
+    node: visibility-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create a Subgroup Born Open
+    type: create_group_in_namespace
+    node: visibility-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: born-open
+    visibility: open
+    outputs:
+      open_subgroup_id: groupId
+
+  - name: Create a Subgroup Born Restricted
+    type: create_group_in_namespace
+    node: visibility-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: born-restricted
+    visibility: restricted
+    outputs:
+      restricted_subgroup_id: groupId
+
+  # No visibility key at all. Asserting on the result is what catches a change
+  # to the server default, which nothing else here would notice.
+  - name: Create a Subgroup Without Naming a Visibility
+    type: create_group_in_namespace
+    node: visibility-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: born-default
+    outputs:
+      default_subgroup_id: groupId
+
+  - name: Read Back the Open Subgroup
+    type: get_group_info
+    node: visibility-node-1
+    group_id: "{{open_subgroup_id}}"
+    outputs:
+      open_visibility: subgroupVisibility
+
+  - name: Read Back the Restricted Subgroup
+    type: get_group_info
+    node: visibility-node-1
+    group_id: "{{restricted_subgroup_id}}"
+    outputs:
+      restricted_visibility: subgroupVisibility
+
+  - name: Read Back the Default Subgroup
+    type: get_group_info
+    node: visibility-node-1
+    group_id: "{{default_subgroup_id}}"
+    outputs:
+      default_visibility: subgroupVisibility
+
+  - name: Assert Birth Visibility Is What Was Asked For
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+      - "equals({{open_visibility}}, open)"
+      - "equals({{restricted_visibility}}, restricted)"
+      # The default is an absent key collapsing to restricted, so it is read
+      # back rather than assumed.
+      - "equals({{default_visibility}}, restricted)"
+      - "{{open_subgroup_id}} != {{restricted_subgroup_id}}"
+
+stop_all_nodes: true
+restart: false
+wait_timeout: 60


### PR DESCRIPTION
## Summary

`create_group_in_namespace` has taken an optional `visibility` (`open` / `restricted`) since calimero-network/core#2771, but almost nothing shipped here exercises it.

Current state of the field across `workflow-examples/`:

| Surface | Files using it | CI lane |
| --- | --- | --- |
| `visibility:` at birth on `create_group_in_namespace` | 1 (`tee-r2-open-no-direct-row.yml`) | TEE only |
| `set_subgroup_visibility` (flip after birth) | 4, all `tee-*` | TEE only |
| `set_default_visibility` | 1 (`workflow-group-admin-example.yml`) | docker only |

So the birth field was reachable only through the TEE lane, which needs a `merod` built with `--features mock-attestation` from a dedicated job. The binary and docker matrices - the two that run on every PR - never touched it. Beyond that, the single usage only ever passes `open`; **`visibility: restricted` was never written explicitly anywhere**, and the default was only ever assumed, never read back.

Existing coverage was `test_create_group_in_namespace_visibility.py`, which asserts the REST body carries the key. That proves merobox sends it, not that a node acts on it.

## What this adds

`workflow-examples/workflow-subgroup-visibility-example.yml` creates three subgroups under one namespace and reads each back with `get_group_info`:

- born `open` → asserts `open`
- born `restricted` → asserts `restricted`
- **no `visibility` key at all** → asserts `restricted`

The third case is the one that catches a change to the server default, which nothing else here would notice.

One node, so it is cheap. **No matrix exclusion**: `0.11.0-rc.24` carries the birth-visibility handler, so the released merod the binary lane downloads is new enough - verified against the tag's `create_group_in_namespace.rs`, which declares `pub visibility: Option<String>`. The response field is `subgroupVisibility`, serialising `"open"` / `"restricted"`.

Independent of #350 and #351; touches no runtime code.

## Test plan

- Confirmed the workflow resolves into **both** the binary and docker matrix expressions from `ci.yml`, so it runs on every PR in both lanes.
- `merobox bootstrap validate` passes on the new file.
- `test_shipped_workflows_validate.py`, `test_ci_workflow_hygiene.py` and `test_create_group_in_namespace_visibility.py` all pass.
- Not run locally against Docker - CI is the check, which is the point of the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only: a new example YAML and changelog entry; no runtime or harness code changes.
> 
> **Overview**
> Adds `workflow-subgroup-visibility-example.yml` so **birth** `visibility` on `create_group_in_namespace` is exercised on every PR, not only the TEE lane.
> 
> The workflow creates three subgroups under one namespace and reads each back with `get_group_info`: born `open`, born `restricted` (never written explicitly before), and no `visibility` key (asserts the server default is `restricted`). One node; not excluded from the binary or docker matrices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffc3ba965efcc050e1e8c1d4968ebdb3ed373d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->