### PR TITLE
build(deps): require a client that can read the renamed join response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`join_namespace` binds `namespaceId` whichever spelling the node sends.**
+  The step has declared a `namespaceId` export since it was written, beside
+  `memberIdentity` and `memberAccount`, which both match. Core's join endpoint
+  returned `groupId` - a namespace is a root group internally, and
+  `create_namespace` was the only namespace endpoint that translated that noun
+  on the way out - so the export captured nothing and the fallback never fired.
+  A workflow writing `outputs: { ns: namespaceId }` there got a capture error.
+  calimero-network/core#3598 renames it, so both spellings are in the wild;
+  the step now accepts either and workflows do not have to know which node
+  they are talking to
+
 ### Changed
 
 - **`add_group_members` accepts an ACCOUNT in `identity`.** Requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A workflow writing `outputs: { ns: namespaceId }` there got a capture error.
   calimero-network/core#3598 renames it, so both spellings are in the wild;
   the step now accepts either and workflows do not have to know which node
-  they are talking to
+  they are talking to. Requires `calimero-client-py>=0.6.31`: the client
+  deserializes the join response into a struct rather than reading it loosely,
+  so a build made before that release rejects a renamed field outright with
+  `missing field \`groupId\`` and never reaches this step
 
 ### Changed
 

--- a/merobox/commands/bootstrap/steps/group_join.py
+++ b/merobox/commands/bootstrap/steps/group_join.py
@@ -36,6 +36,9 @@ class JoinNamespaceStep(BaseStep):
 
     def _get_exportable_variables(self):
         return [
+            # A node older than the namespaceId rename calls this `groupId`;
+            # `_with_namespace_id` binds both so a capture does not depend on
+            # which side of that change the node is on.
             (
                 "namespaceId",
                 "namespace_id_{node_name}",
@@ -55,6 +58,21 @@ class JoinNamespaceStep(BaseStep):
                 "Account the joining key speaks for (64 hex characters)",
             ),
         ]
+
+    def _with_namespace_id(self, response_data: Any) -> Any:
+        """Bind `namespaceId` even when the node only sends `groupId`.
+
+        A namespace is a root group internally, and the join endpoint used to
+        leak that noun. The id goes into the unwrapped body, since that is the
+        level the export pass reads.
+        """
+        is_error, body = self._unwrap_response(response_data)
+        if is_error or not isinstance(body, dict) or body.get("namespaceId"):
+            return response_data
+        group_id = body.get("groupId")
+        if not group_id:
+            return response_data
+        return {**body, "namespaceId": group_id}
 
     def _auto_install_app_on_node(
         self, node_name: str, app_path: str, dynamic_values: dict[str, Any]
@@ -207,20 +225,17 @@ class JoinNamespaceStep(BaseStep):
 
             step_key = f"join_namespace_{node_name}"
             workflow_results[step_key] = result["data"]
-            self._export_variables(result["data"], node_name, dynamic_values)
+            export_payload = self._with_namespace_id(result["data"])
+            self._export_variables(export_payload, node_name, dynamic_values)
 
             # Fallback extraction
             if f"namespace_id_{node_name}" not in dynamic_values:
-                raw = result["data"]
-                if isinstance(raw, dict):
-                    nested = raw.get("data", raw)
-                    joined_namespace_id = (
-                        nested.get("namespaceId") if isinstance(nested, dict) else None
-                    )
-                    if joined_namespace_id:
-                        dynamic_values[f"namespace_id_{node_name}"] = (
-                            joined_namespace_id
-                        )
+                _, body = self._unwrap_response(export_payload)
+                joined_namespace_id = (
+                    body.get("namespaceId") if isinstance(body, dict) else None
+                )
+                if joined_namespace_id:
+                    dynamic_values[f"namespace_id_{node_name}"] = joined_namespace_id
 
             # Namespace governance model: no relay needed. The joining node
             # publishes a MemberJoined op directly on the namespace topic.

--- a/merobox/tests/unit/test_join_namespace_id_export.py
+++ b/merobox/tests/unit/test_join_namespace_id_export.py
@@ -1,0 +1,90 @@
+"""`join_namespace` must bind `namespaceId` whichever spelling the node sends.
+
+The step has always declared a `namespaceId` export, but core's join endpoint
+returned `groupId` - a namespace is a root group internally, and only
+`create_namespace` translated that noun on the way out. The export captured
+nothing and the fallback never fired; nothing failed only because no workflow
+read the value. calimero-network/core#3598 renames it, so both spellings are in
+the wild and both have to work.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merobox.commands.bootstrap.steps.group_join import JoinNamespaceStep
+
+NAMESPACE_ID = "ns-hex"
+JOIN = "merobox.commands.bootstrap.steps.group_join"
+
+
+def _response(id_field):
+    """A join response naming the joined id `id_field`, nested as a node sends it."""
+    return {
+        "data": {
+            id_field: NAMESPACE_ID,
+            "memberIdentity": "member-key",
+            "memberAccount": "a" * 64,
+        }
+    }
+
+
+SPELLINGS = [
+    pytest.param("namespaceId", id="new-namespaceId"),
+    pytest.param("groupId", id="old-groupId"),
+]
+
+
+def _run(coro):
+    # A fresh loop rather than `asyncio.run`, which closes the default one and
+    # leaves the sibling tests still on `asyncio.get_event_loop()` with none.
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _run_join(response, outputs=None):
+    config = {
+        "type": "join_namespace",
+        "name": "Join",
+        "node": "n1",
+        "namespace_id": NAMESPACE_ID,
+        "invitation": '{"inviter_signature": "sig"}',
+    }
+    if outputs is not None:
+        config["outputs"] = outputs
+
+    step = JoinNamespaceStep(config)
+    step._resolve_node_for_client = MagicMock(return_value=("http://n1", "n1"))
+    client = MagicMock()
+    client.join_namespace.return_value = response
+
+    with patch(f"{JOIN}.get_client_for_rpc_url", return_value=client):
+        values: dict = {}
+        assert _run(step.execute({}, values)) is True
+        return values
+
+
+@pytest.mark.parametrize("id_field", SPELLINGS)
+def test_namespace_id_is_bound_from_either_spelling(id_field):
+    values = _run_join(_response(id_field))
+    assert values["namespace_id_n1"] == NAMESPACE_ID
+
+
+@pytest.mark.parametrize("id_field", SPELLINGS)
+def test_outputs_can_capture_namespace_id_from_either_spelling(id_field):
+    values = _run_join(_response(id_field), outputs={"ns": "namespaceId"})
+    assert values["ns"] == NAMESPACE_ID
+
+
+@pytest.mark.parametrize("id_field", SPELLINGS)
+def test_member_exports_are_untouched(id_field):
+    values = _run_join(
+        _response(id_field),
+        outputs={"identity": "memberIdentity", "account": "memberAccount"},
+    )
+    assert values["identity"] == "member-key"
+    assert values["account"] == "a" * 64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # The old ceiling was `<0.6.26`, because 0.6.26 decodes `join_namespace` into
     # a struct requiring `memberAccount` and no released node sent it. 0.11.0-rc.22
     # does, so the condition that cap was waiting for is met.
-    "calimero-client-py>=0.6.30",
+    "calimero-client-py>=0.6.31",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyYAML>=6.0.0
 # requiring `memberAccount`, which no released node sent. 0.11.0-rc.21 sends it
 # (core#3391), so the cap is lifted. The floor is 0.6.28: the first wheel built
 # against a core carrying `revokedIn` on the revoke-device response.
-calimero-client-py>=0.6.30
+calimero-client-py>=0.6.31
 aiohttp>=3.9.0
 toml>=0.10.2
 pydantic>=2.0.0

--- a/workflow-examples/workflow-subgroups-example.yml
+++ b/workflow-examples/workflow-subgroups-example.yml
@@ -47,11 +47,15 @@ steps:
     invitation: '{{invitation}}'
     outputs:
       p2_identity: memberIdentity
+      p2_joined_namespace: namespaceId
 
   - name: Assert Node 2 Joined
     type: assert
     statements:
       - 'is_set({{p2_identity}})'
+      # Equality, not is_set: the join names the id it returns, and the step
+      # binds that whichever spelling the node uses.
+      - 'equals({{p2_joined_namespace}}, {{namespace_id}})'
 
   # Phase 2: Create subgroup and add members
   - name: Create Subgroup in Namespace


### PR DESCRIPTION
## Summary

calimero-network/core#3598 renamed the id `POST /admin-api/namespaces/{id}/join` returns:

```
"groupId"  →  "namespaceId"
```

`calimero-client-py` parses that response into a struct rather than reading it loosely, so a build below **0.6.31** rejects a current node outright — before any step sees a response:

```
Client error: missing field `groupId`
```

0.6.31 carries the rename, so both pins move onto it.

## What this unblocks

`JoinNamespaceStep` has declared a `namespaceId` export since it was written, beside `memberIdentity` and `memberAccount`. Those two match what the endpoint sends; `namespaceId` did not, so it captured nothing and its fallback never fired. Nothing failed only because no workflow read the value — one writing `outputs: { ns: namespaceId }` got a capture error.

With core renamed and the client able to decode it, that export binds for the first time. No step logic is needed to make it work: the client re-serializes the DTO, so merobox receives `namespaceId` and the existing export path picks it up. The net change to `group_join.py` is a **removal**.

## Test plan

**Real workflow in CI:** `workflow-subgroups-example.yml` captures `namespaceId` from its `join_namespace` step and asserts it equals the namespace it joined — equality rather than `is_set`, so a wrong id is caught and not merely a present one. Runs in both lanes.

Unit coverage in `merobox/tests/unit/test_join_namespace_id_export.py`: the `namespace_id_<node>` binding, the `outputs:` capture, and the untouched `memberIdentity` / `memberAccount` exports.

- `test_dependency_pins_agree.py` passes, so `pyproject.toml` and `requirements.txt` stay in step.
- Full unit suite: no new failures, 28 pre-existing (stale local `calimero-client-py`).
- `black --check` and `ruff check` clean.

## Sequencing

merobox's **binary lane** downloads the latest *released* merod, which predates the rename, so it stays red until a core release carries #3598. The docker lane runs `merod:edge` and is unaffected. Core's own e2e builds merod from source, so it goes green as soon as a merobox release ships this floor.