### PR TITLE
test(canary): exercise `expect` in the live wait-for-sync canary

### DIFF
--- a/workflow-examples/workflow-wait-for-sync-example.yml
+++ b/workflow-examples/workflow-wait-for-sync-example.yml
@@ -130,6 +130,18 @@ steps:
     timeout: 60
     check_interval: 2
     trigger_sync: true
+    # Converging on a state hash only proves the nodes agree on a claim about
+    # state. `expect` waits for the value itself, on every node, so the reads
+    # below cannot race an apply that has not landed. This runs as a Docker
+    # canary, which is the point: it is the only coverage that exercises the
+    # real client response shape, and two bugs shipped past unit tests that
+    # stubbed it (calimero-network/merobox#359, #361).
+    expect:
+      method: get
+      args:
+        key: demo_key
+      equals:
+        output: demo_value
     outputs:
       operation_sync_hash: root_hash
       operation_sync_time: elapsed_seconds


### PR DESCRIPTION
## Why

Two bugs shipped in `expect` because every test for it drove past the seam that mattered:

- **#359** — its tests built `WaitForSyncStep` directly, so they missed the Pydantic schema allowlist. The key was rejected by `merobox bootstrap validate`, making the feature unreachable from a workflow file.
- **#361** — its tests stubbed `_check_expect_convergence`, so they missed the shape `call_function` actually returns. `equals` was compared against the JSON-RPC envelope instead of the inner `result`, so the gate burned its full 60s timeout reporting a value as absent while every node had returned it.

Both were found by running a real scenario. Neither was found by a unit test. `expect` was broken in 0.6.61 as a result.

## What this adds

`workflow-wait-for-sync-example.yml` already runs as a live 3-node Docker canary, so declaring `expect` on its state-change barrier makes that the standing end-to-end coverage — the only place a real client response is compared against a real `equals`.

The reads and `json_assert`s below it are left alone; they now assert something the barrier has already observed.

## Measured

Local 3-node run against `merod:edge`, workflow completed successfully:

| barrier | `expect`? | elapsed |
| --- | --- | --- |
| after join | no | **0.0s** |
| after the write | yes | **1.51s** |

Same hashes, different question. The bare barrier returns the instant the nodes agree on a claim; the `expect` barrier waited 1.51s for the value to actually be readable on all three. And since a mis-compared `equals` cannot match, completing at all is proof the envelope unwrap from #361 works — the failure mode would have been a 60s timeout.

## Note

The run above used a port-shifted copy (`base_port: 3428`) because this machine had a native `merod` on 2428. That shift is local only — the committed workflow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example workflow YAML only; no production logic, auth, or data-handling changes.
> 
> **Overview**
> Adds an `expect` block to the post-write `wait_for_sync` step in `workflow-wait-for-sync-example.yml` so the live 3-node Docker canary waits until `get(demo_key)` returns `demo_value` on every node, not just until hashes agree.
> 
> This is the standing end-to-end coverage for the real client response shape that unit tests stubbed, which let #359 and #361 ship. Downstream reads/`json_assert`s are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a6150b7a510088a72e320855115e5d57a10acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->