### PR TITLE
feat(bootstrap): fail a workflow whose node panicked

### DIFF
--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -2082,6 +2082,10 @@ class WorkflowConfig(BaseModel):
     nuke_on_end: Optional[bool] = Field(
         False, description="Nuke all data after workflow"
     )
+    fail_on_panic: Optional[bool] = Field(
+        True,
+        description="Fail the workflow if any node logged a panic (default true)",
+    )
     stop_all_nodes: Optional[bool] = Field(
         False, description="Stop all nodes at the end"
     )

--- a/merobox/commands/bootstrap/run/executor.py
+++ b/merobox/commands/bootstrap/run/executor.py
@@ -408,6 +408,14 @@ class WorkflowExecutor:
                 self._handle_failure_exit(stop_all_nodes)
                 return False
 
+            # A node that panicked is a bug even when every step passed, and
+            # nothing else in the run looks: assertions read RPC responses, not
+            # logs. Checked before teardown so it does not depend on which stop
+            # path runs, and on the success path only - a failing workflow has
+            # already reported a cause worth more than this one.
+            if not self._assert_no_node_panicked():
+                return False
+
             # Step 5: Stop all nodes if requested (at end) - only if we have local nodes
             if has_local_nodes:
                 if stop_all_nodes:
@@ -749,6 +757,34 @@ class WorkflowExecutor:
         if stop_all_nodes:
             self._stop_nodes_on_failure()
         self._teardown_topology_if_present()
+
+    def _assert_no_node_panicked(self) -> bool:
+        """False when a node logged a panic and the workflow opted into the check.
+
+        Default on: a scenario that means to panic a node says `fail_on_panic:
+        false`, which is visible in review, where a silently missing check is not.
+        """
+        if not self.config.get("fail_on_panic", True):
+            return True
+        if self.manager is None or getattr(self.manager, "client", None) is None:
+            return True
+        try:
+            panics = self.manager.scan_nodes_for_panics()
+        except Exception as e:
+            console.print(f"[yellow]⚠️  Could not scan for panics: {str(e)}[/yellow]")
+            return True
+        # Count first, and fail only on a positive one: the gate must never
+        # fail a run for any reason other than a panic it can name.
+        total = sum(len(v) for v in panics.values()) if isinstance(panics, dict) else 0
+        if not total:
+            return True
+        console.print(
+            f"\n[bold red]❌ {total} panic(s) across {len(panics)} node(s)[/bold red]"
+        )
+        for node, msgs in panics.items():
+            for m in msgs:
+                console.print(f"  [red]{node}: {escape(m)}[/red]")
+        return False
 
     def _export_node_logs(self) -> None:
         """Persist logs of all running nodes to ``data/container-logs/``.

--- a/merobox/commands/manager.py
+++ b/merobox/commands/manager.py
@@ -133,6 +133,37 @@ def _dump_container_log(container, container_name: str, log_dir: str) -> bool:
         return False
 
 
+# merod's panic hook logs the message, thread and location as fields under
+# "Application panic occurred", then chains to the default hook, so a panic also
+# leaves Rust's own line. Match either: the structured one is absent for a panic
+# raised before the hook is installed, the default one is what any other process
+# leaves. Matching these two shapes rather than the bare word keeps prose out.
+_PANIC_LINE = re.compile(r"Application panic occurred|thread '[^']*' panicked at")
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_PANIC_MESSAGE = re.compile(r"panic\.message=(?P<msg>.*?)(?= panic\.\w+=|$)")
+_RUST_PANIC = re.compile(r"thread '[^']*' panicked at [^\s,]+")
+
+
+def panic_messages(log_text: str) -> list[str]:
+    """The panic messages in one node's log, most useful form first.
+
+    ANSI escapes are stripped before matching: they sit between a field name and
+    its ``=`` in node logs, so the raw pattern would never match a coloured line.
+    """
+    found = []
+    for line in log_text.splitlines():
+        clean = _ANSI.sub("", line)
+        if not _PANIC_LINE.search(clean):
+            continue
+        m = _PANIC_MESSAGE.search(clean)
+        if m:
+            found.append(m.group("msg").strip())
+            continue
+        m = _RUST_PANIC.search(clean)
+        found.append(m.group(0) if m else clean.strip())
+    return found
+
+
 def _dump_container_state(
     container, container_name: str, log_dir: str
 ) -> Optional[dict]:
@@ -2287,6 +2318,29 @@ class DockerManager(CleanupMixin):
             if detail:
                 console.print(f"[red]💀 {detail}[/red]")
         return written
+
+    def scan_nodes_for_panics(self) -> dict[str, list[str]]:
+        """Panic messages per node, for nodes that logged one.
+
+        Reads the containers directly rather than the exported files so the
+        answer does not depend on which teardown path ran.
+        """
+        found: dict[str, list[str]] = {}
+        for name in self.get_all_nodes():
+            container = self.nodes.get(name)
+            if container is None:
+                try:
+                    container = self.client.containers.get(name)
+                except Exception:
+                    continue
+            try:
+                log = container.logs().decode("utf-8", errors="replace")
+            except Exception:
+                continue
+            msgs = panic_messages(log)
+            if msgs:
+                found[name] = msgs
+        return found
 
     def list_nodes(self) -> None:
         """List all running Calimero nodes and infrastructure."""

--- a/merobox/tests/unit/test_panic_detection.py
+++ b/merobox/tests/unit/test_panic_detection.py
@@ -1,0 +1,84 @@
+"""A node that panics must fail its workflow.
+
+Assertions read RPC responses, so a node can panic, restart, and leave every
+step green. Exactly one scenario in calimero-network/core greps its logs for
+this; the other 89 jobs never look.
+"""
+
+from unittest.mock import MagicMock
+
+from merobox.commands.bootstrap.run.executor import WorkflowExecutor
+from merobox.commands.manager import panic_messages
+
+STRUCTURED = (
+    "ERROR panic.message=Mailbox has closed panic.thread=tokio-runtime-worker "
+    'panic.file=crates/node/src/x.rs "Application panic occurred"'
+)
+RUST = "thread 'tokio-runtime-worker' panicked at crates/node/src/x.rs:42:9:"
+ANSI = (
+    "\x1b[31mERROR\x1b[0m \x1b[2mpanic.message\x1b[0m=boom happened "
+    'panic.thread=main "Application panic occurred"'
+)
+
+
+class TestPanicMessages:
+    def test_structured_hook_line_yields_the_whole_message(self):
+        assert panic_messages(STRUCTURED) == ["Mailbox has closed"]
+
+    def test_default_rust_line_is_matched_too(self):
+        # A panic raised before the hook is installed leaves only this shape.
+        assert panic_messages(RUST) == [RUST]
+
+    def test_ansi_escapes_do_not_hide_a_panic(self):
+        # Escapes sit between the field name and its `=` in node logs.
+        assert panic_messages(ANSI) == ["boom happened"]
+
+    def test_prose_containing_the_word_is_not_a_panic(self):
+        assert panic_messages("INFO the word panicked appears here") == []
+
+    def test_clean_log_is_clean(self):
+        assert panic_messages("INFO started\nINFO ready") == []
+
+    def test_every_panic_in_a_log_is_reported(self):
+        assert len(panic_messages("\n".join([STRUCTURED, "INFO fine", RUST]))) == 2
+
+
+def _executor(panics, config=None):
+    ex = WorkflowExecutor.__new__(WorkflowExecutor)
+    ex.config = config if config is not None else {}
+    ex.manager = MagicMock()
+    ex.manager.client = object()
+    ex.manager.scan_nodes_for_panics.return_value = panics
+    return ex
+
+
+class TestExecutorGate:
+    def test_a_panic_fails_the_workflow(self):
+        assert (
+            _executor({"node-1": ["Mailbox has closed"]})._assert_no_node_panicked()
+            is False
+        )
+
+    def test_no_panic_passes(self):
+        assert _executor({})._assert_no_node_panicked() is True
+
+    def test_a_workflow_may_opt_out(self):
+        ex = _executor({"node-1": ["deliberate"]}, {"fail_on_panic": False})
+        assert ex._assert_no_node_panicked() is True
+
+    def test_a_scan_that_errors_does_not_fail_the_run(self):
+        # Best-effort: an unreadable container must not invent a failure.
+        ex = _executor({})
+        ex.manager.scan_nodes_for_panics.side_effect = RuntimeError("docker gone")
+        assert ex._assert_no_node_panicked() is True
+
+    def test_no_manager_is_not_a_panic(self):
+        ex = _executor({})
+        ex.manager = None
+        assert ex._assert_no_node_panicked() is True
+
+    def test_a_scan_returning_no_messages_does_not_fail_the_run(self):
+        # The gate must fail only on a panic it can name, never on a shape it
+        # did not expect back from the scan.
+        assert _executor({"node-1": []})._assert_no_node_panicked() is True
+        assert _executor(MagicMock())._assert_no_node_panicked() is True


### PR DESCRIPTION
Steps assert over RPC responses, so a node can panic, restart, and leave every one of them green. Nothing in a run looks at the logs for it.

Across calimero-network/core's 133 scenarios, exactly one greps for a panic (`apps/kv-store/workflows/ephemeral-presence-e2e.yml`). The other four workflows that drive merobox — `app-migration-e2e`, `e2e-rust-apps-release`, `fuzzy-load-test`, `sync-regression` — have no check at all.

This belongs here rather than in each consumer's CI: merobox starts the nodes, so merobox already has the logs, and a check here covers every scenario in every workflow in every repo instead of needing the same shell pasted into five places that then drift.

## What it matches

`merod`'s panic hook logs the message, thread and location as fields under `Application panic occurred`, then chains to the previous hook, so a panic also leaves Rust's default `thread '...' panicked at`. Either is matched: the structured line is missing for a panic raised before the hook installs, and the default line is what a non-merod process leaves. Matching those two shapes rather than the bare word keeps prose out.

ANSI escapes are stripped before matching — they sit between a field name and its `=` in node logs, so a coloured line never matches raw.

## Where it runs

Before teardown, reading the containers directly rather than the exported files, so the result does not depend on which stop path ran. Only on the success path: a workflow that already failed has reported a cause worth more than this one.

`fail_on_panic: false` opts a workflow out, for a scenario that panics a node deliberately. Default on, because an opt-out is visible in review and a missing check is not.

## Test plan

12 unit tests, and the implementation was observed failing before the tests were believed. Three deliberate breaks, each caught:

| break | result |
| --- | --- |
| gate always returns True | 1 failed |
| detection stops stripping ANSI | 1 failed |
| message truncated at the first space | 2 failed |

Restored: 12 passed.

That third break is not hypothetical — it is the bug I shipped in a first attempt at this as a core-side CI step, where a real panic was reported as `panic.message=Mailbox` for what is `Mailbox has closed`.

The full suite caught a defect in the first draft too: with a mocked manager the scan returns a non-dict, and the gate failed a run reporting `0 panic(s) across 0 node(s)`. It now counts first and fails only on a positive count, so it can never fail a run for a reason other than a panic it can name.

```
black --check merobox/     148 files unchanged
ruff check merobox/        All checks passed
pytest merobox/tests/unit  1512 passed
```

## Found by the core-side prototype

`namespace-owner-writes-in-a-foreign-open-subgroup` panics with `Mailbox has closed` and passes today. That scenario is green on core master right now. Worth an issue against core regardless of where this check lands.