### PR TITLE
docs(e2e-mode): say that tests opt into mDNS, not that it is a backup

### DIFF
--- a/merobox/commands/config_utils.py
+++ b/merobox/commands/config_utils.py
@@ -307,7 +307,28 @@ def apply_e2e_defaults(
             {
                 # Use unique rendezvous namespace per workflow (like e2e tests)
                 "discovery.rendezvous.namespace": f"calimero/merobox-tests/{workflow_id}",
-                # Keep mDNS as backup (like e2e tests)
+                # Tests opt INTO multicast, deliberately — it is not a backup.
+                # The line above cleared `bootstrap.nodes`, and merod ships no
+                # rendezvous server, so on a single bridge with no sibling
+                # addresses wired there is nothing else for peers to find each
+                # other with: this setting IS the discovery mechanism for a
+                # flat `--e2e-mode` fleet, not a fallback behind one.
+                #
+                # Measured on an 8-node fleet with this set to False and
+                # nothing else changed: 0 kad `RoutingUpdated`, 0 connections,
+                # 0 identify, and the first namespace join dead on
+                # `KeyDelivery timed out`. With it True: 112 multicast dials and
+                # 112 routing updates — the kad table populated as a side
+                # effect of multicast (calimero-network/core#3525).
+                #
+                # Keeping it True is right, because merod now leaves mDNS off
+                # by default and a hosted node should not announce itself; a
+                # test fleet on one Docker bridge is the case where multicast
+                # is the cheap answer. What matters is that the choice is
+                # explicit. A scenario that wants to exercise the discovery
+                # path a real deployment uses overrides it with `mdns: false`
+                # on the `nodes:` block, or asks for
+                # `topology: { type: bootstrap }`.
                 "discovery.mdns": True,
                 # Aggressive sync settings from e2e tests for reliable testing
                 "sync.timeout_ms": 30000,  # 30s timeout (matches production)


### PR DESCRIPTION
Comment-only. No behaviour change, no version bump.

## The line

`apply_e2e_defaults` clears `bootstrap.nodes` and then, two statements later, sets `discovery.mdns = True` under the comment **"Keep mDNS as backup (like e2e tests)"**.

It is not a backup. With the bootstrap list empty, merod shipping only `rendezvous::client::Behaviour` (so no peer can serve as a rendezvous point), and no sibling addresses wired on the per-node startup path, that one setting **is** the discovery mechanism for a flat `--e2e-mode` fleet. There is nothing behind it to fall back to.

Measured on an 8-node fleet with it set to `False` and nothing else changed:

| | mDNS on | mDNS off |
|---|---:|---:|
| multicast dials | 112 | 0 |
| kad `RoutingUpdated` | 112 | **0** |
| connections established | 440 | **0** |
| identify exchanges | 220 | **0** |
| result | pass | first namespace join dead on `KeyDelivery timed out` |

The kad routing table those scenarios depend on was being populated entirely as a side effect of multicast-initiated connections. Full write-up: calimero-network/core#3525.

## Why the wording is the point

A line reading "backup" invites the assumption that something else carries the traffic. That assumption held for a long time: ~80 flat scenarios were credited with exercising the discovery path a real deployment uses, and a total regression in bootstrap/kad would have kept every one of them green. The comment was load-bearing in the worst way — it was the reason nobody checked.

## The setting stays `True`, and is now correct rather than accidental

merod is moving to mDNS **off** by default (a hosted node should not announce itself on a shared segment, and cloud VPCs mostly block multicast anyway). A test fleet on one Docker bridge is precisely the case where multicast is the cheap right answer — so the harness forcing it on becomes an explicit test-only opt-in rather than a hidden guarantee.

What the comment now records: that this is the discovery mechanism and not a fallback, the measurement behind that claim, and the two ways a scenario opts out — `mdns: false` on the `nodes:` block, or `topology: { type: bootstrap }` for the boot-node shape that exercises rendezvous.

`black` and `ruff` clean; `test_config_utils.py` 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment rewrite with no runtime or config behavior change.
> 
> **Overview**
> Comment-only clarification in `apply_e2e_defaults`: `discovery.mdns: True` is the **primary** discovery path for a flat `--e2e-mode` fleet (empty bootstrap list, no merod rendezvous server), not a backup.
> 
> The setting is unchanged. The new comment records why it stays on, the 8-node measurement behind that, and how a scenario opts out (`mdns: false` or `topology: { type: bootstrap }`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc6ff25742f00baf24a3ec6bf9ee90ddfdc5880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->