### PR TITLE
chore(release): 0.6.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.61] - 2026-08-21
 
 ### Added
 

--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.60"
+__version__ = "0.6.61"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
⚠️ **Merging this publishes to PyPI and cuts the `v0.6.61` release.** Opened for review, not merged.

## Contents

Two commits already on master, which together are one feature:

- **#358** — `wait_for_sync` can gate on a read (`expect: {method, args, equals}`) instead of on a state hash.
- **#359** — registers `expect` in the step's schema, without which `merobox bootstrap validate` rejects the key and the feature is unreachable from a workflow file.

`#358` alone is not shippable, which is why no release was cut for it.

## Why a release is needed

`v0.6.60` was tagged from `31142e4` — the commit *before* #358 merged — so no published release carries `expect`. The Release Pipeline ran on both merges and skipped `create-release` / `Publish to PyPI` each time, because `__version__` was still `0.6.60`.

## Verified

`merobox bootstrap validate` passes on the converted `group-subgroup` scenario from calimero-network/core#3611, run against merobox master at `3600a65` (both commits in). That is the same check that caught #358's schema gap, so it is the one worth trusting here.

## Unblocks

calimero-network/core#3611 pins `0.6.61` and is held as a draft until this is on the releases page. That PR converts the three convergence barriers in `group-subgroup` — the scenario whose misleading flake started this — from waiting on a hash to waiting on the read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Version bump only, but merge triggers the release pipeline (tag, GitHub release, PyPI). No runtime code changes in this diff.
> 
> **Overview**
> Cuts **0.6.61** by bumping `__version__` and promoting the Unreleased changelog entry. Merge publishes to PyPI and tags `v0.6.61`.
> 
> This is the release vehicle for `wait_for_sync` gating on a read (`expect: {method, args, equals}`) plus the schema registration that makes `bootstrap validate` accept it. Those landed on master without a version bump, so 0.6.60 never shipped them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d7fad1fb1ce850063d023abc6876d3c78a79d20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->