### PR TITLE
fix(examples): wire the sample workflow's peers instead of sleeping before the join

### DIFF
--- a/workflow-examples/workflow-example.yml
+++ b/workflow-examples/workflow-example.yml
@@ -231,5 +231,26 @@ steps:
 
 # Configuration options
 stop_all_nodes: false   # Stop all nodes at the end of workflow
-restart: false          # Don't restart nodes at the beginning of workflow
+# Wires each node's siblings into its `bootstrap.nodes` and then blocks on the
+# connectivity gate until every node actually has its peers — `restart: true` is
+# the only path that reaches either (`run_multiple_nodes`).
+#
+# Without it the nodes start knowing nobody, and the `wait: 5` above is all that
+# stands between that and the namespace join. A fixed sleep asserts nothing about
+# arrival: here it is really "hope mDNS landed", because with no `--e2e-mode` the
+# only other contact is the public devnet boot-node across the internet. When 5s
+# was not enough — which it stops being whenever CI runs the docker-canary matrix
+# alongside the integration job — the join found no reachable mesh peer, got no
+# group key and returned 500, taking all 12 tests in
+# `tests/test_merobox_integration.py` with it, since they share this fixture.
+# That is the only required check on this repo, so an unrelated PR went red and
+# its author went looking in their own diff (#367).
+#
+# The trade: this fixture no longer exercises peer DISCOVERY. Deliberate —
+# discovery has dedicated coverage in calimero-network/core
+# (`discovery-bootstrap-only-*`, `discovery-rendezvous-3node`) instead of being
+# incidentally load-bearing in a plumbing smoke test. A real connectivity
+# failure now names the mesh at startup rather than surfacing as a 500 from the
+# join handler three steps later.
+restart: true
 wait_timeout: 120


### PR DESCRIPTION
Fixes #367. One line of YAML plus the reasoning; unblocks #366 without an override.

## The problem

`workflow-example.yml` slept a fixed 5 seconds and then joined a namespace. The sleep asserts nothing about arrival — on this workflow it is really *"hope mDNS landed"*, because with no `--e2e-mode` the nodes' only other contact is the public devnet boot-node across the internet.

When 5s was not enough, the join had no peer to fetch the group key from:

```
WARN  join_group: direct namespace-join request found no reachable mesh peer
WARN  join_group: join response contained no group key
ERROR join_namespace: Failed to join namespace
```

surfacing as `HTTP 500` and taking **all 12** tests in `tests/test_merobox_integration.py` down with it, since they share this fixture. That is the repo's only required check, so an unrelated PR goes red and its author starts searching their own diff.

Seen on #366, which changes only version pins: 3 failures there against 6 passes on master over the same period, with the *same* core binary (`0.11.0-rc.25`) and the *same* client (0.6.31) on both sides. The node logs differ only in timing — 0 mDNS dials on the PR runs versus 2 on master. A PR run fires the docker-canary matrix alongside the integration job, so 5 seconds stops being enough.

## The fix

`restart: true` routes startup through `run_multiple_nodes` — the only path that both wires each node's siblings into its `bootstrap.nodes` **and** then blocks on the connectivity gate until every node actually has its peers. So:

- the join no longer waits on discovery at all;
- a genuine connectivity failure fails at startup **naming the mesh**, rather than as a 500 from the join handler three steps later, which is criterion 3 of #367.

The gate reads a real peer count here because this fixture is unauthenticated — on an embedded-auth fleet it would have needed #344, which taught it to authenticate rather than score a 401 as "0 peers".

## One trap worth recording

The key already existed at the bottom of the file as `restart: false`. Setting it near the top as well — which is where the explanation naturally wants to go — would have been a **duplicate YAML key that silently loses to the later one**. I hit exactly that: the file parsed as `restart: False` with my new `restart: true` sitting 200 lines above it, no error anywhere. Changed in place instead.

## The trade, stated

This fixture no longer exercises peer **discovery**. That is deliberate and not a loss: discovery now has dedicated coverage in calimero-network/core (`discovery-bootstrap-only-{2,4}node` for bootstrap→identify→kad, `discovery-rendezvous-3node` for rendezvous) rather than being incidentally load-bearing in a plumbing smoke test. This fixture's job is merobox's own plumbing — install, namespace, context, identity, invite, join, call — and it should get to its peers deterministically.

## What stays open

A polling `wait_for_peers` step is still the general answer for workflows that *cannot* wire their peers, and #367 keeps that open. Worth restating why it matters: merobox has **no waiting barrier at all** today — `assert_log` is a one-shot scan and `assert_api_response` is a single request — which is why a fixed sleep was the only tool this fixture had. `DockerManager._probe_connected_peers` already does the authenticated read such a step would need.

Once this lands, #366 rebases onto it and goes green on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)