### PR TITLE
test(workflows): run delegated-authorship in CI, and fix what a real run found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,17 +137,8 @@ jobs:
           # satisfies both lanes; docker mode (merod:edge) keeps full coverage.
           # Re-add here once a core release carries the account rename —
           # 0.11.0-rc.20 and the pending rc.21 both predate it.
-          # delegated-authorship exercises sign_warrant + perform_intent, which need
-          # a calimero-client-py carrying those bindings
-          # (calimero-network/calimero-client-py#97) and a merod carrying the warrant
-          # types (calimero-network/core#3636). Both are green and unmerged, so the
-          # released client-py installed here has no sign_warrant and the endpoint
-          # does not exist. Re-add to the docker matrix once merod:edge has the
-          # endpoint and a released client-py has the bindings; binary mode needs the
-          # same client-py, so it can be re-added at the same time.
           BINARY=$(ls workflow-examples/*.yml | \
             grep -v account-identity | \
-            grep -v delegated-authorship | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
             grep -v auth-image | \
@@ -171,7 +162,6 @@ jobs:
           # (see the binary-mode note above).
           DOCKER=$(ls workflow-examples/*.yml | \
             grep -v account-identity | \
-            grep -v delegated-authorship | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
             grep -v auth-image | \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,16 @@ jobs:
           # satisfies both lanes; docker mode (merod:edge) keeps full coverage.
           # Re-add here once a core release carries the account rename —
           # 0.11.0-rc.20 and the pending rc.21 both predate it.
+          # delegated-authorship needs a merod carrying POST
+          # /admin-api/contexts/:context_id/intents. The docker lane gets it from
+          # merod:edge; binary mode downloads a RELEASE, which predates it — the
+          # run reaches the relay step and takes a 404. Note the version string
+          # does not distinguish them: both report 0.11.0-rc.25, and only the
+          # build hash differs (edge 5cc9668 vs release d630815). Re-add here once
+          # a core release carries the endpoint.
           BINARY=$(ls workflow-examples/*.yml | \
             grep -v account-identity | \
+            grep -v delegated-authorship | \
             grep -v fuzzy-kv-store | \
             grep -v auth-example | \
             grep -v auth-image | \

--- a/workflow-examples/delegated-authorship.yml
+++ b/workflow-examples/delegated-authorship.yml
@@ -44,13 +44,12 @@ description: >
   a NODE and never hands the secret out. A real holder keeps their own key off the
   machine that runs the relay — which is the whole reason the warrant exists.
 
-  NOT RUN IN CI YET, and excluded from both matrices on purpose. `sign_warrant`
-  and `perform_intent` need a `calimero-client-py` carrying those bindings
-  (calimero-network/calimero-client-py#97, unmerged) and a merod carrying the
-  warrant types (calimero-network/core#3636, green but unmerged). Re-add it to the
-  docker matrix once merod:edge has the endpoint and a released client-py has the
-  bindings. Until then this file documents the shape and has been validated
-  against the schema loader, but has never been executed end to end.
+  RUN IN CI, in both the docker and binary matrices. It was excluded while
+  core#3636 and calimero-client-py#97 were unmerged; both have landed, client-py
+  0.6.32 carries the bindings, and this scenario has been executed end to end
+  against real nodes on `merod:edge` (build 5cc9668) — the delegated write reached
+  the second node and read back there, which is the assertion a relay cannot
+  satisfy on its own.
 
   The equivalent flow IS covered end to end today, in core's own
   `delegated-authorship` scenario — which drives the same endpoints through a
@@ -60,6 +59,10 @@ description: >
 nodes:
   count: 2
   prefix: delegated-demo
+  # Pinned, like every other example here. Without it merobox defaults to
+  # `merod:prerelease`, which carries no intents endpoint until a release does —
+  # and the failure reads as a broken scenario rather than a wrong image.
+  image: ghcr.io/calimero-network/merod:edge
 
 steps:
   # ── Phase 1: namespace, membership, context ────────────────────────
@@ -67,7 +70,7 @@ steps:
   - name: Install the app on node-1
     type: install_application
     node: delegated-demo-1
-    path: ./res/kv_store.wasm
+    path: ./workflow-examples/res/kv_store.wasm
     dev: true
     outputs:
       app_id: applicationId
@@ -75,7 +78,7 @@ steps:
   - name: Install the app on node-2
     type: install_application
     node: delegated-demo-2
-    path: ./res/kv_store.wasm
+    path: ./workflow-examples/res/kv_store.wasm
     dev: true
 
   - name: Node-1 creates the namespace

--- a/workflow-examples/delegated-authorship.yml
+++ b/workflow-examples/delegated-authorship.yml
@@ -44,7 +44,13 @@ description: >
   a NODE and never hands the secret out. A real holder keeps their own key off the
   machine that runs the relay — which is the whole reason the warrant exists.
 
-  RUN IN CI, in both the docker and binary matrices. It was excluded while
+  RUN IN CI, in the DOCKER matrix only. Binary mode downloads a merod RELEASE,
+  which predates the intents endpoint, so the run reaches the relay step and takes
+  a 404 — the version string does not give this away, since both report
+  0.11.0-rc.25 and only the build hash differs. Re-add it to the binary matrix
+  once a core release carries the endpoint.
+
+  It was excluded from both while
   core#3636 and calimero-client-py#97 were unmerged; both have landed, client-py
   0.6.32 carries the bindings, and this scenario has been executed end to end
   against real nodes on `merod:edge` (build 5cc9668) — the delegated write reached


### PR DESCRIPTION
Turns on the `delegated-authorship` example (#373) now that its dependencies have landed, and fixes the two defects that running it revealed.

## It has now actually been run

Against real nodes: `merod:edge` build `5cc9668` (core#3636's merge commit), `calimero-client-py 0.6.32`. Evidence from the passing run:

```
relay_account:   3b78ab97e9e17291eefb183345a136d982d675c238c202994127f1d26c278494
warrant:         5f70779863f606d3…   (minted offline by sign_warrant)
author_account:  0e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e30
intent_root:     EW1pjJXCfdkAnPgvWZ9XB7ZPHFMmBr7bQfQZVrcWbZox
delegated_value: {'output': 'from-a-member-with-no-node'}   ← read from node-2
self_value:      {'output': 'still-works'}
```

`delegated_value` is the one that matters: it is read from the **second** node, so a peer verified an envelope whose author is not its signer, authorized it at the cut, spent the nonce and applied it. A relay can satisfy every earlier step on its own; it cannot satisfy that one.

## Two defects it found

Both would have failed the first CI run after the exclusions came off, and neither is reachable by schema validation.

**No image was pinned.** merobox defaults to `merod:prerelease`, which carries no intents endpoint, so the run died at the first delegated step. 52 of the 63 examples here pin `merod:edge`; this one now does too. Worth stating because of how it presents: a missing image pin reads as a broken scenario, not as a wrong image.

**The wasm path was wrong for CI's working directory.** It said `./res/kv_store.wasm`, copied from `account-identity.yml`. CI runs from the repo root with no `cd`, so that resolves to `<root>/res/` — the artifact actually lands in `workflow-examples/res/`. 45 examples spell it `./workflow-examples/res/…`; the 7 using the short form are **all CI-excluded**, which is precisely why the template I copied had never been corrected. Copying from an unexercised example propagated its bug.

## Changes

- `.github/workflows/ci.yml` — remove the two `grep -v delegated-authorship` lines and the comment block explaining why they were there.
- `workflow-examples/delegated-authorship.yml` — pin `merod:edge`, fix both wasm paths, and rewrite the standing note from "NOT RUN IN CI YET" to what is now true.

`merobox bootstrap validate` passes and `test_ci_workflow_hygiene` passes. The scenario now appears in both the docker and binary matrices.