### PR TITLE
refactor(mesh): stop pre-installing the app the network is supposed to deliver

### DIFF
--- a/docs/src/content/docs/workflows/yaml.mdx
+++ b/docs/src/content/docs/workflows/yaml.mdx
@@ -1559,7 +1559,6 @@ step.
 | `application_id` | yes | string | Application to instantiate. |
 | `nodes` | yes | list | Nodes to join into the mesh (must include one ≠ `context_node`). |
 | `params` | no | string | Init params as a JSON string. |
-| `path` | no | string | WASM path to pre-install on joining nodes. |
 
 `outputs:` captures from the context response, plus `namespaceId` folded in:
 

--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1662,9 +1662,6 @@ class CreateMeshStep(BaseStepConfig):
     application_id: str = Field(..., description="Application ID")
     nodes: list[str] = Field(..., description="List of nodes to include in mesh")
     params: Optional[str] = Field(None, description="Initialization params JSON string")
-    path: Optional[str] = Field(
-        None, description="WASM path to pre-install on the joining nodes"
-    )
 
 
 class FuzzyTestStep(BaseStepConfig):

--- a/merobox/commands/bootstrap/steps/install.py
+++ b/merobox/commands/bootstrap/steps/install.py
@@ -253,11 +253,6 @@ class InstallApplicationStep(BaseStep):
             step_key = f"install_{node_name}"
             workflow_results[step_key] = result["data"]
 
-            # Store the application path so create_mesh can auto-install
-            # on joining nodes without requiring path in the workflow YAML.
-            if application_path:
-                dynamic_values[f"app_path_{node_name}"] = application_path
-
             # Debug: Show what we actually received
             console.print(f"[blue]📝 Install result data: {result['data']}[/blue]")
 

--- a/merobox/commands/bootstrap/steps/mesh.py
+++ b/merobox/commands/bootstrap/steps/mesh.py
@@ -4,21 +4,17 @@ Create mesh step executor - Creates a context and connects multiple nodes to it.
 The mesh step uses the namespace governance flow:
 1. Create namespace on the context_node
 2. Create context in that namespace
-3. Pre-install the application on joining nodes (if path is provided)
-4. For each joining node: create namespace invitation, join namespace
-5. Contexts are joined automatically via namespace/group auto_join
+3. For each joining node: create namespace invitation, join namespace
+4. Contexts are joined automatically via namespace/group auto_join
 """
 
 import json as json_lib
-import os
-import shutil
-from typing import Any, Optional
+from typing import Any
 
 from rich.markup import escape
 
 from merobox.commands.bootstrap.steps.base import BaseStep
 from merobox.commands.client import get_client_for_rpc_url
-from merobox.commands.constants import CONTAINER_DATA_DIR_PATTERNS, DEFAULT_METADATA
 from merobox.commands.identity import (
     create_namespace_invitation_via_admin_api,
     generate_identity_via_admin_api,
@@ -87,108 +83,6 @@ class CreateMeshStep(BaseStep):
                 "Namespace the mesh was created under",
             ),
         ]
-
-    def _is_binary_mode(self) -> bool:
-        manager = getattr(self, "manager", None)
-        if manager is None:
-            return False
-        return hasattr(manager, "binary_path") and manager.binary_path is not None
-
-    def _resolve_application_path(self, path: str) -> str:
-        expanded_path = os.path.expanduser(path)
-        return os.path.abspath(expanded_path)
-
-    def _prepare_container_path(
-        self, node_name: str, source_path: str
-    ) -> Optional[str]:
-        container_data_dir: Optional[str] = None
-
-        for pattern in CONTAINER_DATA_DIR_PATTERNS:
-            if "{node_name}" in pattern:
-                candidate = pattern.format(node_name=node_name)
-            else:
-                candidate = None
-
-            if candidate and os.path.exists(candidate):
-                container_data_dir = candidate
-                break
-
-        if not container_data_dir or not os.path.exists(container_data_dir):
-            console.print(
-                f"[red]Container data directory not found for {node_name}[/red]"
-            )
-            return None
-        try:
-            abs_container_data_dir = os.path.abspath(container_data_dir)
-            abs_source_path = os.path.abspath(source_path)
-            if (
-                os.path.commonpath([abs_source_path, abs_container_data_dir])
-                == abs_container_data_dir
-            ):
-                filename = os.path.basename(source_path)
-                return f"/app/data/{filename}"
-        except ValueError:
-            pass
-
-        filename = os.path.basename(source_path)
-        try:
-            os.makedirs(container_data_dir, exist_ok=True)
-            container_file_path = os.path.join(container_data_dir, filename)
-            shutil.copy2(source_path, container_file_path)
-            console.print(
-                f"[blue]Copied file to container data directory: {container_file_path}[/blue]"
-            )
-            return f"/app/data/{filename}"
-        except (OSError, shutil.Error) as error:
-            console.print(
-                f"[red]Failed to copy file to container data directory: {error}[/red]"
-            )
-            return None
-
-    def _install_application_on_node(
-        self, node_name: str, application_path: str
-    ) -> bool:
-        """Install the application WASM on a single node.
-
-        Returns True on success, False on failure.
-        """
-        try:
-            rpc_url, client_node_name = self._resolve_node_for_client(node_name)
-            client = get_client_for_rpc_url(rpc_url, node_name=client_node_name)
-
-            if self._is_binary_mode():
-                api_result = client.install_dev_application(
-                    path=application_path, metadata=DEFAULT_METADATA
-                )
-            else:
-                container_path = self._prepare_container_path(
-                    node_name, application_path
-                )
-                if not container_path:
-                    console.print(
-                        f"[red]Unable to prepare application file for {node_name}[/red]"
-                    )
-                    return False
-                api_result = client.install_dev_application(
-                    path=container_path, metadata=DEFAULT_METADATA
-                )
-
-            if isinstance(api_result, dict) and "error" in api_result:
-                console.print(
-                    f"[yellow]Warning: install_dev_application returned error for {node_name}: {api_result['error']}[/yellow]"
-                )
-                return False
-
-            console.print(
-                f"  [green]\u2713 Pre-installed application on {node_name}[/green]"
-            )
-            return True
-        except Exception as e:
-            console.print(
-                f"  [yellow]\u26a0\ufe0f Failed to pre-install app on {node_name}: "
-                f"{escape(str(e))}[/yellow]"
-            )
-            return False
 
     async def execute(
         self, workflow_results: dict[str, Any], dynamic_values: dict[str, Any]
@@ -365,30 +259,6 @@ class CreateMeshStep(BaseStep):
                 dynamic_values["group_id"] = namespace_id
 
         connected_nodes = [context_node]
-
-        # Pre-install application on all joining nodes so context state sync works.
-        # The core join protocol no longer transfers application blobs.
-        # If path not specified, auto-resolve from install_application step.
-        raw_application_path = self.config.get("path")
-        if not raw_application_path:
-            raw_application_path = dynamic_values.get(f"app_path_{context_node}")
-        if raw_application_path:
-            application_path = self._resolve_application_path(raw_application_path)
-            if not os.path.isfile(application_path):
-                console.print(
-                    f"[red]Application path not found or not a file: {application_path}[/red]"
-                )
-                return False
-
-            console.print("\n[bold]Pre-installing application on joining nodes[/bold]")
-            for node_name in nodes:
-                if node_name == context_node:
-                    continue
-                if not self._install_application_on_node(node_name, application_path):
-                    console.print(
-                        f"[red]Failed to pre-install application on {node_name}[/red]"
-                    )
-                    return False
 
         for node_name in nodes:
             if node_name == context_node:

--- a/merobox/tests/unit/test_unknown_step_keys_rejected.py
+++ b/merobox/tests/unit/test_unknown_step_keys_rejected.py
@@ -91,7 +91,6 @@ class TestKeysTheExecutorsActuallyRead:
                 "context_node": "n1",
                 "application_id": "app",
                 "nodes": ["n1", "n2"],
-                "path": "res/app.wasm",
             },
             {
                 "type": "create_context",

--- a/workflow-examples/workflow-fault-injection-convergence-example.yml
+++ b/workflow-examples/workflow-fault-injection-convergence-example.yml
@@ -54,7 +54,6 @@ steps:
     type: create_mesh
     context_node: calimero-node-1
     application_id: "{{app_id}}"
-    path: ./workflow-examples/res/kv_store.wasm
     nodes:
       - calimero-node-2
       - calimero-node-3

--- a/workflow-examples/workflow-fault-injection-partition-peers-example.yml
+++ b/workflow-examples/workflow-fault-injection-partition-peers-example.yml
@@ -48,7 +48,6 @@ steps:
     type: create_mesh
     context_node: calimero-node-1
     application_id: "{{app_id}}"
-    path: ./workflow-examples/res/kv_store.wasm
     nodes:
       - calimero-node-2
       - calimero-node-3

--- a/workflow-examples/workflow-mesh-example.yml
+++ b/workflow-examples/workflow-mesh-example.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: calimero-node-1
     application_id: "{{app_id}}"
-    path: ./workflow-examples/res/kv_store.wasm
     nodes:
       - calimero-node-2
       - calimero-node-3

--- a/workflow-examples/workflow-mesh-exports-example.yml
+++ b/workflow-examples/workflow-mesh-exports-example.yml
@@ -25,7 +25,6 @@ steps:
     type: create_mesh
     context_node: mesh-exports-node-1
     application_id: "{{app_id}}"
-    path: ./workflow-examples/res/kv_store.wasm
     nodes:
       - mesh-exports-node-2
       - mesh-exports-node-3

--- a/workflow-examples/workflow-propagation-monitoring.yml
+++ b/workflow-examples/workflow-propagation-monitoring.yml
@@ -27,7 +27,6 @@ steps:
     type: create_mesh
     context_node: dag-node-1
     application_id: "{{app_id}}"
-    path: ./workflow-examples/res/kv_store.wasm
     nodes:
       - dag-node-2
       - dag-node-3

--- a/workflow-examples/workflow-snapshot-finalize-regression-3252.yml
+++ b/workflow-examples/workflow-snapshot-finalize-regression-3252.yml
@@ -75,7 +75,6 @@ steps:
     type: create_mesh
     context_node: snapshot-node-1
     application_id: "{{app_id}}"
-    path: ./workflow-examples/res/kv_store.wasm
     nodes:
       - snapshot-node-2
       - snapshot-node-3


### PR DESCRIPTION
## Summary

`create_mesh` installed the application on every joining node before wiring them in. That is the same pre-empting removed from `join_namespace` in #369, and core already handles the case it was covering: when the application row is missing, sync fetches the context's blob from a peer and installs it (`crates/node/src/sync/manager/blob_fetch.rs:81`, reached from `manager/mod.rs:1951`). Pre-installing means that path never runs.

#369 is the evidence this is safe. Removing the `join_namespace` pre-install left CI fully green, and 25 of merobox's 26 join steps had relied on it, so core demonstrably delivers the application over the wire. Those workflows install a raw `.wasm`, so this is not limited to bundles.

## The comment that kept it alive

```python
# mesh.py:370
# The core join protocol no longer transfers application blobs.
```

True of the join protocol, and misleading about the outcome: the sync that follows it does transfer them. For as long as that line stood it read as "nothing delivers this," which is why both pre-installs looked justified.

## Changes

- Remove the pre-install from `create_mesh`, and the four helpers that existed only to serve it (`_is_binary_mode`, `_resolve_application_path`, `_prepare_container_path`, `_install_application_on_node`).
- Remove `path` from `CreateMeshStep`: with the pre-install gone it has no reader, and a key nothing reads is what `extra="forbid"` exists to catch.
- Remove the `app_path_<node>` memo `install_application` kept solely for that lookup. No workflow references it as a template variable.
- Drop `path` from the six shipped workflows that set it, and from the `KeysTheExecutorsActuallyRead` fixture, since the executor no longer reads it.
- Drop the `path` row from the `create_mesh` table in the YAML reference.

Net -149 lines.

## Ordering

calimero-network/core#3630 removes the same key from the 39 core scenarios that set it. Core pins merobox at 0.6.62 (`setup-merobox/action.yml:39`), so nothing breaks the moment this lands, but #3630 should merge before the pin is bumped past this release.

## Test plan

```
ruff check merobox/        All checks passed
black --check merobox/     146 files unchanged
pytest merobox/tests/unit  1461 passed
```

The unit suite caught the incomplete first pass: `test_shipped_workflows_validate` and `TestKeysTheExecutorsActuallyRead` both failed until the shipped workflows and the fixture stopped setting `path`. The canary and binary matrices exercising `mesh-example`, `mesh-exports-example`, `propagation-monitoring`, `snapshot-finalize-regression-3252` and the two fault-injection workflows are the real check, since those are the mesh scenarios whose joining nodes now depend on core's delivery.