### PR TITLE
fix(example-project): ask for mDNS instead of inheriting it

### DIFF
--- a/example-project/workflows/workflow-example.yml
+++ b/example-project/workflows/workflow-example.yml
@@ -17,6 +17,7 @@ nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node
+  mdns: true
   base_port: 9000
   base_rpc_port: 9100
 

--- a/merobox/tests/unit/test_fixture_workflow_discovery.py
+++ b/merobox/tests/unit/test_fixture_workflow_discovery.py
@@ -1,0 +1,43 @@
+"""The workflow behind the integration fixture must ask for its discovery.
+
+`merod` leaves mDNS off unless asked for, so a workflow that sets no `mdns`
+and no bootstrap peers gets nodes that never find each other: the namespace
+join finds no reachable peer, gets no group key, and returns 500, taking every
+test that shares the session fixture with it.
+
+The fixture inherited working discovery from an older merod default rather
+than requesting it, so a core-side default flip turned this repo red with no
+change of its own. Asking explicitly is what makes that impossible.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[3]
+_CONFTEST = _ROOT / "example-project" / "conftest.py"
+
+
+def _fixture_workflow() -> tuple[Path, dict]:
+    """The workflow `@run_workflow` loads, resolved against example-project/."""
+    match = re.search(r'@run_workflow\(\s*"([^"]+)"', _CONFTEST.read_text())
+    assert match, "no @run_workflow(...) literal found in example-project/conftest.py"
+    path = (_CONFTEST.parent / match.group(1)).resolve()
+    return path, yaml.safe_load(path.read_text())
+
+
+def test_fixture_workflow_exists():
+    path, _ = _fixture_workflow()
+    assert path.is_file()
+
+
+def test_fixture_workflow_asks_for_discovery():
+    path, config = _fixture_workflow()
+    nodes = config.get("nodes") or {}
+    reachable = nodes.get("mdns") is True or bool(config.get("restart"))
+    assert reachable, (
+        f"{path.relative_to(_ROOT)} must set 'mdns: true' on its nodes (or wire "
+        f"bootstrap peers via 'restart: true'); merod leaves mDNS off unless asked, "
+        f"so relying on the default means the nodes never discover each other"
+    )


### PR DESCRIPTION
## Summary

`merod` now leaves mDNS off unless asked for (`calimero-network/core` #3620). The integration fixture sets neither `mdns` nor bootstrap peers, so it relied on the old default for its two nodes to find each other. Its nodes run `merod:edge`, so the flip reached CI with no merobox change and `test-merobox-integration` went red on master:

```
Got 0 peers ... new mesh: {}
Failed to negotiate transport protocol(s)
Join namespace failed on calimero-node-2: Client error: HTTP 500
E   RuntimeError: Workflow execution failed: workflow-example.yml
```

`manager.py:883` applies the setting only `if mdns is not None`, so a workflow naming neither gets whatever merod defaults to.

## Changes

- `example-project/workflows/workflow-example.yml`: `mdns: true` on the node block.
- `merobox/tests/unit/test_fixture_workflow_discovery.py`: fails if the fixture leaves discovery to a default. It reads the workflow path from the `@run_workflow` literal in `conftest.py`, so it follows the fixture, and accepts either explicit mDNS or wired bootstrap peers.

## Test plan

`test-merobox-integration` passes here and fails on master.

Removing the line reproduces master's state:

```
E   AssertionError: example-project/workflows/workflow-example.yml must set 'mdns: true'
    on its nodes (or wire bootstrap peers via 'restart: true'); merod leaves mDNS off
    unless asked, so relying on the default means the nodes never discover each other
1 failed, 1 passed
```

```
black --check merobox/     146 files unchanged
ruff check merobox/        All checks passed
pytest merobox/tests/unit  1461 passed
```