### PR TITLE
feat(node_exec): capture named fields out of a command's stdout

### DIFF
--- a/merobox/commands/bootstrap/config.py
+++ b/merobox/commands/bootstrap/config.py
@@ -1088,6 +1088,13 @@ class NodeExecStepConfig(BaseStepConfig):
         description="Files to write under /app/data before running, "
         "as container path -> contents",
     )
+    capture: Optional[dict[str, str]] = Field(
+        None,
+        description="Named fields to pull out of stdout, as name -> regex with "
+        "exactly one capturing group. For commands printing several values, "
+        "where `stdout_first_line` reaches only the first. A pattern that "
+        "matches nothing fails the step rather than exporting an empty value",
+    )
     allow_running: Optional[bool] = Field(
         None,
         description="Run even if the node is up. Unsafe for anything that opens "

--- a/merobox/commands/bootstrap/steps/node_exec.py
+++ b/merobox/commands/bootstrap/steps/node_exec.py
@@ -24,6 +24,7 @@ disagree with how the node was actually started.
 """
 
 import os
+import re
 from typing import Any, Optional
 
 from merobox.commands.bootstrap.steps.base import BaseStep
@@ -45,6 +46,10 @@ class NodeExecStep(BaseStep):
     lock is exclusive. Running against a live node is refused rather than
     attempted, because the failure otherwise surfaces as an opaque lock error
     several layers down.
+
+    `capture:` maps names to regexes, each with one capturing group, pulled out
+    of stdout — for commands that print several values where
+    `stdout_first_line` reaches only one.
 
     Exports `stdout`, `stdout_first_line` (what a single-value command like
     `account export` actually produces, ahead of its advisory output), `stderr`
@@ -83,6 +88,34 @@ class NodeExecStep(BaseStep):
             value = self.config.get(flag)
             if value is not None and not isinstance(value, bool):
                 raise ValueError(f"Step '{step_name}': '{flag}' must be a bool")
+        capture = self.config.get("capture")
+        if capture is not None:
+            if not isinstance(capture, dict):
+                raise ValueError(
+                    f"Step '{step_name}': 'capture' must be a mapping of "
+                    "name -> regex with one capturing group"
+                )
+            for name, pattern in capture.items():
+                if not isinstance(name, str) or not isinstance(pattern, str):
+                    raise ValueError(
+                        f"Step '{step_name}': 'capture' names and patterns must "
+                        "both be strings"
+                    )
+                try:
+                    compiled = re.compile(pattern)
+                except re.error as err:
+                    raise ValueError(
+                        f"Step '{step_name}': capture '{name}' is not a valid "
+                        f"regex: {err}"
+                    ) from err
+                # Refused up front rather than at run time: a pattern with no
+                # group cannot yield a value, and the step would otherwise fail
+                # only once the command had run and only for that one field.
+                if compiled.groups != 1:
+                    raise ValueError(
+                        f"Step '{step_name}': capture '{name}' must have exactly "
+                        f"one capturing group, found {compiled.groups}"
+                    )
 
     def _get_exportable_variables(self):
         return [
@@ -95,6 +128,44 @@ class NodeExecStep(BaseStep):
             ("stderr", "exec_stderr_{node_name}", "Anything on stderr"),
             ("exit_code", "exec_exit_code_{node_name}", "The command's exit status"),
         ]
+
+    def _captured(self, stdout: str) -> dict[str, str]:
+        """Named fields pulled out of stdout by regex.
+
+        `stdout_first_line` reaches exactly one value, which is enough for a
+        command like `account export` that prints a single thing. It is not
+        enough for one that prints several: `account sign-cert --generate` emits
+        a credential, an account, a device and a secret, and a scenario needs
+        both the credential and the secret. Reordering the output only changes
+        which one is stranded.
+
+        A missing match is a failure, not an empty export. The alternative is a
+        scenario carrying `''` into whatever consumed it and failing somewhere
+        else — which is how an unresolved placeholder reaching an API as a
+        literal `{{secret}}` gets diagnosed three steps downstream.
+
+        Each pattern is searched per line and must have exactly one group, which
+        `_validate_field_types` checks before the command runs.
+        """
+        capture = self.config.get("capture") or {}
+        if not capture:
+            return {}
+
+        lines = stdout.splitlines()
+        found: dict[str, str] = {}
+        for name, pattern in capture.items():
+            compiled = re.compile(pattern)
+            for line in lines:
+                match = compiled.search(line)
+                if match:
+                    found[name] = match.group(1)
+                    break
+            else:
+                raise RuntimeError(
+                    f"capture '{name}' matched nothing in the command's output "
+                    f"(pattern {pattern!r})"
+                )
+        return found
 
     def _container_spec(self, node_name: str) -> tuple[str, str]:
         """The node's image and the HOST path backing its `/app/data` mount.
@@ -267,14 +338,14 @@ class NodeExecStep(BaseStep):
             first_line = next(
                 (line for line in stdout.splitlines() if line.strip()), ""
             )
-            result = ok(
-                {
-                    "stdout": stdout,
-                    "stdout_first_line": first_line.strip(),
-                    "stderr": stderr,
-                    "exit_code": exit_code,
-                }
-            )
+            payload = {
+                "stdout": stdout,
+                "stdout_first_line": first_line.strip(),
+                "stderr": stderr,
+                "exit_code": exit_code,
+            }
+            payload.update(self._captured(stdout))
+            result = ok(payload)
         except Exception as e:  # noqa: BLE001 - reported, not swallowed
             result = fail(f"node_exec failed: {e}", error=e)
 

--- a/merobox/tests/unit/test_node_exec_step.py
+++ b/merobox/tests/unit/test_node_exec_step.py
@@ -436,3 +436,104 @@ class TestNodeExecUsesTheRecordedDataDir:
         )
         assert _run(step.execute({}, {})) is False
         manager.client.containers.create.assert_not_called()
+
+
+#: What `merod account sign-cert --generate` prints: the credential first, then
+#: the three values it minted. Two of them are needed together, which is the
+#: whole reason `capture` exists — `stdout_first_line` reaches only the first.
+SIGN_CERT_STDOUT = """02b2a942ff4c98718bed76e2559
+Account: 0e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e30
+Device:  4d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba3803
+Secret:  4987ccd0fb7ef36bf7f61e8f99fd150d33e6adac47649f23bfd7109c2e36a3ba
+
+Hand this to the device it names.
+"""
+
+
+class TestNodeExecCaptureValidation:
+    def setup_method(self):
+        self.config = {
+            "type": "node_exec",
+            "name": "Mint",
+            "node": "calimero-node-2",
+            "args": ["account", "sign-cert", "--generate"],
+        }
+
+    def test_capture_must_be_a_mapping(self):
+        with pytest.raises(ValueError, match="capture"):
+            NodeExecStep({**self.config, "capture": ["Secret: (.*)"]})
+
+    def test_an_invalid_regex_is_refused_up_front(self):
+        with pytest.raises(ValueError, match="not a valid regex"):
+            NodeExecStep({**self.config, "capture": {"secret": "Secret: ("}})
+
+    @pytest.mark.parametrize("pattern", ["^Secret: +[0-9a-f]+$", "^(S)(ecret): (.+)$"])
+    def test_exactly_one_group_is_required(self, pattern):
+        """Zero groups can never yield a value; two is ambiguous.
+
+        Checked before the command runs, so the scenario fails on the step that
+        is wrong rather than after a container has done real work.
+        """
+        with pytest.raises(ValueError, match="one capturing group"):
+            NodeExecStep({**self.config, "capture": {"secret": pattern}})
+
+
+class TestNodeExecCapture:
+    def setup_method(self):
+        self.config = {
+            "type": "node_exec",
+            "name": "Mint",
+            "node": "calimero-node-2",
+            "args": ["account", "sign-cert", "--generate"],
+            "capture": {
+                "credential": r"^([0-9a-f]{20,})$",
+                "author_secret": r"^Secret: +([0-9a-f]{64})$",
+                "author_account": r"^Account: +([0-9a-f]{64})$",
+            },
+        }
+
+    def _step(self, manager, config=None):
+        return NodeExecStep(config or self.config, manager=manager)
+
+    def test_it_pulls_every_named_field_out_of_stdout(self, tmp_path):
+        manager = _manager(tmp_path)
+        stub = _stub_container(stdout=SIGN_CERT_STDOUT)
+        with patch.object(manager.client.containers, "create", return_value=stub):
+            results = {}
+            assert _run(self._step(manager).execute(results, {})) is True
+
+        data = results["exec_calimero-node-2"]
+        assert data["credential"] == "02b2a942ff4c98718bed76e2559"
+        assert (
+            data["author_secret"]
+            == "4987ccd0fb7ef36bf7f61e8f99fd150d33e6adac47649f23bfd7109c2e36a3ba"
+        )
+        assert (
+            data["author_account"]
+            == "0e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e30"
+        )
+        # The built-ins still work alongside it.
+        assert data["stdout_first_line"] == "02b2a942ff4c98718bed76e2559"
+
+    def test_a_pattern_that_matches_nothing_fails_the_step(self, tmp_path):
+        """Not an empty export.
+
+        Exporting `''` would carry an unresolved value into whatever consumed it
+        and fail somewhere else — a literal `{{author_secret}}` reaching an API
+        three steps later, which is how this class of bug gets diagnosed by
+        inference instead of by reading.
+        """
+        manager = _manager(tmp_path)
+        stub = _stub_container(stdout="Account: abc\n")
+        config = {**self.config, "capture": {"author_secret": r"^Secret: +(.+)$"}}
+        with patch.object(manager.client.containers, "create", return_value=stub):
+            assert _run(self._step(manager, config).execute({}, {})) is False
+
+    def test_no_capture_is_unchanged(self, tmp_path):
+        manager = _manager(tmp_path)
+        stub = _stub_container(stdout=SIGN_CERT_STDOUT)
+        config = {k: v for k, v in self.config.items() if k != "capture"}
+        with patch.object(manager.client.containers, "create", return_value=stub):
+            results = {}
+            assert _run(self._step(manager, config).execute(results, {})) is True
+        assert "author_secret" not in results["exec_calimero-node-2"]


### PR DESCRIPTION
`stdout_first_line` reaches exactly one value. That is enough for `account export`, which prints a single thing. It is not enough for `account sign-cert --generate`:

```
02b2a942ff4c98718bed76e2559…        ← the credential
Account: 0e2cd2d3…
Device:  4d0774b9…
Secret:  4987ccd0…                  ← and this
```

A scenario minting a device needs the **credential and the secret together**, and reordering the output only changes which one is stranded.

`capture:` maps names to regexes with one capturing group each, searched per line and merged into the step's result, so `outputs:` exports them like any other field:

```yaml
- type: node_exec
  node: calimero-node-2
  args: [account, sign-cert, --generate]
  capture:
    credential:     '^([0-9a-f]{20,})$'
    author_secret:  '^Secret: +([0-9a-f]{64})$'
    author_account: '^Account: +([0-9a-f]{64})$'
  outputs:
    credential: credential
    secret: author_secret
```

## Two things it refuses rather than tolerates

**A pattern with no capturing group, or more than one**, is rejected by validation *before* the command runs. Zero groups can never yield a value; two are ambiguous. Finding that out after a container has done real work costs the scenario its clarity about which step was wrong.

**A pattern matching nothing fails the step.** Exporting `''` would carry an unresolved value into whatever consumed it and fail somewhere else — a literal `{{author_secret}}` reaching an API three steps later, which is how this class of bug gets diagnosed by inference instead of by reading.

## Why it exists

The `delegated-authorship` scenario currently hardcodes a device secret and credential as a fixture. That fixture never exercises `merod account sign-cert`, so it cannot catch a change in how a credential is *produced* — and the rewrite that introduced it (#375, core#3642) removed the only coverage that path had.

With this, the scenario can mint a device live against a node's own account root and drop the fixture entirely. Fully live is only reachable this way: the root private key never crosses the admin API by design (it leaves a node only via `merod account export`, as a mnemonic), so merobox cannot mint a certificate itself and the offline CLI is the only route.

## Tests

31 in `test_node_exec_step.py`, up from 24 — validation in both directions, all three fields extracted from real `sign-cert` output, a missing match failing the step, and no-`capture` behaviour unchanged.

Mutation-tested: making a missing match export `''` fails `test_a_pattern_that_matches_nothing_fails_the_step` and nothing else. Validation checked end to end against a real workflow — a valid `capture` passes, a malformed regex is rejected naming the field.

`black --check` and `ruff check` clean.