### PR TITLE
feat(wait_for_sync): gate on a read, not just a converged hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`wait_for_sync` can gate on a read instead of a hash.** An optional
+  `expect: {method, args, equals}` block makes the step wait until that read
+  returns `equals` on *every* node, not merely until the nodes agree on a state
+  hash. A hash is a claim about state, not proof of it: a node can publish a
+  root it does not hold (calimero-network/core#3595, #3596), and even truthful
+  hashes can agree a few milliseconds before a pending delta finishes applying,
+  so the read that follows still misses. Both show up as `✓ All targets synced`
+  followed by an assertion reading `null`. `equals` is compared against the
+  call's `data` payload — the same shape a following `json_assert` sees — so an
+  existing assertion moves into `expect` unchanged. The read is only probed once
+  the hashes agree, since each probe executes on every node, and a failure
+  prints each node's observed value beside the expected one
+
 ### Changed
 
 - **Requires `calimero-client-py>=0.6.31`.** calimero-network/core#3598 renamed

--- a/LLM.md
+++ b/LLM.md
@@ -1184,6 +1184,47 @@ outputs:
   seconds: 2 # Allow node to fully sync
 ```
 
+### 2b. Wait on the State You Are About to Assert
+
+`wait_for_sync` converges on a state hash. A hash is a *claim* about state, not
+proof of it, and it can be satisfied while the read you are about to make still
+misses:
+
+- a node can publish a root hash whose state it does not actually hold
+  (calimero-network/core#3595, #3596);
+- even truthful hashes can agree a few milliseconds before a pending delta
+  finishes applying, so the read that follows loses the race.
+
+Both produce the same signature — `✓ All targets synced` immediately, followed
+by an assertion that reads `null`. Declare `expect:` and the step waits for the
+value itself, on every node, rather than for agreement about a hash:
+
+```yaml
+- name: Wait for root context sync
+  type: wait_for_sync
+  context_id: "{{ctx}}"
+  nodes:
+    - node-1
+    - node-2
+  expect:
+    method: get
+    args:
+      key: "ns_root_key"
+    equals:
+      output: "from_node1"
+```
+
+`equals` is compared against the call's `data` payload — the same shape a
+following `json_assert` sees from `outputs: {x: result}`, so an existing
+assertion can be moved into `expect` unchanged. `equals: null` is a valid
+expectation (a read that must return nothing); a node that cannot be read at
+all never satisfies it.
+
+The hash targets still apply: `expect` is an additional condition, and it is
+only probed once the hashes agree, since each probe executes on every node.
+On failure the step prints each node's observed value next to the expected one
+— hashes agreeing while the reads disagree is the diagnosis, not a mystery.
+
 ### 3. Use Assertions to Validate State
 
 ```yaml

--- a/merobox/commands/bootstrap/README.md
+++ b/merobox/commands/bootstrap/README.md
@@ -90,7 +90,7 @@ Generate a sample workflow configuration file.
 - **repeat**: Loop through step sequences
 - **parallel**: Execute multiple step groups concurrently (see [Parallel Execution](#parallel-execution))
 - **wait**: Add delays between steps
-- **wait_for_sync**: Wait for nodes to reach consensus (root hash verification)
+- **wait_for_sync**: Wait for nodes to reach consensus (state-hash convergence, plus an optional `expect:` read that must return a given value on every node — gate on that when the scenario cares whether a write is readable, since a hash is a claim about state rather than proof of it)
 - **script**: Execute custom scripts
 
 ## Parallel Execution

--- a/merobox/commands/bootstrap/steps/wait_for_sync.py
+++ b/merobox/commands/bootstrap/steps/wait_for_sync.py
@@ -1,6 +1,14 @@
 """
 Wait for sync step executor — waits for nodes to converge on context state
-hash, group governance state hash, or both.
+hash, group governance state hash, or both, and optionally on a *read* that
+must return an expected value on every node.
+
+A converged state hash is a claim about state, not proof of it. Two ways it
+misleads, both observed in CI: a node can publish a root hash whose state it
+does not actually hold (calimero-network/core#3595, #3596), and even truthful
+hashes can agree a few milliseconds before a pending delta finishes applying,
+so the read that follows still misses. `expect:` closes both by waiting on the
+value the scenario is about to assert.
 """
 
 import asyncio
@@ -8,6 +16,7 @@ import time
 from typing import Any
 
 from merobox.commands.bootstrap.steps.base import BaseStep
+from merobox.commands.call import call_function
 from merobox.commands.client import get_client_for_rpc_url
 from merobox.commands.constants import (
     SYNC_BACKOFF_FACTOR,
@@ -23,12 +32,27 @@ from merobox.commands.utils import (
 )
 
 
+class _ExpectUnread:
+    """Sentinel: the ``expect`` read could not be performed on a node.
+
+    Distinct from a read that legitimately returned ``None`` — conflating the
+    two would let an unreachable node satisfy an ``equals: null`` expectation.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "<unread>"
+
+
+_EXPECT_UNREAD = _ExpectUnread()
+
+
 def _build_success_details(
     targets: list[dict],
     converged_hashes: dict[str, str],
     per_target_state: dict[str, dict[str, str | None]],
     elapsed: float,
     attempt: int,
+    expect_observed: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the success result dict with backwards-compatible top-level keys.
 
@@ -48,6 +72,9 @@ def _build_success_details(
         "attempts": attempt,
         "per_target_node_hashes": per_target_state,
     }
+    if expect_observed is not None:
+        details["expect_satisfied"] = True
+        details["per_node_expect"] = expect_observed
     for target in targets:
         label = f"{target['kind']}={target['id']}"
         hash_val = converged_hashes.get(label)
@@ -184,6 +211,32 @@ class WaitForSyncStep(BaseStep):
         ):
             raise ValueError(f"Step '{step_name}': 'trigger_sync' must be a boolean")
 
+        # Validate the optional `expect` block.
+        if self.config.get("expect") is not None:
+            expect = self.config["expect"]
+            if not isinstance(expect, dict):
+                raise ValueError(f"Step '{step_name}': 'expect' must be a dictionary")
+            if not isinstance(expect.get("method"), str) or not expect["method"]:
+                raise ValueError(
+                    f"Step '{step_name}': 'expect.method' must be a non-empty string"
+                )
+            if "args" in expect and not isinstance(expect["args"], dict):
+                raise ValueError(
+                    f"Step '{step_name}': 'expect.args' must be a dictionary"
+                )
+            # `equals: null` is a legitimate expectation, so presence is what
+            # matters here, not truthiness.
+            if "equals" not in expect:
+                raise ValueError(
+                    f"Step '{step_name}': 'expect.equals' is required — it is the value "
+                    f"the read must return on every node"
+                )
+            if not has_context_id:
+                raise ValueError(
+                    f"Step '{step_name}': 'expect' needs 'context_id' — the read is "
+                    f"executed in that context"
+                )
+
     async def _fetch_hash(
         self,
         target: dict,
@@ -310,6 +363,104 @@ class WaitForSyncStep(BaseStep):
         unique = {h for h in node_hashes.values() if h is not None}
         return len(unique) == 1, node_hashes
 
+    def _resolve_nested(
+        self,
+        value: Any,
+        workflow_results: dict[str, Any],
+        dynamic_values: dict[str, Any],
+    ) -> Any:
+        """Resolve ``{{placeholders}}`` anywhere inside a nested structure."""
+        if isinstance(value, dict):
+            return {
+                k: self._resolve_nested(v, workflow_results, dynamic_values)
+                for k, v in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                self._resolve_nested(v, workflow_results, dynamic_values) for v in value
+            ]
+        if isinstance(value, str):
+            return self._resolve_dynamic_value(value, workflow_results, dynamic_values)
+        return value
+
+    async def _read_expect_on_node(
+        self,
+        expect: dict,
+        context_id: str,
+        node_name: str,
+    ) -> tuple[str, Any]:
+        """Run the ``expect`` read on one node.
+
+        Returns ``(node_name, observed)``, where ``observed`` is the call's
+        ``data`` payload — the same shape a following ``json_assert`` sees when
+        an ``execute`` step captures ``outputs: {x: result}``. A failed or
+        errored call yields the ``_EXPECT_UNREAD`` sentinel rather than
+        ``None``, because ``None`` is itself a legitimate observed value and
+        must not be mistaken for "could not read".
+        """
+        try:
+            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
+        except Exception as e:
+            console.print(f"[red]Failed to resolve node {node_name}: {str(e)}[/red]")
+            return node_name, _EXPECT_UNREAD
+
+        try:
+            result = await call_function(
+                rpc_url,
+                context_id,
+                expect["method"],
+                expect.get("args") or {},
+                node_name=client_node_name,
+            )
+        except (
+            RuntimeError,
+            ValueError,
+            ConnectionError,
+            TimeoutError,
+            OSError,
+        ) as e:
+            vprint(
+                f"[dim]⚠️  expect read failed on {node_name}: {str(e)}[/dim]",
+                level=LOG_LEVEL_VERBOSE,
+            )
+            return node_name, _EXPECT_UNREAD
+
+        if not isinstance(result, dict) or not result.get("success"):
+            return node_name, _EXPECT_UNREAD
+        return node_name, result.get("data")
+
+    async def _check_expect_convergence(
+        self,
+        expect: dict,
+        context_id: str,
+        nodes: list[str],
+    ) -> tuple[bool, dict[str, Any]]:
+        """Run the ``expect`` read on every node.
+
+        Satisfied only when every node returned the expected value. One node
+        still short is the whole point of the gate: it is the node whose read
+        the scenario would otherwise have raced.
+        """
+        results = await asyncio.gather(
+            *(self._read_expect_on_node(expect, context_id, node) for node in nodes)
+        )
+        observed = dict(results)
+        expected = expect["equals"]
+        return all(v == expected for v in observed.values()), observed
+
+    @staticmethod
+    def _render_expect(observed: dict[str, Any], expected: Any) -> list[str]:
+        """One line per node describing how its read compares to ``expected``."""
+        lines = []
+        for node, value in observed.items():
+            if value is _EXPECT_UNREAD:
+                lines.append(f"{node}: <could not read>")
+            elif value == expected:
+                lines.append(f"{node}: matches")
+            else:
+                lines.append(f"{node}: {value!r}")
+        return lines
+
     @staticmethod
     def _target_label(target: dict) -> str:
         """Human-readable label for log lines."""
@@ -325,12 +476,19 @@ class WaitForSyncStep(BaseStep):
         trigger_sync: bool = False,
         initial_check_interval: float = SYNC_INITIAL_CHECK_INTERVAL,
         backoff_factor: float = SYNC_BACKOFF_FACTOR,
+        expect: dict | None = None,
+        expect_context_id: str | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         """
         Wait for all targets to converge across all nodes.
 
         A target converges when every node returns the same hash for it.
         All specified targets must converge for the overall result to succeed.
+
+        When ``expect`` is given, every node must additionally return
+        ``expect["equals"]`` from the declared read. That is the only condition
+        here that observes state rather than a claim about it, so a scenario
+        that cares whether a write is readable should declare it.
 
         Polling uses adaptive backoff: the inter-attempt sleep starts at
         ``initial_check_interval`` and grows geometrically by
@@ -358,6 +516,7 @@ class WaitForSyncStep(BaseStep):
         )
 
         last_per_target: dict[str, dict[str, str | None]] = {}
+        last_expect: dict[str, Any] | None = None
 
         # Adaptive backoff: the inter-attempt sleep starts short and grows
         # geometrically, capped at check_interval. Never start above the cap.
@@ -390,12 +549,29 @@ class WaitForSyncStep(BaseStep):
 
             last_per_target = per_target_state
 
+            # Only probe the read once the hashes agree: before that the answer
+            # is known to be "not yet", and each probe is a real execution on
+            # every node.
+            expect_observed = None
+            if expect is not None and all_converged:
+                expect_ok, expect_observed = await self._check_expect_convergence(
+                    expect, expect_context_id, nodes
+                )
+                last_expect = expect_observed
+                if not expect_ok:
+                    all_converged = False
+
             if all_converged:
                 console.print(
                     f"[green]✓ All targets synced after {elapsed:.2f}s ({attempt} attempts)![/green]"
                 )
                 for label, hash_val in converged_hashes.items():
                     console.print(f"[green]  {label}: {hash_val}[/green]")
+                if expect is not None:
+                    console.print(
+                        f"[green]  expect {expect['method']}: observed on all "
+                        f"{len(nodes)} node(s)[/green]"
+                    )
 
                 return True, _build_success_details(
                     targets,
@@ -403,6 +579,7 @@ class WaitForSyncStep(BaseStep):
                     per_target_state,
                     elapsed,
                     attempt,
+                    expect_observed,
                 )
 
             # Report what didn't converge yet. This per-attempt block is the
@@ -439,6 +616,10 @@ class WaitForSyncStep(BaseStep):
                             level=LOG_LEVEL_VERBOSE,
                         )
 
+            if expect is not None and last_expect is not None:
+                for line in self._render_expect(last_expect, expect["equals"]):
+                    vprint(f"[dim]  · expect {line}[/dim]", level=LOG_LEVEL_VERBOSE)
+
             # Sleep the current backoff interval before the next check, with a
             # small jitter folded on top to de-sync parallel node pollers, then
             # grow the interval geometrically toward the check_interval cap.
@@ -467,6 +648,15 @@ class WaitForSyncStep(BaseStep):
                 all_converged = False
         last_per_target = per_target_state
 
+        expect_observed = None
+        if expect is not None and all_converged:
+            expect_ok, expect_observed = await self._check_expect_convergence(
+                expect, expect_context_id, nodes
+            )
+            last_expect = expect_observed
+            if not expect_ok:
+                all_converged = False
+
         if all_converged:
             console.print(
                 f"[green]✓ All targets synced after {elapsed:.2f}s ({attempt} attempts, verified on final check)[/green]"
@@ -479,6 +669,7 @@ class WaitForSyncStep(BaseStep):
                 last_per_target,
                 elapsed,
                 attempt,
+                expect_observed,
             )
 
         console.print(
@@ -489,6 +680,19 @@ class WaitForSyncStep(BaseStep):
             console.print(f"[red]    {label}:[/red]")
             for node, hash_val in node_hashes.items():
                 console.print(f"[red]      {node}: {hash_val or 'N/A'}[/red]")
+        if expect is not None:
+            # Hashes agreeing while this does not is the interesting failure:
+            # it means convergence was claimed but the state is not readable.
+            console.print(
+                f"[red]    expect {expect['method']} (want {expect['equals']!r}):[/red]"
+            )
+            if last_expect is None:
+                console.print(
+                    "[red]      never probed — the state hashes never converged[/red]"
+                )
+            else:
+                for line in self._render_expect(last_expect, expect["equals"]):
+                    console.print(f"[red]      {line}[/red]")
 
         return False, {
             "synced": False,
@@ -501,6 +705,7 @@ class WaitForSyncStep(BaseStep):
             "elapsed_seconds": round(elapsed, 2),
             "attempts": attempt,
             "per_target_node_hashes": last_per_target,
+            "per_node_expect": last_expect,
         }
 
     async def execute(
@@ -533,6 +738,21 @@ class WaitForSyncStep(BaseStep):
         )
         backoff_factor = self.config.get("backoff_factor", SYNC_BACKOFF_FACTOR)
 
+        expect = self.config.get("expect")
+        expect_context_id = None
+        if expect is not None:
+            expect = {
+                "method": expect["method"],
+                "args": self._resolve_nested(
+                    expect.get("args") or {}, workflow_results, dynamic_values
+                ),
+                "equals": self._resolve_nested(
+                    expect["equals"], workflow_results, dynamic_values
+                ),
+            }
+            # Validation guarantees a context target exists when expect is set.
+            expect_context_id = next(t["id"] for t in targets if t["kind"] == "context")
+
         vprint(
             "\n[bold cyan]⏳ Waiting for node synchronization...[/bold cyan]",
             level=LOG_LEVEL_NORMAL,
@@ -547,6 +767,8 @@ class WaitForSyncStep(BaseStep):
             trigger_sync,
             initial_check_interval,
             backoff_factor,
+            expect,
+            expect_context_id,
         )
 
         if "outputs" in self.config:

--- a/merobox/tests/unit/test_wait_for_sync_step.py
+++ b/merobox/tests/unit/test_wait_for_sync_step.py
@@ -186,3 +186,147 @@ def test_invalid_backoff_config_rejected(bad_config, field):
 def test_backoff_factor_one_is_accepted():
     # factor == 1 is the lower bound (legacy fixed interval), must validate.
     _make_step({"backoff_factor": 1})
+
+
+# ---------------------------------------------------------------------------
+# `expect`: gate on a read, not on a hash
+#
+# A converged state hash is a claim about state, not proof of it — a node can
+# publish a root it cannot back, and even truthful hashes can agree a few
+# milliseconds before a pending delta finishes applying. These tests pin that
+# agreeing hashes alone are no longer enough to declare sync when the scenario
+# has declared what it expects to read.
+# ---------------------------------------------------------------------------
+
+EXPECT = {"method": "get", "args": {"key": "k"}, "equals": {"output": "v"}}
+
+
+def _run_with_expect(step, expect, reads_per_attempt, converge_on_attempt=1):
+    """Run ``_wait_for_sync`` with stubbed hash convergence and expect reads.
+
+    ``reads_per_attempt`` is a list of per-node read maps, consumed one entry
+    per probe; the last entry repeats once exhausted. Returns
+    ``(result, details, probe_count)``.
+    """
+    attempts = {"n": 0}
+    probes = {"n": 0}
+
+    async def fake_check(target, nodes, trigger_sync):
+        attempts["n"] += 1
+        converged = attempts["n"] >= converge_on_attempt
+        return converged, dict.fromkeys(nodes, "h" if converged else None)
+
+    async def fake_expect(expect_arg, context_id, nodes):
+        index = min(probes["n"], len(reads_per_attempt) - 1)
+        probes["n"] += 1
+        observed = reads_per_attempt[index]
+        return all(v == expect_arg["equals"] for v in observed.values()), observed
+
+    async def run():
+        with (
+            patch.object(step, "_check_target_convergence", side_effect=fake_check),
+            patch.object(step, "_check_expect_convergence", side_effect=fake_expect),
+            patch(
+                "merobox.commands.bootstrap.steps.wait_for_sync.asyncio.sleep",
+                side_effect=lambda _d: asyncio.sleep(0),
+            ),
+        ):
+            return await step._wait_for_sync(
+                TARGETS,
+                NODES,
+                timeout=30,
+                check_interval=0.01,
+                initial_check_interval=0.01,
+                retry_attempts=4,
+                expect=expect,
+                expect_context_id="ctx-1",
+            )
+
+    result, details = asyncio.run(run())
+    return result, details, probes["n"]
+
+
+def test_expect_satisfied_on_every_node_reports_sync():
+    step = _make_step({"expect": EXPECT})
+    both_match = {node: {"output": "v"} for node in NODES}
+    result, details, probes = _run_with_expect(step, EXPECT, [both_match])
+
+    assert result is True
+    assert details["expect_satisfied"] is True
+    assert probes == 1
+
+
+def test_agreeing_hashes_do_not_declare_sync_while_a_node_cannot_read_it():
+    """The exact shape of the CI flake this gate exists for.
+
+    Both nodes report the same state hash, so the pre-existing hash-equality
+    check would have declared sync immediately — and the scenario's next read
+    would have raced an apply that had not landed. One node still returning a
+    stale value must keep the step waiting.
+    """
+    step = _make_step({"expect": EXPECT})
+    one_behind = {NODES[0]: {"output": "v"}, NODES[1]: {"output": None}}
+    result, details, probes = _run_with_expect(step, EXPECT, [one_behind])
+
+    assert result is False
+    assert probes > 1, "a miss must be retried, not accepted"
+    assert details["per_node_expect"] == one_behind
+
+
+def test_expect_that_catches_up_mid_wait_succeeds():
+    """The lagging node materialises the write on a later probe."""
+    step = _make_step({"expect": EXPECT})
+    behind = {NODES[0]: {"output": "v"}, NODES[1]: {"output": None}}
+    caught_up = {node: {"output": "v"} for node in NODES}
+    result, details, probes = _run_with_expect(step, EXPECT, [behind, caught_up])
+
+    assert result is True
+    assert details["expect_satisfied"] is True
+    assert probes == 2
+
+
+def test_expect_is_not_probed_until_the_hashes_agree():
+    """Each probe is a real execution on every node, so don't spend them
+    while the answer is already known to be "not yet"."""
+    step = _make_step({"expect": EXPECT})
+    both_match = {node: {"output": "v"} for node in NODES}
+    result, _details, probes = _run_with_expect(
+        step, EXPECT, [both_match], converge_on_attempt=3
+    )
+
+    assert result is True
+    assert probes == 1, "probed only after the hashes converged on attempt 3"
+
+
+@pytest.mark.parametrize(
+    "bad_expect,fragment",
+    [
+        ({"args": {}, "equals": 1}, "expect.method"),
+        ({"method": "", "equals": 1}, "expect.method"),
+        ({"method": "get"}, "expect.equals"),
+        ({"method": "get", "args": [], "equals": 1}, "expect.args"),
+        ("not-a-dict", "'expect' must be a dictionary"),
+    ],
+)
+def test_invalid_expect_rejected(bad_expect, fragment):
+    with pytest.raises(ValueError, match=fragment):
+        _make_step({"expect": bad_expect})
+
+
+def test_expect_equals_null_is_a_valid_expectation():
+    """`equals: null` asserts a read returns nothing — presence of the key is
+    what's required, not a truthy value."""
+    step = _make_step({"expect": {"method": "get", "equals": None}})
+    assert step.config["expect"]["equals"] is None
+
+
+def test_expect_requires_a_context_to_read_in():
+    with pytest.raises(ValueError, match="needs 'context_id'"):
+        WaitForSyncStep(
+            {
+                "type": "wait_for_sync",
+                "group_id": "grp-1",
+                "nodes": NODES,
+                "expect": EXPECT,
+            }
+        )


### PR DESCRIPTION
## The problem

`wait_for_sync` declared success when every node reported the same state hash. A hash is a **claim** about state, not proof of it, and it can be satisfied while the read the scenario is about to make still misses:

- a node can publish a root hash whose state it does not hold — calimero-network/core#3595 and #3596;
- even with truthful hashes, agreement can land a few milliseconds before a pending delta finishes applying, so the following read loses the race. In the run that prompted this, by **4ms**.

Both produce the same signature, which reads like a product bug:

```
✓ All targets synced after 0.00s (1 attempts)!
  context=7wX23f…: B66sV3mV…
✗ JSON equality failed
  left={'output': None}
  right='{"output": "from_node1"}'
```

The core-side causes are fixed, but the harness weakness is structural and outlives them: nothing in the step knew *what* it was waiting for, so it could only ever check that nodes agreed — never that the state was there.

## What this adds

An optional `expect` block, so the step waits for the value itself on every node:

```yaml
- name: Wait for root context sync
  type: wait_for_sync
  context_id: "{{root_ctx_id}}"
  nodes: [e2e-node-1, e2e-node-2]
  expect:
    method: get
    args:
      key: "ns_root_key"
    equals:
      output: "from_node1"
```

`equals` is compared against the call's `data` payload — the same shape a following `json_assert` sees from `outputs: {x: result}` — so an existing assertion moves into `expect` unchanged. The wait and the assert stop being two separate observations with a race between them.

## Design notes

- **Probed only after the hashes agree.** Before that the answer is known to be "not yet", and each probe is a real execution on every node.
- **"Could not read" is distinct from "read returned null."** A sentinel keeps an unreachable node from satisfying `equals: null`, which would be a silently green negative test.
- **`equals` is checked for presence, not truthiness**, so `equals: null` is a valid expectation.
- **Additive.** Hash targets are unchanged and still required. `expect` needs `context_id`, since the read executes in that context — validated up front.
- **Failure output names the diagnosis.** Each node's observed value is printed beside the expected one; hashes agreeing while the reads disagree is the finding, not a mystery to go dig for.

## Tests

10 new tests in `test_wait_for_sync_step.py` (23 in that file now, 151 across the three `wait_for_sync`-related files), including the exact flake shape: **both nodes report the same hash — which the old logic would have accepted immediately — while one still returns a stale value, and the step keeps waiting.** Plus catch-up-mid-wait, the probe-only-after-convergence guarantee, and validation coverage.

I extended the existing test file rather than adding a new one, since new files that call `asyncio.run` have broken the legacy suite before.

## Checks

`black --check` and `ruff check` clean. Full unit suite: **38 failed / 1396 passed** — byte-identical failure set to master's **38 failed / 1385 passed** (verified by diffing the `FAILED` lists), so all 38 are pre-existing and need live containers. Net effect is +11 passing.

## Follow-up

The value lands once scenarios adopt it, which needs a merobox release first because core pins `MIN_MEROBOX`. The natural first adopter is `group-subgroup`, the scenario this came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the sync-wait path used by e2e workflows and issues extra contract calls after hash convergence. Behavior is additive and covered by unit tests, but a mis-specified `expect` can timeout a previously green wait.
> 
> **Overview**
> Optional `expect: {method, args, equals}` on `wait_for_sync` waits until that contract read returns `equals` on **every** node, not just until state hashes agree. Hash agreement can still race a pending apply or a published root the node does not hold, which showed up as `✓ All targets synced` then a `null` assertion.
> 
> The read is probed only after hashes converge. Failed/unread calls use a sentinel so they cannot satisfy `equals: null`. Failures print each node's observed value next to the expected one. Existing hash-only workflows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4311cbb8d71145acd508c35613c36444a1e136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->