### PR TITLE
feat(steps): honour expected_failure on sign_warrant and perform_intent

### DIFF
--- a/merobox/commands/bootstrap/steps/account.py
+++ b/merobox/commands/bootstrap/steps/account.py
@@ -570,12 +570,22 @@ class SignWarrantStep(_AccountStepBase):
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
             result = fail(f"signing the warrant failed: {e}", error=e)
 
+        # Minting refuses too — a credential that certifies a different key than
+        # `device_secret` holds, most usefully — and that refusal is worth
+        # asserting rather than only surviving.
+        expected_failure = self._is_expected_failure()
+
         if not result["success"]:
+            if expected_failure:
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]Failed to sign a warrant for {method} in {context_id}: "
                 f"{escape(str(result.get('error')))}[/red]"
             )
             return False
+
+        if expected_failure:
+            return self._report_unexpected_success()
 
         data = result["data"]
         console.print(
@@ -665,12 +675,28 @@ class PerformIntentStep(_AccountStepBase):
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
             result = fail(f"performing the intent failed: {e}", error=e)
 
+        # A refusal is a first-class outcome here, not just an error. The three
+        # things this endpoint refuses — a relay holding no authorship grant, a
+        # warrant that does not cover the intent, and a warrant already spent —
+        # are each worth asserting positively, and a scenario that can only
+        # assert acceptance cannot show that the grant is load-bearing.
+        #
+        # Pair it with `expected_error` in anything that matters: without one,
+        # an unreachable node satisfies the same assertion as the refusal under
+        # test.
+        expected_failure = self._is_expected_failure()
+
         if not result["success"]:
+            if expected_failure:
+                return self._report_expected_failure(self._failure_detail(result))
             console.print(
                 f"[red]{node_name} could not perform {method} in {context_id}: "
                 f"{escape(str(result.get('error')))}[/red]"
             )
             return False
+
+        if expected_failure:
+            return self._report_unexpected_success()
 
         data = result["data"]
         console.print(

--- a/merobox/tests/unit/test_account_steps.py
+++ b/merobox/tests/unit/test_account_steps.py
@@ -753,3 +753,93 @@ class TestPerformIntentStep:
         )
         step = _step(PerformIntentStep, self.config, client)
         assert _run(step.execute({}, {})) is False
+
+
+class TestPerformIntentExpectedFailure:
+    """A refusal is a first-class outcome, and the RIGHT refusal at that.
+
+    The endpoint refuses three things worth asserting positively — a relay with
+    no authorship grant, a warrant that does not cover the intent, and one
+    already spent. A scenario that can only assert acceptance cannot show the
+    grant is load-bearing, which is the whole point of granting it.
+    """
+
+    def setup_method(self):
+        self.config = {
+            "type": "perform_intent",
+            "name": "Delegate",
+            "node": "calimero-node-1",
+            "context_id": WARRANT_CONTEXT,
+            "method": "set",
+            "args": {"key": "k"},
+            "warrant": "aa" * 8,
+            "author_proof": WARRANT_CREDENTIAL,
+            "expected_failure": True,
+        }
+
+    def _refusing(self, message):
+        client = MagicMock()
+        client.perform_intent.side_effect = RuntimeError(message)
+        return client
+
+    def test_a_refusal_passes_when_it_is_expected(self):
+        step = _step(
+            PerformIntentStep,
+            self.config,
+            self._refusing("the executor holds no CAN_AUTHOR_ON_BEHALF grant"),
+        )
+        assert _run(step.execute({}, {})) is True
+
+    def test_the_expected_error_must_actually_match(self):
+        """Otherwise an unreachable node satisfies the refusal under test.
+
+        This is the assertion that makes `expected_failure` worth having rather
+        than merely permissive: a connection error and a `403` are both failures,
+        and only one of them is evidence.
+        """
+        step = _step(
+            PerformIntentStep,
+            {**self.config, "expected_error": "CAN_AUTHOR_ON_BEHALF"},
+            self._refusing("connection refused"),
+        )
+        assert _run(step.execute({}, {})) is False
+
+        step = _step(
+            PerformIntentStep,
+            {**self.config, "expected_error": "CAN_AUTHOR_ON_BEHALF"},
+            self._refusing("the executor holds no CAN_AUTHOR_ON_BEHALF grant"),
+        )
+        assert _run(step.execute({}, {})) is True
+
+    def test_an_unexpected_success_fails_the_step(self):
+        """A warrant that should have been refused and was not is the worst
+        outcome of the three, so it must not read as a pass."""
+        client = MagicMock()
+        client.perform_intent.return_value = _envelope(
+            {"rootHash": "abc", "returns": None}
+        )
+        step = _step(PerformIntentStep, self.config, client)
+        assert _run(step.execute({}, {})) is False
+
+
+class TestSignWarrantExpectedFailure:
+    def test_a_refused_mint_passes_when_expected(self):
+        module = MagicMock()
+        module.sign_warrant = MagicMock(
+            side_effect=ValueError("this credential certifies a different key")
+        )
+        step = SignWarrantStep(
+            {
+                "type": "sign_warrant",
+                "name": "Mint",
+                "context_id": WARRANT_CONTEXT,
+                "executor": WARRANT_ACCOUNT,
+                "method": "set",
+                "device_secret": WARRANT_SECRET,
+                "credential": WARRANT_CREDENTIAL,
+                "expected_failure": True,
+                "expected_error": "certifies a different key",
+            }
+        )
+        with patch.dict(sys.modules, {"calimero_client_py": module}):
+            assert _run(step.execute({}, {})) is True


### PR DESCRIPTION
`expected_failure` is a `BaseStep` helper that each step **opts into**, and `account.py` never did — so a refusal from either new step was a hard failure with no way to assert it.

That is the wrong shape for this endpoint in particular, because refusing is most of what it does. Three refusals are normal answers worth asserting positively:

- the relay holds no `CAN_AUTHOR_ON_BEHALF` grant,
- the warrant does not cover the intent presented with it,
- the warrant's nonce is already spent.

A scenario that can only assert *acceptance* cannot show that the grant is load-bearing — which is the entire reason the capability exists.

## How this was found

Starting core's side of the rollout. Rewriting core's `delegated-authorship` e2e onto these steps would have silently dropped its two most valuable assertions — the **pre-grant refusal** and the **refused replay** — because there was no way to express them. The rewrite would have looked like a clean simplification while weakening the test. This is what unblocks it.

## Pair it with `expected_error`

Without one, an unreachable node satisfies the same assertion as the refusal under test, and the step passes for the wrong reason. `test_the_expected_error_must_actually_match` pins that: `"connection refused"` must **not** satisfy an assertion looking for `CAN_AUTHOR_ON_BEHALF`, while the real refusal must.

## Tests

62 in `test_account_steps.py`, up from 58. Mutation-tested: removing the unexpected-success guard fails `test_an_unexpected_success_fails_the_step` and nothing else.

A warrant that should have been refused and was **not** is the worst of the three outcomes, so it must not read as a pass — hence `_report_unexpected_success()` on both steps rather than only on the refusal path.

`black --check` and `ruff check` clean.

## Relationship to the other open PRs

Independent of #375 (which only touches `ci.yml` and the workflow file) — no overlapping files. Both are needed before core's e2e can move onto the steps and `delegated-intent.sh` can be deleted; this one is the blocker for keeping the refusal assertions in that rewrite.