### PR TITLE
refactor(join): stop pre-installing the app the network is supposed to deliver

### DIFF
--- a/merobox/commands/bootstrap/steps/group_join.py
+++ b/merobox/commands/bootstrap/steps/group_join.py
@@ -3,15 +3,12 @@ Join namespace step executor.
 """
 
 import json as json_lib
-import os
-import shutil
-from typing import Any, Optional
+from typing import Any
 
 from rich.markup import escape
 
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
-from merobox.commands.constants import CONTAINER_DATA_DIR_PATTERNS, DEFAULT_METADATA
 from merobox.commands.result import fail, ok
 from merobox.commands.utils import console
 
@@ -55,58 +52,6 @@ class JoinNamespaceStep(BaseStep):
                 "Account the joining key speaks for (64 hex characters)",
             ),
         ]
-
-    def _auto_install_app_on_node(
-        self, node_name: str, app_path: str, dynamic_values: dict[str, Any]
-    ) -> None:
-        """Auto-install the application on a joining node using the path
-        from the install_application step."""
-        try:
-            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
-            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-
-            # Check if binary mode (host filesystem) or Docker mode (container path)
-            manager = getattr(self, "manager", None)
-            is_binary = (
-                manager
-                and hasattr(manager, "binary_path")
-                and manager.binary_path is not None
-            )
-
-            if is_binary:
-                install_path = app_path
-            else:
-                # Copy WASM to container data dir
-                install_path = self._prepare_container_path(node_name, app_path)
-                if not install_path:
-                    return
-
-            client.install_dev_application(path=install_path, metadata=DEFAULT_METADATA)
-            console.print(f"[blue]Auto-installed application on {node_name}[/blue]")
-            dynamic_values[f"app_path_{node_name}"] = app_path
-        except Exception as e:
-            console.print(
-                f"[yellow]⚠️  Auto-install on {node_name} failed: {escape(str(e))}[/yellow]"
-            )
-
-    def _prepare_container_path(
-        self, node_name: str, source_path: str
-    ) -> Optional[str]:
-        """Copy WASM file to container data directory."""
-        for pattern in CONTAINER_DATA_DIR_PATTERNS:
-            if "{node_name}" in pattern:
-                candidate = pattern.format(node_name=node_name)
-            else:
-                candidate = None
-            if candidate and os.path.exists(candidate):
-                filename = os.path.basename(source_path)
-                try:
-                    dest = os.path.join(candidate, filename)
-                    shutil.copy2(source_path, dest)
-                    return f"/app/data/{filename}"
-                except (OSError, shutil.Error):
-                    pass
-        return None
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -161,16 +106,6 @@ class JoinNamespaceStep(BaseStep):
                 f"'invitation' must be a dict or JSON string[/red]"
             )
             return False
-
-        # Auto-install application on joining node if not already installed.
-        # Look up the WASM path stored by install_application step.
-        app_path = None
-        for key, val in dynamic_values.items():
-            if key.startswith("app_path_"):
-                app_path = val
-                break
-        if app_path and not dynamic_values.get(f"app_path_{node_name}"):
-            self._auto_install_app_on_node(node_name, app_path, dynamic_values)
 
         try:
             rpc_url, client_node_name = self._resolve_node_for_client(node_name)


### PR DESCRIPTION
## Summary

A node joining a namespace it has no application for is a case core already handles. During sync it fetches the context's blob from a peer, recognises a bundle and installs it, then repoints the context:

```
crates/node/src/sync/manager/mod.rs:1951
  // Get application - if not found, we'll try to install it after blob sharing

crates/node/src/sync/manager/blob_fetch.rs:81
  install_bundle_after_blob_sharing(...) -> install_application_from_bundle_blob(blob_id, &source)
```

`join_namespace` pre-empted that, installing from a local path before the join. Since core's path only runs when the application is **not found**, pre-installing skips it. Of 104 join steps across core's 133 scenarios, **76** rely on the pre-install, so they never reach the code core actually ships.

The pre-install also had to infer *which* application to install, having only a node name in hand, so it took the first `app_path_*` in dict insertion order and never consulted the namespace being joined. With two applications live a joiner got the wrong one, silently: any wasm installs fine and the join never executes app code, so it surfaced later as a deserialization error. Core needs no such guess, it derives the application from the context's blob. The guess existed only because merobox had taken the job over.

## Changes

Remove the pre-install from `join_namespace`, plus the two helpers that existed only to serve it (`_auto_install_app_on_node`, `_prepare_container_path`) and their now-unused imports. Net -65 lines.

## What this is testing

This is deliberately an experiment run against CI. If core's delivery works, the scenarios that dropped their pre-install stay green and merobox is doing less. If any go red, they name exactly which flows depend on the pre-install and why, which is information the suite does not currently have, because nothing exercises the real path today: `install_bundle_after_blob_sharing` has no test referencing it, and no scenario asserts an application arrived over the wire.

Two known limits of the experiment:

- merobox CI covers `workflow-examples/` and `example-project/` only. Core's 133 scenarios run in core's CI against the pinned merobox, so confirming those needs a core-side run against this build.
- Core's install path is gated on `is_bundle_blob`, so it delivers `.mpk` bundles. Core scenarios are still mostly raw `.wasm` (142 `.wasm` vs 75 `.mpk`), which may bound how much of the suite can rely on network delivery today.

`create_mesh` still pre-installs on joining nodes (`mesh.py:369`). That one is declared through its `path:` key rather than inferred, and removing it would leave that key dead in 39 core scenarios, so it is left for a separate change.

## Test plan

```
ruff check merobox/        All checks passed
black --check merobox/     146 files unchanged
pytest merobox/tests/unit  1461 passed
```

The unit suite passing unchanged is itself a finding: nothing covered the removed code.

Rebased onto master so it picks up #371 and runs against green CI.