### PR TITLE
chore(release): 0.6.64, carrying expected_failure on the intent steps

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.63"
+__version__ = "0.6.64"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Publishes #376 (merged as `72b4ea8f5`), which lets `sign_warrant` and `perform_intent` honour `expected_failure` / `expected_error`.

**calimero-network/core#3642 pins this version and cannot merge without it.** Its two most valuable assertions — the pre-grant refusal and the refused replay — are *inert* against `0.6.63`: that release has the steps, but no way to assert that a refusal happened, so a scenario written against it would report a pass whether the endpoint refused or accepted.

`0.6.63` is the current release, hence `0.6.64`. One line; the version lives only in `merobox/__init__.py`.

## Checked

- 63 unit tests pass, `black --check` and `ruff check` clean.
- `0.6.63` confirmed as the published latest in the `/simple/` index.

Merging publishes to PyPI, at which point core#3642 can come out of draft.