### PR TITLE
chore(release): 0.6.63, carrying the delegated-authorship steps

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.62"
+__version__ = "0.6.63"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Publishes `sign_warrant` and `perform_intent` (#373, merged as `5eb320b2f`).

core needs these on PyPI before its CI can use them: the pin in `.github/actions/setup-merobox` is **exact** and guarded — it errors if the installed version differs from the pinned one — so an unpublished version reaches nothing. This is the step that makes `0.6.63` pinnable.

One line. The version lives only in `merobox/__init__.py`; pyproject reads it from there.

## Checked

- `0.6.62` is the current release on PyPI (confirmed against the `/simple/` index, not just the JSON API), so `0.6.63` is the next number.
- 59 unit tests pass, `black --check` and `ruff check` clean.

## Note for whoever merges

The `delegated-authorship.yml` example shipped in #373 is still **excluded from both CI matrices** and has never been executed end to end. Turning it on is a separate PR, once it has been run against a `merod:edge` carrying the intents endpoint — core#3636 merged, but its `Release` workflow was still rebuilding that image when this went up.

So `0.6.63` ships the steps and their unit coverage, not a proven scenario. That is deliberate: it unblocks core's pin without putting an unexecuted workflow into a required matrix.