### PR TITLE
fix(example-project): wire the integration fixture's peers too

### DIFF
--- a/example-project/workflows/workflow-example.yml
+++ b/example-project/workflows/workflow-example.yml
@@ -148,5 +148,26 @@ steps:
           iteration_get_result: result
 
 stop_all_nodes: false
-restart: false
+# Wires each node's siblings into its `bootstrap.nodes` and then blocks on the
+# connectivity gate until both nodes actually have their peer — `restart: true`
+# is the only path that reaches either (`run_multiple_nodes`).
+#
+# This fixture backs every test in `tests/test_merobox_integration.py`, so when
+# its namespace join fails all 12 error together — and
+# `test-merobox-integration` is the only required check on this repo, so an
+# unrelated PR goes red and its author starts searching their own diff.
+#
+# Without wiring, the two `wait` steps above are all that stand between "the
+# nodes know nobody" and the join. A fixed sleep asserts nothing about arrival,
+# and on this workflow it really means "hope mDNS landed": with no
+# `--e2e-mode` the only other contact is the public devnet boot-node across the
+# internet. When the sleep was not enough the join found no reachable mesh
+# peer, got no group key, and returned 500 (#367).
+#
+# The trade is deliberate: this fixture stops exercising peer DISCOVERY, which
+# has dedicated coverage in calimero-network/core
+# (`discovery-bootstrap-only-*`, `discovery-rendezvous-3node`) rather than
+# belonging in a plumbing smoke test. A real connectivity failure now fails at
+# startup naming the mesh, instead of surfacing as a 500 three steps later.
+restart: true
 wait_timeout: 60


### PR DESCRIPTION
Follow-up to #368, which fixed the wrong file. Still fixes #367.

## The correction

`tests/test_merobox_integration.py` drives **`example-project/workflows/workflow-example.yml`**, not the `workflow-examples/workflow-example.yml` that #368 changed. The step names in the failing logs prove which one: `Node 2 Joins Namespace` exists only in the example-project fixture — the file #368 touched calls the same step `Join Namespace from Node 2`.

I should have checked that before claiming a fix. Worse, #368's `test-merobox-integration` passed on merge and I reported that as confirmation the diagnosis was right. It wasn't: the race is load-dependent, so a single green run is not evidence. What actually surfaced the mistake was #366 failing again after being rebased onto #368 — and its run contains **no `Wiring static bootstrap peers` line at all**, because the fixture under test had never been changed.

## The fix

Same change, correct file. `restart: true` routes startup through `run_multiple_nodes`, the only path that both wires each node's siblings into `bootstrap.nodes` **and** then blocks on the connectivity gate until both nodes actually have their peer.

So the join no longer depends on the two `wait` steps above it. A fixed sleep asserts nothing about arrival, and on this workflow it really means *"hope mDNS landed"* — with no `--e2e-mode`, the nodes' only other contact is the public devnet boot-node across the internet. When the sleep wasn't enough:

```
WARN  join_group: direct namespace-join request found no reachable mesh peer
WARN  join_group: join response contained no group key
ERROR join_namespace: Failed to join namespace
```

All 12 tests in that file share this fixture, and `test-merobox-integration` is the only required check on this repo — so its join failing takes the whole suite down and blocks unrelated PRs. #366, a pure version-pin change, has now been red three times for this reason.

## Verification

I ran the equivalent change against real containers earlier and confirmed the mechanism end to end:

```
Wiring static bootstrap peers for the cluster (no longer mDNS-only)...
✓ Cluster fully connected
```

That is the barrier this fixture was missing. (The local run then hit an unrelated `error decoding response body` — my local `merod:edge` image is newer than the released `calimero-client-py` in my venv, which is the skew #362 is about, and not something CI's matched pair hits.)

The real proof for this PR is its own `test-merobox-integration` run, plus #366 going green once rebased onto it. Given I misread a single green run as proof once already, I'd rather state that plainly than claim more than the evidence supports.

## Not changed

#368's edit to `workflow-examples/workflow-example.yml` stays. It is a genuine improvement to that example for exactly the same reasons — it just isn't the fixture under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)