### PR TITLE
chore(release): 0.6.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Requires `calimero-client-py>=0.6.31`.** calimero-network/core#3598 renamed
+  the id `POST admin-api/namespaces/:id/join` returns from `groupId` to
+  `namespaceId`. The client decodes that response into a struct rather than
+  reading it loosely, so a build below 0.6.31 rejects a current node outright
+  with `missing field \`groupId\`` - the join fails before any step sees a
+  response. The same shape as the old `<0.6.26` cap, one rename later. 0.6.31
+  also makes `join_namespace`'s long-declared `namespaceId` export bind for the
+  first time: it named a field the endpoint never sent, so it captured nothing,
+  and nothing failed only because no workflow read it
+
 - **`add_group_members` accepts an ACCOUNT in `identity`.** Requires
   `calimero-client-py>=0.6.30`. Below that the bundled client parsed the field
   as a bs58 key with `.expect`, so an account - the only id

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.58"
+__version__ = "0.6.59"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,21 +26,7 @@ dependencies = [
     "docker>=6.0.0",
     "rich>=13.0.0,<14.3.4",
     "PyYAML>=6.0.0",
-    # 0.6.21 is where `revoke_device` grew its `proof` argument. Below it the
-    # account_revoke step's three-argument call is a TypeError at run time, not a
-    # resolution failure at install time, so the floor has to say so.
-    # 0.6.27 is where `get_node_identity` lands, which the `node_identity` step
-    # calls — below it that step is an AttributeError at run time.
-    #
-    # 0.6.28 is the first wheel built against a core carrying `revokedIn` on the
-    # revoke-device response. Below it the field is absent from what the binding
-    # returns, so a scenario capturing it gets `Export failed: 'revokedIn' not
-    # found` — which is what core's account-facts-cross-namespace hit.
-    #
-    # The old ceiling was `<0.6.26`, because 0.6.26 decodes `join_namespace` into
-    # a struct requiring `memberAccount` and no released node sent it. 0.11.0-rc.22
-    # does, so the condition that cap was waiting for is met.
-    "calimero-client-py>=0.6.30",
+    "calimero-client-py>=0.6.31",
     "aiohttp>=3.9.0",
     "toml>=0.10.2",
     "base58>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,19 +2,7 @@ click>=8.0.0
 docker>=6.0.0
 rich>=13.0.0,<14.3.4
 PyYAML>=6.0.0
-# 0.6.24 is the first release that can talk to BOTH sides of two in-flight core
-# changes:
-#   - member ids are decoded as the node writes them rather than parsed as bs58
-#     keys, so a node naming members by account (core#3391) is readable;
-#   - `create_namespace` still sends `upgradePolicy`, which every released node
-#     requires and a master node ignores. 0.6.22 and 0.6.23 omitted it and could
-#     not create a namespace on any released node — which is what turned this
-#     suite red when it was floored at 0.6.23.
-# The <0.6.26 cap was there because 0.6.26 decodes `join_namespace` into a struct
-# requiring `memberAccount`, which no released node sent. 0.11.0-rc.21 sends it
-# (core#3391), so the cap is lifted. The floor is 0.6.28: the first wheel built
-# against a core carrying `revokedIn` on the revoke-device response.
-calimero-client-py>=0.6.30
+calimero-client-py>=0.6.31
 aiohttp>=3.9.0
 toml>=0.10.2
 pydantic>=2.0.0


### PR DESCRIPTION
## What this ships

**`calimero-client-py>=0.6.31`**, and the version bump to cut a release with it.

calimero-network/core#3598 renamed the id `POST /admin-api/namespaces/{id}/join` returns:

```
"groupId"  →  "namespaceId"
```

The client decodes that response into a struct rather than reading it loosely, so a build below 0.6.31 rejects a current node outright — the join fails before any step sees a response:

```
Client error: missing field `groupId`
```

This is the same shape as the `<0.6.26` cap the pin comments already record, where the struct required a `memberAccount` no released node sent. One rename later.

0.6.31 also makes `join_namespace`'s `namespaceId` export bind for the first time. It has been declared since the step was written, beside `memberIdentity` and `memberAccount` — but it named a field the endpoint never sent, so it captured nothing. Nothing failed only because no workflow read it.

## Why a release, not just a merge

core's e2e installs merobox **only from a published release**, verified against its `.sha256`, and always resolves `releases/latest`. There is no path to an unshipped build, so core's suite stays red until this release exists.

## Contents

- `calimero-client-py` floor `>=0.6.30` → `>=0.6.31`, in both `pyproject.toml` and `requirements.txt`, with the pin comments updated to say why this floor exists.
- `__version__` 0.6.58 → 0.6.59. `pyproject.toml` reads it via `version = {attr = "merobox.__version__"}`, so that is the single source.

## Test plan

- `test_dependency_pins_agree.py` passes, so the two files that govern the wheel and the standalone binary stay in step — they drifted once before and shipped a binary whose embedded client lacked a method the steps called.
- `black --check` and `ruff check` clean.

## Sequencing note

merobox's **binary lane** downloads the latest *released* merod, which predates the rename, so it stays red until a core release carries #3598. The docker lane runs `merod:edge` and is unaffected. Core's own e2e builds merod from source, so it recovers as soon as this release publishes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor and version bump only; no merobox runtime or auth/data-path changes. Older client wheels will no longer install.
> 
> **Overview**
> Cuts **0.6.59** and raises the `calimero-client-py` floor from `>=0.6.30` to `>=0.6.31` in `pyproject.toml` and `requirements.txt`.
> 
> That client matches core#3598’s join-namespace response rename (`groupId` → `namespaceId`). Older clients decode the response as a struct and fail immediately with `missing field groupId`. 0.6.31 also makes the long-declared `namespaceId` export on `join_namespace` actually bind.
> 
> No merobox step logic changes; this is a pin + version stamp so published installs can talk to current nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6eceedf5ef453a6896faa834a5bebe19f628ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->