### PR TITLE
fix(wait_for_sync): put `expect` in the schema so a workflow can use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`wait_for_sync` can gate on a read instead of a hash.** An optional
+  `expect: {method, args, equals}` block makes the step wait until that read
+  returns `equals` on *every* node, not merely until the nodes agree on a state
+  hash. A hash is a claim about state, not proof of it: a node can publish a
+  root it does not hold (calimero-network/core#3595, #3596), and even truthful
+  hashes can agree a few milliseconds before a pending delta finishes applying,
+  so the read that follows still misses. Both show up as `✓ All targets synced`
+  followed by an assertion reading `null`. `equals` is compared against the
+  call's `data` payload — the same shape a following `json_assert` sees — so an
+  existing assertion moves into `expect` unchanged. The read is only probed once
+  the hashes agree, since each probe executes on every node, and a failure
+  prints each node's observed value beside the expected one. `expect` is part
+  of the `wait_for_sync` schema, so `merobox bootstrap validate` catches a
+  malformed block — a `eqauls:` typo, a missing `context_id` — before a run
+  spends 60 seconds timing out on it
+
 ## [0.6.60] - 2026-08-21
 
 ### Added
@@ -29,21 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the config module previously described as future work. Unknown keys under a
   `bootstrap` block are rejected rather than ignored, so a `nat_mode` carried over
   by copy-paste fails validation instead of silently configuring nothing.
-
-### Added
-
-- **`wait_for_sync` can gate on a read instead of a hash.** An optional
-  `expect: {method, args, equals}` block makes the step wait until that read
-  returns `equals` on *every* node, not merely until the nodes agree on a state
-  hash. A hash is a claim about state, not proof of it: a node can publish a
-  root it does not hold (calimero-network/core#3595, #3596), and even truthful
-  hashes can agree a few milliseconds before a pending delta finishes applying,
-  so the read that follows still misses. Both show up as `✓ All targets synced`
-  followed by an assertion reading `null`. `equals` is compared against the
-  call's `data` payload — the same shape a following `json_assert` sees — so an
-  existing assertion moves into `expect` unchanged. The read is only probed once
-  the hashes agree, since each probe executes on every node, and a failure
-  prints each node's observed value beside the expected one
 
 ### Changed
 

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -542,6 +542,14 @@ class WaitForSyncStep(BaseStepConfig):
     trigger_sync: Optional[bool] = Field(
         False, description="Trigger sync before waiting"
     )
+    expect: Optional[dict[str, Any]] = Field(
+        None,
+        description=(
+            "Read that must return `equals` on every node before sync is declared: "
+            "{method, args, equals}. Gates on state rather than on a hash, which is "
+            "only a claim about state"
+        ),
+    )
 
     @model_validator(mode="after")
     def _at_least_one_id(self) -> "WaitForSyncStep":
@@ -550,6 +558,41 @@ class WaitForSyncStep(BaseStepConfig):
         if self.context_id is None and self.group_id is None:
             raise ValueError(
                 "wait_for_sync: at least one of 'context_id' or 'group_id' must be specified"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _expect_is_well_formed(self) -> "WaitForSyncStep":
+        """Check `expect` at schema-validation time too.
+
+        The step executor validates this as well, but `merobox validate` runs
+        without touching a node, and a typo inside `expect` is exactly the kind
+        of thing that should fail there rather than 60 seconds into a timeout.
+        """
+        if self.expect is None:
+            return self
+        unknown = set(self.expect) - {"method", "args", "equals"}
+        if unknown:
+            raise ValueError(
+                f"wait_for_sync: unknown key(s) in 'expect': {sorted(unknown)} "
+                f"(valid: args, equals, method)"
+            )
+        if not isinstance(self.expect.get("method"), str) or not self.expect["method"]:
+            raise ValueError(
+                "wait_for_sync: 'expect.method' must be a non-empty string"
+            )
+        if "args" in self.expect and not isinstance(self.expect["args"], dict):
+            raise ValueError("wait_for_sync: 'expect.args' must be a mapping")
+        # Presence, not truthiness — `equals: null` is a real expectation.
+        if "equals" not in self.expect:
+            raise ValueError(
+                "wait_for_sync: 'expect.equals' is required — it is the value the "
+                "read must return on every node"
+            )
+        if self.context_id is None:
+            raise ValueError(
+                "wait_for_sync: 'expect' needs 'context_id' — the read is executed "
+                "in that context"
             )
         return self
 

--- a/merobox/tests/unit/test_workflow_schema_validation.py
+++ b/merobox/tests/unit/test_workflow_schema_validation.py
@@ -116,6 +116,73 @@ class TestValidateWorkflowStep:
         errors = config_module.validate_workflow_step(step, 0)
         assert len(errors) == 0
 
+    def test_wait_for_sync_accepts_an_expect_block(self, config_module):
+        """`expect` gates on a read, so the schema has to know the key exists.
+
+        Unknown step keys are fatal, so without this the feature is
+        unreachable from a workflow file at all.
+        """
+        step = {
+            "name": "Wait for Sync",
+            "type": "wait_for_sync",
+            "context_id": "{{context_id}}",
+            "nodes": ["calimero-node-1", "calimero-node-2"],
+            "expect": {
+                "method": "get",
+                "args": {"key": "k"},
+                "equals": {"output": "v"},
+            },
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    def test_wait_for_sync_expect_equals_null_is_valid(self, config_module):
+        """A read that must return nothing is a legitimate expectation."""
+        step = {
+            "name": "Wait for Sync",
+            "type": "wait_for_sync",
+            "context_id": "{{context_id}}",
+            "nodes": ["calimero-node-1", "calimero-node-2"],
+            "expect": {"method": "get", "equals": None},
+        }
+        assert config_module.validate_workflow_step(step, 0) == []
+
+    @pytest.mark.parametrize(
+        "expect,fragment",
+        [
+            ({"method": "get"}, "expect.equals"),
+            ({"equals": 1}, "expect.method"),
+            ({"method": "", "equals": 1}, "expect.method"),
+            ({"method": "get", "args": [], "equals": 1}, "expect.args"),
+            ({"method": "get", "equals": 1, "eqauls": 1}, "unknown key"),
+        ],
+    )
+    def test_wait_for_sync_rejects_malformed_expect(
+        self, config_module, expect, fragment
+    ):
+        """Caught at validate time, not 60 seconds into a timeout — a typo like
+        `eqauls` would otherwise read as "the value never arrived"."""
+        step = {
+            "name": "Wait for Sync",
+            "type": "wait_for_sync",
+            "context_id": "{{context_id}}",
+            "nodes": ["calimero-node-1", "calimero-node-2"],
+            "expect": expect,
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert any(fragment in e for e in errors), errors
+
+    def test_wait_for_sync_expect_requires_a_context(self, config_module):
+        """The read executes in a context, so a group-only target cannot host it."""
+        step = {
+            "name": "Wait for Sync",
+            "type": "wait_for_sync",
+            "group_id": "{{group_id}}",
+            "nodes": ["calimero-node-1", "calimero-node-2"],
+            "expect": {"method": "get", "equals": 1},
+        }
+        errors = config_module.validate_workflow_step(step, 0)
+        assert any("needs 'context_id'" in e for e in errors), errors
+
     def test_valid_repeat_step(self, config_module):
         """Test validation of a valid repeat step."""
         step = {


### PR DESCRIPTION
Follow-up to #358, which shipped the `expect` gate **unusable from a workflow file**.

## The bug

`expect` was never registered in `WaitForSyncStep`'s Pydantic model, so `merobox bootstrap validate` rejects any workflow carrying it:

```
Step 'Wait for root context sync' (index 12): unknown field 'expect' - the step
would ignore it. Did you mean 'expected_error'? Valid fields: backoff_factor,
check_interval, context_id, description, expected_error, expected_failure,
group_id, initial_check_interval, name, nodes, outputs, retry_attempts, timeout,
token, trigger_sync, type
```

Unknown step keys are fatal as of 0.6.59, so this is not a cosmetic warning — the executor validates and honours `expect` perfectly, but no workflow containing it ever gets that far.

**Why #358's tests missed it:** the per-step field allowlist is the model in `config.py`, not the step class's own `_validate_field_types`. Every test in #358 constructed `WaitForSyncStep` directly and so bypassed the schema entirely. It surfaced only when a real converted scenario was run through `merobox bootstrap validate` (calimero-network/core#3611).

## The fix

Declares `expect` on the model, and validates its shape there rather than only declaring the key. `merobox bootstrap validate` runs without touching a node, and that is where a typo belongs: `eqauls:` would otherwise be accepted as an unknown inner key and surface 60 seconds later as *"the value never arrived"* — precisely the misleading-timeout shape `expect` exists to remove.

Six schema tests: a valid block, `equals: null` (a legitimate expectation — presence is checked, not truthiness), an unknown inner key, a missing `equals`, a non-string `method`, a non-mapping `args`, and `expect` without `context_id`.

## Changelog

Also refiles the `expect` entry. It was written under `[Unreleased]` while #358 was open, and `v0.6.60` was tagged from `31142e4` — the commit *before* that merge — so the entry landed under a released heading describing a release that does not contain it. Moved to a fresh `[Unreleased]`.

## Verification

`black --check` and `ruff check` clean; 155 passing across the two affected test files. And the end-to-end check that found this in the first place: `merobox bootstrap validate` on the converted `group-subgroup` scenario from calimero-network/core#3611 now passes.

## Release ordering

**0.6.61 should not be cut before this lands**, or the release ships a feature no workflow can use. Once it does, `chore(release): 0.6.61` unblocks calimero-network/core#3611, which pins that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and changelog only. No change to wait_for_sync runtime behavior beyond allowing workflows to pass validation.
> 
> **Overview**
> Makes `wait_for_sync`'s `expect` block usable from workflow YAML. The executor already honored it, but `WaitForSyncStep` never declared the field, so `merobox bootstrap validate` rejected any workflow that used it as an unknown key.
> 
> The model now accepts `{method, args, equals}` and checks the shape at schema time: required `method`/`equals`, mapping `args`, no unknown inner keys, and `context_id` when `expect` is set. `equals: null` is valid. Typos like `eqauls` fail validate instead of timing out at runtime.
> 
> Moves the changelog entry from `[0.6.60]` to `[Unreleased]` (that release was tagged before the feature landed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835133f3af20b861e0813b857f1acdca8f543a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->