### PR TITLE
feat(topology): add a single-bridge boot-node topology for discovery tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.60] - 2026-08-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`topology: { type: bootstrap }` — one bridge, one boot-node, no mDNS.** Every
+  client lands on a single plain bridge with the boot-node and is given exactly
+  one `bootstrap.nodes` entry: the boot-node's. Sibling addresses are withheld and
+  `discovery.mdns` is forced off after any per-node override, so the only way a
+  node learns about another is to ask the boot-node — bootstrap dial, identify,
+  kad, rendezvous register/discover.
+
+  Default cluster mode cannot test that: it writes every sibling's address into
+  each node's config and leaves mDNS on. `type: nat` does test it, but behind a
+  gateway, alongside relay reservations and DCUtR hole-punching, so a discovery
+  regression there presents as a NAT failure and gets triaged as one. This variant
+  is the same discovery shape with the confounds removed. Measured on a 3-node
+  local run: 0 mDNS dials, 6-10 kad `RoutingUpdated` per node, and rendezvous
+  register + discover on every client — a joiner-to-joiner write crossed with no
+  address any client was handed up front.
+
+  `TopologyConfig` is now a discriminated union on `type`, which is the migration
+  the config module previously described as future work. Unknown keys under a
+  `bootstrap` block are rejected rather than ignored, so a `nat_mode` carried over
+  by copy-paste fails validation instead of silently configuring nothing.
+
 ### Changed
 
 - **Requires `calimero-client-py>=0.6.31`.** calimero-network/core#3598 renamed

--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -67,7 +67,7 @@ steps:
 | `e2e_mode` | no | bool (`false`) | Clear merod's default public bootstrap list and assign a private per-workflow rendezvous namespace. |
 | `preserve_default_bootstrap` | no | bool (`false`) | Under `e2e_mode`, keep merod's default boot-node list instead of clearing it. |
 | `bootstrap_nodes` | no | list | Explicit bootstrap peers to connect to. |
-| `topology` | no | object | NAT/relay topology selector (see [Topology](#topology)). |
+| `topology` | no | object | Startup wiring: `bootstrap` (discovery only) or `nat` (relay). See [Topology](#topology). |
 
 ## Node configuration
 
@@ -145,10 +145,32 @@ remote_nodes:
 
 ### Topology
 
-Setting `topology` switches startup from the default single-bridge cluster to a
-multi-bridge NAT layout with a relay boot-node and a NAT gateway — required to
-exercise relay-reservation recovery, where clients cannot dial each other
-directly.
+Setting `topology` replaces the default startup wiring. By default merobox puts
+every node on one bridge, writes all of its siblings into each node's
+`bootstrap.nodes`, and leaves mDNS on — convenient, and unlike any deployment,
+where a node is told about one or two bootstrap peers, has to ask one of them who
+else exists, and has no multicast path to peers on other hosts.
+
+Two variants:
+
+`type: bootstrap` — one plain bridge, one boot-node, mDNS forced off, and a
+single bootstrap address per client. Clients can only learn a sibling's address
+by asking the boot-node, so this exercises bootstrap → identify → kad →
+rendezvous and nothing else. Use it when discovery itself is what you want to
+test: a regression there fails the scenario and means only that.
+
+```yaml
+topology:
+  type: bootstrap
+  boot_node:
+    image: ghcr.io/calimero-network/boot-node:edge   # optional
+```
+
+`type: nat` — a boot-node on a public bridge, a NAT gateway, and clients on an
+`--internal` LAN bridge with no direct path to each other. Required to exercise
+relay-reservation recovery and DCUtR hole-punching. It also exercises the
+discovery path above, which is why a discovery regression can surface here as a
+NAT failure; prefer `bootstrap` when the relay is not the point.
 
 ```yaml
 topology:
@@ -158,6 +180,12 @@ topology:
     image: merobox/boot-node:local   # optional; auto-built when omitted
     keypair: ./boot-node-key.json    # optional; fresh keypair when omitted
 ```
+
+Both variants require Docker mode, force `discovery.mdns = false` on every
+client, and skip the sibling bootstrap wiring. `nodes:` must use the `count:`
+form. Unknown keys under `topology` are rejected rather than ignored, so a
+`nat_mode` left behind on a `bootstrap` block fails validation instead of
+silently doing nothing.
 
 ## Common step keys
 

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.59"
+__version__ = "0.6.60"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -6,7 +6,7 @@ import math
 import os
 import re
 from difflib import get_close_matches
-from typing import Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 import yaml
 from pydantic import (
@@ -1860,32 +1860,51 @@ class NatTopologyConfig(BaseModel):
     )
 
 
-# `TopologyConfig` is a bare alias today, not a discriminated
-# union. There's only one topology variant (`NatTopologyConfig`),
-# and a single-element Union is idiomatically equivalent + draws
-# type-checker warnings, so we don't pay that cost yet.
-#
-# When the SECOND topology variant lands (e.g. `MeshTopologyConfig`
-# with multiple relays, `WireguardTopologyConfig`, etc.) the
-# migration is NOT just `TopologyConfig = Union[A, B]`. Pydantic
-# needs an explicit `Field(discriminator=...)` so it can pick the
-# right class from the YAML `type:` value — without that, every
-# variant's optional fields would be treated as candidates and
-# parsing errors would be unhelpfully vague. Migration steps:
-#
-# 1. Each variant gets a literal type tag: `type: Literal["nat"]`
-#    on `NatTopologyConfig`, `type: Literal["mesh"]` on the new
-#    `MeshTopologyConfig`, etc. The tag is what Pydantic
-#    dispatches on.
-# 2. Redefine the alias as a discriminated Union:
-#    `TopologyConfig = Annotated[Union[NatTopologyConfig, ...],
-#    Field(discriminator="type")]`
-# 3. Workflow YAMLs already use a `type:` key, so no schema
-#    migration on the operator side.
-#
-# Until that work happens, the bare alias keeps call-sites
-# future-proof in annotation form without paying the lint cost.
-TopologyConfig = NatTopologyConfig
+class BootstrapTopologyConfig(BaseModel):
+    """Single bridge, one boot-node, mDNS off — `type: bootstrap`.
+
+    Every client sits on one plain bridge with the boot-node and knows
+    exactly one address: the boot-node's. Sibling addresses are withheld
+    and multicast is disabled, so the only way a node learns about
+    another is to ask the boot-node — which is the discovery path a
+    deployed node actually uses, and the one the default cluster mode
+    hands out for free.
+
+    Compared with `type: nat`, which exercises the same asking but
+    behind a gateway: no NAT, no relay reservation, no hole-punching, no
+    route injection. A failure here means discovery broke, and nothing
+    else. That specificity is the reason this variant exists rather than
+    leaning on the NAT scenarios.
+    """
+
+    # Strict, unlike most models here: the only keys this topology has
+    # are `type` and `boot_node`, so anything else is a mistake worth
+    # naming — most likely `nat_mode`, carried over from the NAT variant
+    # by someone who copied a workflow. Accepting and ignoring it would
+    # leave a scenario that reads as if it configured a gateway it does
+    # not have (calimero-network/merobox#349 is the general form of this).
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["bootstrap"] = "bootstrap"
+    boot_node: NatBootNodeConfig = Field(
+        default_factory=NatBootNodeConfig,
+        description=(
+            "Configuration for the boot-node container. Shared with the "
+            "NAT topology: same binary in the same role (the rendezvous "
+            "server merod cannot be, shipping only the client behaviour), "
+            "differing only in what sits between it and the clients."
+        ),
+    )
+
+
+# Discriminated on `type`, per the migration this comment block used to
+# describe as future work. Pydantic needs the explicit discriminator:
+# without it every variant's optional fields become candidates and a bad
+# `type:` surfaces as a vague union error rather than "unknown topology".
+TopologyConfig = Annotated[
+    Union[NatTopologyConfig, BootstrapTopologyConfig],
+    Field(discriminator="type"),
+]
 
 
 class WorkflowConfig(BaseModel):

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -227,6 +227,10 @@ class WorkflowExecutor:
         # and networks at workflow exit. Stays `None` for non-NAT
         # workflows.
         self._nat_state = None
+        # Set instead of `_nat_state` when the workflow asks for
+        # `topology: { type: bootstrap }`; exactly one of the two is
+        # ever populated, and teardown dispatches on which.
+        self._bootstrap_state = None
 
         # Generate unique workflow ID for test isolation (like e2e tests)
         self.workflow_id = str(uuid.uuid4())[:8]
@@ -430,12 +434,12 @@ class WorkflowExecutor:
                 # bridges) on success too. `stop_all_nodes` covers
                 # the client merods that the normal manager knows
                 # about; the topology pieces are merobox-owned.
-                self._teardown_nat_topology_if_present()
+                self._teardown_topology_if_present()
             else:
                 console.print(
                     "\n[bold blue]Step 5: Skipped (no local nodes to stop)[/bold blue]"
                 )
-                self._teardown_nat_topology_if_present()
+                self._teardown_topology_if_present()
 
             # Step 6: Nuke on end if requested
             if nuke_on_end:
@@ -744,7 +748,7 @@ class WorkflowExecutor:
         self._export_node_logs()
         if stop_all_nodes:
             self._stop_nodes_on_failure()
-        self._teardown_nat_topology_if_present()
+        self._teardown_topology_if_present()
 
     def _export_node_logs(self) -> None:
         """Persist logs of all running nodes to ``data/container-logs/``.
@@ -782,15 +786,16 @@ class WorkflowExecutor:
         else:
             console.print("[green]✓ All nodes stopped[/green]")
 
-    def _teardown_nat_topology_if_present(self) -> None:
-        """Stop the NAT-topology containers + networks if any were
-        stood up for this workflow.
+    def _teardown_topology_if_present(self) -> None:
+        """Stop the topology containers + networks if any were stood up
+        for this workflow (NAT or bootstrap — whichever ran).
 
         Safe to call multiple times; the second call is a no-op
         because `self._nat_state` is cleared after the first
         successful teardown.
         """
-        if self._nat_state is None:
+        state = self._nat_state or self._bootstrap_state
+        if state is None:
             return
         # Manager is `Optional` in the executor's constructor —
         # remote-only workflows, dry runs, and binary-mode call
@@ -801,11 +806,12 @@ class WorkflowExecutor:
         # would leak boot-node + gateway + bridges across runs.
         if self.manager is None or getattr(self.manager, "client", None) is None:
             console.print(
-                "[yellow]Skipping NAT topology teardown: manager / docker client "
+                "[yellow]Skipping topology teardown: manager / docker client "
                 "unavailable (likely a binary-mode or remote-only path that should "
                 "have refused `topology:` earlier — investigate)[/yellow]"
             )
             self._nat_state = None
+            self._bootstrap_state = None
             return
         # Stop and remove any client containers tracked in state
         # FIRST, before tearing down the networks they're attached
@@ -818,7 +824,7 @@ class WorkflowExecutor:
         # modes the outer path doesn't run at all), so we have to
         # reap clients here too. Best-effort: a failing stop on one
         # client shouldn't block the rest of teardown.
-        for client_name in list(self._nat_state.client_names):
+        for client_name in list(state.client_names):
             try:
                 container = self.manager.client.containers.get(client_name)
             except Exception:
@@ -828,26 +834,32 @@ class WorkflowExecutor:
                 container.stop(timeout=5)
             except Exception as e:
                 console.print(
-                    f"[yellow]NAT teardown: failed to stop {client_name}: "
+                    f"[yellow]Topology teardown: failed to stop {client_name}: "
                     f"{escape(str(e))}[/yellow]"
                 )
             try:
                 container.remove(force=True)
             except Exception as e:
                 console.print(
-                    f"[yellow]NAT teardown: failed to remove {client_name}: "
+                    f"[yellow]Topology teardown: failed to remove {client_name}: "
                     f"{escape(str(e))}[/yellow]"
                 )
         try:
-            from merobox.topology import teardown_nat_topology
+            if self._bootstrap_state is not None:
+                from merobox.topology import teardown_bootstrap_topology
 
-            teardown_nat_topology(self.manager.client, self._nat_state)
+                teardown_bootstrap_topology(self.manager.client, self._bootstrap_state)
+            else:
+                from merobox.topology import teardown_nat_topology
+
+                teardown_nat_topology(self.manager.client, self._nat_state)
         except Exception as e:
             console.print(
-                f"[yellow]NAT topology teardown raised: {escape(str(e))}[/yellow]"
+                f"[yellow]Topology teardown raised: {escape(str(e))}[/yellow]"
             )
         finally:
             self._nat_state = None
+            self._bootstrap_state = None
             # Drop the manager-side handle in lockstep so a
             # subsequent restart_container step (in a fresh
             # workflow that reuses the same manager) doesn't
@@ -1044,6 +1056,119 @@ class WorkflowExecutor:
             elif key in nodes_config:
                 run_node_kwargs[key] = nodes_config[key]
 
+    async def _start_nodes_bootstrap_topology(
+        self,
+        nodes_config: dict,
+        restart: bool,
+        image: Optional[str],
+    ) -> bool:
+        """Bring up one bridge with a boot-node and spawn N clients on it.
+
+        Called instead of the normal cluster-mode `_start_nodes` body when
+        the workflow declares `topology: { type: bootstrap }`. Each client
+        gets the boot-node as its ONLY bootstrap entry and `mdns=False`, so
+        the sole route to a sibling's address is asking the boot-node. That
+        is what makes a bootstrap/kad/rendezvous regression fail here.
+
+        Sibling wiring is deliberately skipped — `_wire_cluster_bootstrap_peers`
+        hands out exactly the roster this topology withholds. Unlike the NAT
+        path there is no gateway and no route injection, so a client is up as
+        soon as `run_node` returns.
+
+        Returns False on any failure; the caller's exit path tears the
+        topology down via the stored state either way.
+        """
+        from merobox.topology import setup_bootstrap_topology
+        from merobox.topology.bootstrap import bootstrap_multiaddrs
+        from merobox.topology.nat import slugify_workflow_name
+
+        topology_raw = self.topology or {}
+        if hasattr(topology_raw, "model_dump"):
+            topology_cfg = topology_raw.model_dump()
+        else:
+            topology_cfg = topology_raw
+
+        if "count" not in nodes_config:
+            keys = sorted(nodes_config.keys())
+            console.print(
+                "[red]❌ Bootstrap topology requires `nodes:` to use the "
+                f"`count:` form (saw keys: {keys}). Every client is spawned "
+                "with the same image and the same single bootstrap address, "
+                "so the individual-node list form has nothing to vary.[/red]"
+            )
+            return False
+
+        count = nodes_config["count"]
+        prefix = nodes_config.get("prefix", "calimero-node")
+        base_port = nodes_config.get("base_port", DEFAULT_P2P_PORT)
+        base_rpc_port = nodes_config.get("base_rpc_port", DEFAULT_RPC_PORT)
+        use_image_entrypoint = nodes_config.get("use_image_entrypoint", False)
+
+        if restart:
+            console.print(
+                "[yellow]Bootstrap topology ignores `restart: true` — clients "
+                "are always spawned fresh, and a restart would only re-read "
+                "the same single-entry bootstrap config[/yellow]"
+            )
+
+        boot_node_cfg = topology_cfg.get("boot_node") or {}
+        workflow_slug = slugify_workflow_name(
+            self.config.get("name", "merobox-bootstrap")
+        )
+
+        try:
+            self._bootstrap_state = setup_bootstrap_topology(
+                self.manager.client,
+                workflow_name=workflow_slug,
+                boot_node_image_override=boot_node_cfg.get("image"),
+            )
+        except Exception as e:
+            console.print(
+                f"[red]❌ Bootstrap topology setup failed: {escape(str(e))}[/red]"
+            )
+            return False
+
+        client_bootstrap_nodes = bootstrap_multiaddrs(self._bootstrap_state)
+        network_name = self._bootstrap_state.network.name
+
+        for i in range(count):
+            node_name = f"{prefix}-{i + 1}"
+            run_node_kwargs = self._build_run_node_kwargs(
+                node_name,
+                port=base_port + i,
+                rpc_port=base_rpc_port + i,
+                image=image,
+                use_image_entrypoint=use_image_entrypoint,
+            )
+            # Same bridge as the boot-node, so the clients can reach it.
+            run_node_kwargs["network"] = network_name
+            # The boot-node, and nothing else. Overriding the kwargs dict
+            # rather than `self.bootstrap_nodes` keeps the executor reusable
+            # across runs — a mutation would leak these addresses into the
+            # next workflow's config.
+            run_node_kwargs["bootstrap_nodes"] = client_bootstrap_nodes
+            # Fault overrides first, then force mdns off last so no
+            # per-node override can put multicast back and hide a broken
+            # discovery path behind it.
+            self._apply_fault_kwargs(run_node_kwargs, None, nodes_config)
+            run_node_kwargs["mdns"] = False
+
+            if not self.manager.run_node(**run_node_kwargs):
+                # Tear down here rather than leaving it to the caller: the
+                # boot-node, the bridge and any earlier clients are all up.
+                # Teardown is idempotent, so the outer exit path running it
+                # again is safe.
+                self._teardown_topology_if_present()
+                return False
+            self._bootstrap_state.client_names.append(node_name)
+
+        console.print(
+            f"[green]✓ Bootstrap topology: {count} client(s) on "
+            f"{network_name}, each holding one bootstrap address and no "
+            f"mDNS[/green]"
+        )
+        return True
+
     async def _start_nodes_nat_topology(
         self,
         nodes_config: dict,
@@ -1234,7 +1359,7 @@ class WorkflowExecutor:
                 # outer caller's `stop_all_nodes=True` path also
                 # gets called normally — duplicate teardown is
                 # safe.
-                self._teardown_nat_topology_if_present()
+                self._teardown_topology_if_present()
                 return False
             # Track the just-spawned client IMMEDIATELY (before
             # inject + reachability). If either of those later
@@ -1265,7 +1390,7 @@ class WorkflowExecutor:
                     f"[red]❌ Could not route {node_name} through the NAT "
                     f"gateway: {escape(str(e))}[/red]"
                 )
-                self._teardown_nat_topology_if_present()
+                self._teardown_topology_if_present()
                 return False
             # Even with the route installed, the kernel's
             # forwarding path (per-iface state, ARP cache, neighbour
@@ -1285,7 +1410,7 @@ class WorkflowExecutor:
                     f"[red]❌ {node_name} cannot reach the boot-node via "
                     f"the NAT gateway: {escape(str(e))}[/red]"
                 )
-                self._teardown_nat_topology_if_present()
+                self._teardown_topology_if_present()
                 return False
             # client_names was populated immediately after run_node
             # above; nothing left to track at this point — the
@@ -1335,7 +1460,7 @@ class WorkflowExecutor:
                 "is missing the autonat-failure → relay-reservation "
                 "trigger.[/red]"
             )
-            self._teardown_nat_topology_if_present()
+            self._teardown_topology_if_present()
             return False
         return True
 
@@ -1357,8 +1482,20 @@ class WorkflowExecutor:
         if self.topology is not None:
             if self.is_binary_mode:
                 console.print(
-                    "[red]❌ topology: { type: nat } is Docker-mode only "
-                    "(NAT routing needs the docker bridge + iptables container)[/red]"
+                    "[red]❌ `topology:` is Docker-mode only (both variants "
+                    "stand up their own bridges and a boot-node "
+                    "container)[/red]"
+                )
+                return False
+            topology_raw = self.topology
+            if hasattr(topology_raw, "model_dump"):
+                topology_type = topology_raw.model_dump().get("type")
+            else:
+                topology_type = (topology_raw or {}).get("type")
+            if topology_type not in ("nat", "bootstrap"):
+                console.print(
+                    f"[red]❌ Unknown topology type {topology_type!r}; "
+                    f"expected 'nat' or 'bootstrap'[/red]"
                 )
                 return False
             # Match the resolution order used by the normal
@@ -1371,6 +1508,10 @@ class WorkflowExecutor:
             client_image = (
                 self.image if self.image is not None else nodes_config.get("image")
             )
+            if topology_type == "bootstrap":
+                return await self._start_nodes_bootstrap_topology(
+                    nodes_config, restart, image=client_image
+                )
             return await self._start_nodes_nat_topology(
                 nodes_config, restart, image=client_image
             )

--- a/merobox/tests/unit/test_bootstrap_topology.py
+++ b/merobox/tests/unit/test_bootstrap_topology.py
@@ -1,0 +1,195 @@
+"""Unit tests for the single-bridge boot-node topology.
+
+Standing the topology up needs a real Docker daemon, so what is covered
+here is the YAML contract, the pure helpers, and — with a mocked docker
+client — the two properties the topology exists to guarantee: every
+client is given exactly one bootstrap address, and mDNS cannot be turned
+back on. Both are what make a discovery regression fail a scenario
+rather than being papered over.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from merobox.commands.bootstrap.config import (
+    BootstrapTopologyConfig,
+    WorkflowConfig,
+)
+from merobox.topology.bootstrap import (
+    BootstrapTopologyState,
+    bootstrap_multiaddrs,
+    setup_bootstrap_topology,
+    teardown_bootstrap_topology,
+)
+from merobox.topology.nat import BOOT_NODE_PORT
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_topology_validates_and_discriminates():
+    """`type: bootstrap` selects the bootstrap variant, not the NAT one."""
+    cfg = WorkflowConfig.model_validate(
+        {
+            "name": "boot",
+            "topology": {"type": "bootstrap"},
+            "nodes": {"count": 3},
+        }
+    )
+    assert isinstance(cfg.topology, BootstrapTopologyConfig)
+    assert cfg.topology.type == "bootstrap"
+
+
+def test_bootstrap_topology_takes_a_boot_node_image_override():
+    cfg = WorkflowConfig.model_validate(
+        {
+            "name": "boot",
+            "topology": {
+                "type": "bootstrap",
+                "boot_node": {"image": "ghcr.io/example/boot-node:pinned"},
+            },
+            "nodes": {"count": 2},
+        }
+    )
+    assert cfg.topology.boot_node.image == "ghcr.io/example/boot-node:pinned"
+
+
+def test_nat_mode_is_rejected_on_the_bootstrap_variant():
+    """`nat_mode` belongs to the NAT variant, and there is no gateway here
+    to configure. Accepting and ignoring it would leave a workflow reading
+    as though it had asked for something it did not get — so it fails
+    validation, naming the key."""
+    with pytest.raises(ValidationError) as err:
+        WorkflowConfig.model_validate(
+            {
+                "name": "boot",
+                "topology": {"type": "bootstrap", "nat_mode": "symmetric"},
+                "nodes": {"count": 2},
+            }
+        )
+    assert "nat_mode" in str(err.value)
+
+
+def test_unknown_topology_type_still_rejected():
+    with pytest.raises(ValidationError):
+        WorkflowConfig.model_validate(
+            {
+                "name": "bad",
+                "topology": {"type": "starnet"},
+                "nodes": {"count": 2},
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap addresses
+# ---------------------------------------------------------------------------
+
+
+def _state(ip="172.30.0.2", peer_id="12D3KooWBootNode"):
+    return BootstrapTopologyState(
+        network=MagicMock(name="network"),
+        boot_node_container=MagicMock(name="boot-node"),
+        boot_node_peer_id=peer_id,
+        boot_node_ip=ip,
+    )
+
+
+def test_bootstrap_multiaddrs_offer_one_peer_over_two_transports():
+    """One contact, TCP and QUIC — the shape a deployed node's config has.
+
+    The absence of sibling addresses is the point: if this ever returned
+    more than the boot-node, clients would no longer have to ask, and the
+    topology would stop testing discovery.
+    """
+    addrs = bootstrap_multiaddrs(_state())
+
+    assert addrs == [
+        f"/ip4/172.30.0.2/tcp/{BOOT_NODE_PORT}/p2p/12D3KooWBootNode",
+        f"/ip4/172.30.0.2/udp/{BOOT_NODE_PORT}/quic-v1/p2p/12D3KooWBootNode",
+    ]
+    assert all("12D3KooWBootNode" in a for a in addrs)
+
+
+# ---------------------------------------------------------------------------
+# Setup / teardown against a mocked docker client
+# ---------------------------------------------------------------------------
+
+
+@patch("merobox.topology.bootstrap._resolve_boot_node_peer_id")
+@patch("merobox.topology.bootstrap._resolve_container_ip")
+@patch("merobox.topology.bootstrap._spawn_boot_node")
+@patch("merobox.topology.bootstrap._pull_image_if_missing")
+@patch("merobox.topology.bootstrap._ensure_network")
+def test_setup_creates_a_non_internal_bridge(
+    ensure_network, _pull, spawn, resolve_ip, resolve_peer
+):
+    """The bridge must NOT be internal: clients need to reach the
+    boot-node on it. Internal is the NAT topology's LAN bridge, whose
+    whole purpose is to deny that."""
+    ensure_network.return_value = MagicMock(name="net")
+    spawn.return_value = MagicMock(name="boot")
+    resolve_ip.return_value = "172.31.0.2"
+    resolve_peer.return_value = "12D3KooWXyz"
+
+    state = setup_bootstrap_topology(MagicMock(), workflow_name="wf")
+
+    assert ensure_network.call_args.kwargs["internal"] is False
+    assert state.boot_node_ip == "172.31.0.2"
+    assert state.boot_node_peer_id == "12D3KooWXyz"
+    assert state.client_names == []
+
+
+@patch("merobox.topology.bootstrap._resolve_boot_node_peer_id")
+@patch("merobox.topology.bootstrap._resolve_container_ip")
+@patch("merobox.topology.bootstrap._spawn_boot_node")
+@patch("merobox.topology.bootstrap._pull_image_if_missing")
+@patch("merobox.topology.bootstrap._ensure_network")
+def test_setup_cleans_up_when_peer_id_never_appears(
+    ensure_network, _pull, spawn, resolve_ip, resolve_peer
+):
+    """A half-built topology left behind makes the next run of the same
+    workflow collide with its own leftovers, which surfaces as an
+    unrelated Docker error. So a failing setup owns nothing."""
+    network = MagicMock(name="net")
+    boot = MagicMock(name="boot")
+    ensure_network.return_value = network
+    spawn.return_value = boot
+    resolve_ip.return_value = "172.31.0.2"
+    resolve_peer.side_effect = RuntimeError("no peer id in boot-node log")
+
+    with pytest.raises(RuntimeError):
+        setup_bootstrap_topology(MagicMock(), workflow_name="wf")
+
+    boot.remove.assert_called_once()
+    network.remove.assert_called_once()
+
+
+def test_teardown_removes_boot_node_then_network():
+    state = _state()
+    teardown_bootstrap_topology(MagicMock(), state)
+
+    state.boot_node_container.remove.assert_called_once()
+    state.network.remove.assert_called_once()
+
+
+def test_teardown_still_removes_the_network_when_the_boot_node_fails():
+    """Best-effort and independently guarded: a teardown that aborts
+    halfway leaves a bridge that breaks the next run."""
+    state = _state()
+    state.boot_node_container.remove.side_effect = RuntimeError("daemon hiccup")
+
+    teardown_bootstrap_topology(MagicMock(), state)
+
+    state.network.remove.assert_called_once()
+
+
+def test_teardown_can_keep_the_network():
+    state = _state()
+    teardown_bootstrap_topology(MagicMock(), state, remove_networks=False)
+
+    state.boot_node_container.remove.assert_called_once()
+    state.network.remove.assert_not_called()

--- a/merobox/topology/__init__.py
+++ b/merobox/topology/__init__.py
@@ -1,19 +1,35 @@
-"""Multi-bridge / NAT topology primitives for merobox.
+"""Topology primitives for merobox.
 
-Default merobox cluster mode puts every node on a single Docker
-bridge so siblings reach each other directly via `/ip4/<sibling>/...`.
-That's the right shape for the bulk of e2e tests; the only thing it
-can't exercise is the relay-reservation-recovery code path in
-calimero-network/core#2446, which fires only when nodes physically
-cannot dial each other and depend on a relay.
+Default merobox cluster mode puts every node on a single Docker bridge
+and wires each node's `bootstrap.nodes` with all of its siblings, mDNS
+left on. That is convenient and unlike any deployment: a shipped node is
+told about one or two bootstrap peers, has to ask one of them who else
+exists, and has no multicast path to peers on other hosts.
 
-This package adds the NAT topology — `topology: { type: nat }` in
-the workflow YAML — which spawns a dedicated boot-node + a NAT
-gateway + N client merods on an `--internal` LAN bridge. Clients
-must register relay reservations with the boot-node to be
-reachable. See ``nat.py`` for the orchestration details.
+A `topology:` block in the workflow YAML replaces that wiring. Two
+variants:
+
+* ``nat`` (``nat.py``) — a boot-node on a public bridge, a NAT gateway,
+  and N clients on an ``--internal`` LAN bridge that can only reach each
+  other through the boot-node's relay circuit. The only shape that
+  exercises relay-reservation recovery (calimero-network/core#2446) and
+  DCUtR hole-punching.
+* ``bootstrap`` (``bootstrap.py``) — one plain bridge, one boot-node,
+  mDNS forced off, and a single bootstrap address per client. The same
+  ask-a-peer discovery path as ``nat``, without the relay, the gateway
+  or the route injection, so a bootstrap/kad/rendezvous regression fails
+  here and means only that.
 """
 
+from merobox.topology.bootstrap import (
+    setup_bootstrap_topology,
+    teardown_bootstrap_topology,
+)
 from merobox.topology.nat import setup_nat_topology, teardown_nat_topology
 
-__all__ = ["setup_nat_topology", "teardown_nat_topology"]
+__all__ = [
+    "setup_bootstrap_topology",
+    "setup_nat_topology",
+    "teardown_bootstrap_topology",
+    "teardown_nat_topology",
+]

--- a/merobox/topology/bootstrap.py
+++ b/merobox/topology/bootstrap.py
@@ -1,0 +1,182 @@
+"""Single-bridge boot-node topology: `topology: { type: bootstrap }`.
+
+Default cluster mode wires every node's `bootstrap.nodes` with the
+addresses of all its siblings, and leaves mDNS on. Both of those are
+harness conveniences a real deployment does not have. A shipped node is
+told about one or two bootstrap peers and has to ASK one of them who
+else exists — rendezvous register/discover — and it never has a
+multicast path to its peers, which live on other hosts.
+
+The NAT topology (`nat.py`) does exercise that discovery path, because
+its clients can only reach each other through the boot-node. But it does
+so while simultaneously testing relay reservations, DCUtR hole-punching
+and iptables MASQUERADE, so a discovery regression there presents as a
+NAT failure and gets triaged as one. This topology is the same discovery
+shape with those confounds removed: one plain bridge, one boot-node, no
+gateway, no relay pressure, no route injection.
+
+What each node gets:
+
+  * a single non-internal bridge shared with the boot-node and every
+    sibling, so any pair COULD dial directly once they know an address;
+  * exactly one entry in `bootstrap.nodes` — the boot-node — so the only
+    way to learn a sibling's address is to ask;
+  * `discovery.mdns = false`, forced after any workflow override, so
+    multicast cannot paper over a discovery failure.
+
+That combination makes the interesting failure legible: if bootstrap
+dialling, identify, kad or rendezvous regresses, nodes never learn about
+each other and the scenario fails on its own convergence assertions.
+Nothing else in the harness can carry the traffic.
+
+Deliberately NOT here: sibling bootstrap wiring (that is cluster mode,
+and it hands out the roster this topology exists to withhold) and the
+NAT gateway (a client that cannot dial its sibling directly is a relay
+test, which `nat.py` already owns).
+"""
+
+from dataclasses import dataclass, field
+
+import docker
+
+from merobox.commands.utils import console
+
+# Reused from the NAT topology rather than duplicated: these are generic
+# Docker/boot-node mechanics with hard-won details in them — the IPAM
+# population race in `_resolve_container_ip`, the peer-id scan that has
+# to tolerate the boot-node's log format, the create-vs-run auto-pull
+# asymmetry. A third topology variant is the point at which they should
+# move to a shared module; two does not justify the churn.
+from merobox.topology.nat import (
+    BOOT_NODE_IMAGE_TAG,
+    BOOT_NODE_PORT,
+    _ensure_network,
+    _pull_image_if_missing,
+    _resolve_boot_node_peer_id,
+    _resolve_container_ip,
+    _spawn_boot_node,
+)
+
+
+@dataclass
+class BootstrapTopologyState:
+    """Handles to the bridge + boot-node this topology created.
+
+    Mirrors `NatTopologyState` minus the LAN bridge and gateway, which
+    is the whole difference between the two topologies. The executor
+    holds it for the run and hands it back to
+    :func:`teardown_bootstrap_topology`.
+    """
+
+    network: docker.models.networks.Network
+    boot_node_container: docker.models.containers.Container
+    boot_node_peer_id: str
+    boot_node_ip: str
+    # Client containers are spawned through the normal NodeManager path;
+    # these are names rather than handles so a transient Docker
+    # reconnect cannot invalidate them before teardown runs.
+    client_names: list[str] = field(default_factory=list)
+
+
+def setup_bootstrap_topology(
+    client: docker.DockerClient,
+    workflow_name: str,
+    boot_node_image_override: str | None = None,
+) -> BootstrapTopologyState:
+    """Create the bridge and boot-node, and return the state to tear down.
+
+    Raises on any failure after cleaning up whatever it had already
+    created, so a caller that sees an exception owns nothing.
+    """
+    network_name = f"{workflow_name}-bootstrap"
+    boot_node_image = boot_node_image_override or BOOT_NODE_IMAGE_TAG
+
+    # Non-internal: the clients need the bridge to reach the boot-node,
+    # and unlike the NAT topology we are not trying to prevent direct
+    # sibling dials — only to withhold the addresses that would make
+    # them possible without asking.
+    network = _ensure_network(client, network_name, internal=False)
+
+    boot_node = None
+    try:
+        _pull_image_if_missing(client, boot_node_image)
+        boot_node = _spawn_boot_node(client, boot_node_image, network, workflow_name)
+        boot_node_ip = _resolve_container_ip(boot_node, network.name)
+        boot_node_peer_id = _resolve_boot_node_peer_id(boot_node)
+    except Exception:
+        # Undo in reverse order. Leaving a half-built topology behind
+        # would make the next run of the same workflow collide with its
+        # own leftovers, which reads as an unrelated Docker error.
+        if boot_node is not None:
+            try:
+                boot_node.remove(force=True)
+            except Exception:
+                pass
+        try:
+            network.remove()
+        except Exception:
+            pass
+        raise
+
+    console.print(
+        f"[green]✓ Bootstrap topology up: boot-node at "
+        f"/ip4/{boot_node_ip}/tcp/{BOOT_NODE_PORT}/p2p/{boot_node_peer_id} "
+        f"on {network.name}[/green]"
+    )
+
+    return BootstrapTopologyState(
+        network=network,
+        boot_node_container=boot_node,
+        boot_node_peer_id=boot_node_peer_id,
+        boot_node_ip=boot_node_ip,
+    )
+
+
+def bootstrap_multiaddrs(state: BootstrapTopologyState) -> list[str]:
+    """The single bootstrap entry every client is given.
+
+    TCP and QUIC forms of the same peer — one contact, two transports,
+    which is what a deployed node's config looks like. Sibling addresses
+    are deliberately absent: learning those is the thing under test.
+    """
+    return [
+        f"/ip4/{state.boot_node_ip}/tcp/{BOOT_NODE_PORT}/p2p/{state.boot_node_peer_id}",
+        f"/ip4/{state.boot_node_ip}/udp/{BOOT_NODE_PORT}/quic-v1/p2p/{state.boot_node_peer_id}",
+    ]
+
+
+def teardown_bootstrap_topology(
+    client: docker.DockerClient,
+    state: BootstrapTopologyState,
+    remove_networks: bool = True,
+) -> None:
+    """Remove the boot-node and its bridge.
+
+    Client containers are stopped by the normal node-management teardown;
+    this owns only what :func:`setup_bootstrap_topology` created. Every
+    step is best-effort and independently guarded — a teardown that
+    aborts halfway leaves resources that break the next run, so a
+    failure to remove one thing must not skip the rest.
+    """
+    try:
+        state.boot_node_container.remove(force=True)
+    except docker.errors.NotFound:
+        pass
+    except Exception as e:
+        console.print(f"[yellow]Could not remove boot-node: {e}[/yellow]")
+
+    if not remove_networks:
+        return
+
+    # The bridge only goes once its last endpoint is gone; clients are
+    # torn down by the caller, so a still-attached client here means the
+    # caller's ordering changed and the warning is the signal for that.
+    try:
+        state.network.remove()
+    except docker.errors.NotFound:
+        pass
+    except Exception as e:
+        console.print(
+            f"[yellow]Could not remove network {state.network.name}: {e} "
+            f"(a client container may still be attached)[/yellow]"
+        )


### PR DESCRIPTION
Enables the remaining half of calimero-network/core#3525. Core now has scenarios that discover peers without mDNS (calimero-network/core#3585), but they get every sibling's address handed to them up front — so they test dialling and kad, not *finding*. This is the variant that tests finding.

## The gap

Default cluster mode writes every sibling's address into each node's `bootstrap.nodes` and leaves mDNS on. Both are harness conveniences no deployment has: a shipped node is told about one or two bootstrap peers, has to **ask** one of them who else exists, and has no multicast path to peers living on other hosts.

`type: nat` does exercise that asking — its clients can only reach each other through the boot-node. But it does so while simultaneously testing relay reservations, DCUtR hole-punching and iptables MASQUERADE, and those scenarios are the most environment-sensitive in the suite. A discovery regression there presents as a NAT failure and gets triaged as one.

## What this adds

`topology: { type: bootstrap }` — one plain bridge, one boot-node, no gateway, no route injection. Each client gets:

- a single `bootstrap.nodes` entry, the boot-node, TCP and QUIC — the shape a deployed node's config actually has;
- `discovery.mdns = false`, forced *after* any per-node override so multicast cannot paper over a broken path;
- no sibling addresses, because learning those is the thing under test.

Sibling wiring is skipped deliberately: `_wire_cluster_bootstrap_peers` hands out precisely the roster this topology withholds.

## Verification

Ten unit tests cover the schema, the discriminator, the single-contact address list, and setup/teardown against a mocked client — including that a setup which fails partway removes the boot-node **and** the bridge, since a half-built topology makes the next run of the same workflow collide with its own leftovers.

More usefully, a 3-client run against real containers, joining a namespace and passing a joiner-to-joiner write:

| client | mDNS dials | kad `RoutingUpdated` | rendezvous Registered | rendezvous Discovered |
|---|---:|---:|---:|---:|
| client-1 | **0** | 6 | 9 | 2 |
| client-2 | **0** | 8 | 29 | 3 |
| client-3 | **0** | 10 | 7 | 4 |

Zero multicast, and every client both registered with and discovered through the boot-node's rendezvous server. The write from client-2 was read back by client-3 — two nodes neither of which was ever handed the other's address. That is the code path with no single-bridge coverage today.

## Schema change

`TopologyConfig` becomes a discriminated union on `type`. That is the migration the module's own comment block described as future work, and the second variant requires it: without an explicit discriminator, every variant's optional fields become candidates and a bad `type:` reports a vague union error instead of naming the topology. The stale comment describing the migration is removed, since this is it.

`BootstrapTopologyConfig` sets `extra="forbid"` — stricter than its neighbours on purpose. Its only keys are `type` and `boot_node`, so anything else is a mistake worth naming, most likely a `nat_mode` carried over by copying a NAT workflow. Accepting and ignoring it would leave a scenario reading as though it configured a gateway it does not have; #349 is the general form of that complaint.

## Notes for review

The generic Docker/boot-node helpers (`_ensure_network`, `_spawn_boot_node`, `_resolve_container_ip`, `_resolve_boot_node_peer_id`, `_pull_image_if_missing`) are **imported from `nat.py`** rather than duplicated or extracted to a shared module. They carry details that were expensive to get right — the IPAM population race, the peer-id log scan, the `create()`-does-not-auto-pull asymmetry — so duplicating them would be worse than the import. A third variant is the point at which they should move; two did not seem to justify the churn in the same PR as a feature. Happy to extract if you'd rather.

`_teardown_nat_topology_if_present` is renamed to `_teardown_topology_if_present` and dispatches on which state is populated, since it now owns both.

Unit suite: 1415 passed, 18 failed — the 18 are the pre-existing `test_migrations_v2_steps.py` failures from the local `calimero-client-py` version floor, identical on master. `black` and `ruff` clean. Docs and changelog updated.

Once this is released, core gets one `topology: { type: bootstrap }` scenario and #3525's last criterion is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Docker topology setup/teardown and workflow node startup, so a bug can leak containers/networks or silently change how clients discover peers. Schema is a discriminated union; existing `type: nat` YAML should still parse.
> 
> **Overview**
> Adds **`topology: { type: bootstrap }`**: one non-internal bridge, one boot-node, each client gets only that boot-node in `bootstrap.nodes`, and **mDNS is forced off** after per-node overrides. Sibling wiring is skipped so discovery (bootstrap → identify → kad → rendezvous) is the only way nodes learn about each other — unlike default cluster mode, and without NAT/relay/DCUtR mixing failures.
> 
> `TopologyConfig` is now a **discriminated union** on `type` (`nat` | `bootstrap`). The bootstrap variant **forbids extra keys** so a copied `nat_mode` fails validation. Executor teardown is generalized to `_teardown_topology_if_present` and dispatches on which state is set. Docker-only; `nodes:` must use `count:`.
> 
> Reuses NAT boot-node helpers rather than extracting them. Unit tests cover schema, single-contact multiaddrs, and mocked setup/teardown (including cleanup on partial setup failure). Version **0.6.60**; docs updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c8d4ae9423c0d94e8347d2fb285955aac63ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->