### PR TITLE
fix(wait_for_sync): compare `expect.equals` against the result, not the envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`wait_for_sync`'s `expect` compared the JSON-RPC envelope, not the result.**
+  `call_function` returns the whole envelope
+  (`{"id", "jsonrpc", "result": {...}}`), while an `execute` step's
+  `outputs: {x: result}` captures only the inner `result` — and `equals` is
+  documented as matching that capture. Comparing the envelope could never match
+  a hand-written `equals`, so the gate waited out its full timeout and reported
+  the value as never arriving while every node had in fact returned it: the
+  exact misleading-timeout shape `expect` exists to remove, reintroduced by the
+  thing meant to remove it. `expect` was unusable in 0.6.61
+
 ## [0.6.61] - 2026-08-21
 
 ### Added

--- a/merobox/commands/bootstrap/steps/wait_for_sync.py
+++ b/merobox/commands/bootstrap/steps/wait_for_sync.py
@@ -32,6 +32,27 @@ from merobox.commands.utils import (
 )
 
 
+def _rpc_result(data: Any) -> Any:
+    """Unwrap a JSON-RPC envelope down to its ``result``.
+
+    ``call_function`` hands back the whole envelope —
+    ``{"id": "1", "jsonrpc": "2.0", "result": {"output": "v"}}`` — while an
+    ``execute`` step's ``outputs: {x: result}`` captures only the inner
+    ``result``. `expect.equals` is written to match what a `json_assert` on that
+    capture would compare, so it has to be compared against the same level.
+
+    Comparing the envelope instead is not a near miss: it can never match a
+    hand-written `equals`, so the gate waits out its full timeout and reports
+    "the value never arrived" while every node has in fact returned it.
+
+    Falls back to ``data`` unchanged when there is no ``result`` key, so a
+    method whose response is not enveloped still compares sensibly.
+    """
+    if isinstance(data, dict) and "result" in data:
+        return data["result"]
+    return data
+
+
 class _ExpectUnread:
     """Sentinel: the ``expect`` read could not be performed on a node.
 
@@ -392,8 +413,8 @@ class WaitForSyncStep(BaseStep):
         """Run the ``expect`` read on one node.
 
         Returns ``(node_name, observed)``, where ``observed`` is the call's
-        ``data`` payload — the same shape a following ``json_assert`` sees when
-        an ``execute`` step captures ``outputs: {x: result}``. A failed or
+        JSON-RPC ``result`` — the same shape a following ``json_assert`` sees
+        when an ``execute`` step captures ``outputs: {x: result}``. A failed or
         errored call yields the ``_EXPECT_UNREAD`` sentinel rather than
         ``None``, because ``None`` is itself a legitimate observed value and
         must not be mistaken for "could not read".
@@ -427,7 +448,7 @@ class WaitForSyncStep(BaseStep):
 
         if not isinstance(result, dict) or not result.get("success"):
             return node_name, _EXPECT_UNREAD
-        return node_name, result.get("data")
+        return node_name, _rpc_result(result.get("data"))
 
     async def _check_expect_convergence(
         self,

--- a/merobox/tests/unit/test_wait_for_sync_step.py
+++ b/merobox/tests/unit/test_wait_for_sync_step.py
@@ -330,3 +330,87 @@ def test_expect_requires_a_context_to_read_in():
                 "expect": EXPECT,
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# What `expect` actually observes.
+#
+# The tests above stub `_check_expect_convergence`, so none of them touch the
+# shape `call_function` really returns. That gap shipped a gate that compared
+# the JSON-RPC envelope against an `equals` written for the inner result: it
+# could never match, so the step waited out its full 60s timeout and reported
+# "the value never arrived" while both nodes had returned it. These pin the
+# level being compared.
+# ---------------------------------------------------------------------------
+
+
+def test_rpc_result_unwraps_the_envelope():
+    from merobox.commands.bootstrap.steps.wait_for_sync import _rpc_result
+
+    envelope = {"id": "1", "jsonrpc": "2.0", "result": {"output": "from_node1"}}
+    assert _rpc_result(envelope) == {"output": "from_node1"}
+
+
+def test_rpc_result_passes_through_a_non_enveloped_payload():
+    """A response with no `result` key compares as-is rather than becoming None."""
+    from merobox.commands.bootstrap.steps.wait_for_sync import _rpc_result
+
+    assert _rpc_result({"output": "v"}) == {"output": "v"}
+    assert _rpc_result(None) is None
+    assert _rpc_result("scalar") == "scalar"
+
+
+def test_expect_read_observes_the_inner_result_not_the_envelope():
+    """The regression test for the 60s-timeout-on-a-present-value bug.
+
+    `call_function` hands back the whole envelope; `equals` is written to match
+    what `outputs: {x: result}` captures, which is the inner `result`.
+    """
+    step = _make_step({"expect": EXPECT})
+    envelope = {"id": "1", "jsonrpc": "2.0", "result": {"output": "v"}}
+
+    async def fake_call(rpc_url, context_id, method, args, node_name=None):
+        return {"success": True, "data": envelope}
+
+    async def run():
+        with (
+            patch.object(
+                step, "_resolve_node_for_client", return_value=("http://x", "n")
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.wait_for_sync.call_function",
+                side_effect=fake_call,
+            ),
+        ):
+            return await step._check_expect_convergence(EXPECT, "ctx-1", NODES)
+
+    satisfied, observed = asyncio.run(run())
+    assert satisfied is True, f"envelope was not unwrapped: {observed}"
+    assert observed == {node: {"output": "v"} for node in NODES}
+
+
+def test_expect_read_marks_a_failed_call_unread_not_null():
+    """`equals: null` must not be satisfiable by a node that cannot be read."""
+    from merobox.commands.bootstrap.steps.wait_for_sync import _EXPECT_UNREAD
+
+    expect = {"method": "get", "args": {}, "equals": None}
+    step = _make_step({"expect": expect})
+
+    async def fake_call(rpc_url, context_id, method, args, node_name=None):
+        return {"success": False, "error": "boom"}
+
+    async def run():
+        with (
+            patch.object(
+                step, "_resolve_node_for_client", return_value=("http://x", "n")
+            ),
+            patch(
+                "merobox.commands.bootstrap.steps.wait_for_sync.call_function",
+                side_effect=fake_call,
+            ),
+        ):
+            return await step._check_expect_convergence(expect, "ctx-1", NODES)
+
+    satisfied, observed = asyncio.run(run())
+    assert satisfied is False
+    assert all(v is _EXPECT_UNREAD for v in observed.values())


### PR DESCRIPTION
`expect` is unusable in 0.6.61. Found by running calimero-network/core#3611 against the real release.

## The bug

`call_function` returns the whole JSON-RPC envelope — `{"id": "1", "jsonrpc": "2.0", "result": {"output": "v"}}` — while an `execute` step's `outputs: {x: result}` captures only the inner `result`. `equals` is documented as matching that capture, but was compared against the envelope, which no hand-written `equals` can ever equal.

So the gate waited out its full timeout and reported that the value never arrived, while every node had already returned it:

```
✗ Sync verification failed after 60.18s (99 attempts)
  Final state:
    context=Bb4BJtV7…:
      e2e-node-1: 2XUpNPCc…
      e2e-node-2: 2XUpNPCc…
    expect get (want {'output': 'from_node1'}):
      e2e-node-1: {'id': '1', 'jsonrpc': '2.0', 'result': {'output': 'from_node1'}}
      e2e-node-2: {'id': '1', 'jsonrpc': '2.0', 'result': {'output': 'from_node1'}}
```

That is precisely the misleading-timeout shape `expect` exists to remove, reintroduced by the thing meant to remove it.

## The fix

Unwrap `data["result"]` when present, falling back to `data` unchanged otherwise — so a method whose response is not enveloped still compares sensibly.

## Why the tests missed it

Every `expect` test so far stubbed `_check_expect_convergence`, so none of them touched the shape `call_function` actually returns. Same class of gap as the missing schema registration in #359: the tests drove past the seam that mattered.

Now pinned properly — `call_function` itself is patched with a realistic envelope and the observed value asserted to be the inner result. Verified as a real regression test: reverting the unwrap fails it. Plus direct coverage of the unwrap for enveloped, non-enveloped, `None`, and scalar payloads.

27 tests in that file. `black --check` and `ruff check` clean.

## Worth noting

The failure output made this a one-look diagnosis — the gate printed both node hashes *and* both observed values, so "hashes agree, reads present, comparison wrong" was readable straight off CI without downloading an artifact. The diagnostics were worth more here than the feature.

## Release

Needs `chore(release): 0.6.62` after this lands; calimero-network/core#3611 will be re-pinned from 0.6.61 to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `wait_for_sync` expect gate used as an e2e convergence check. The change is a small unwrap with a regression test, but a wrong comparison level would again make the gate always time out.
> 
> **Overview**
> Makes `wait_for_sync` `expect` usable again: it now compares `equals` to the inner JSON-RPC `result`, matching what an `execute` step captures via `outputs: {x: result}`.
> 
> In 0.6.61 the gate compared the full envelope (`id`/`jsonrpc`/`result`), so a hand-written `equals` could never match. The step then timed out and claimed the value never arrived while every node had already returned it.
> 
> Unwraps `data["result"]` when present and leaves non-enveloped payloads unchanged. Adds a regression test that patches `call_function` with a real envelope, plus coverage for non-enveloped, `None`, and failed-call (`_EXPECT_UNREAD`) paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4664c59a1c2fc3634746ee7eee2ace5f37ccab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->