### PR TITLE
chore(release): 0.6.66, carrying node_exec's stdout capture

### DIFF
--- a/merobox/__init__.py
+++ b/merobox/__init__.py
@@ -2,6 +2,6 @@
 Merobox - A Python CLI tool for managing Calimero nodes in Docker containers.
 """
 
-__version__ = "0.6.65"
+__version__ = "0.6.66"
 __author__ = "Calimero Ltd."
 __email__ = "engineering@calimero.network"


### PR DESCRIPTION
Publishes #380 (merged as `ea5e970bb`), which lets a step pull named fields out of an offline `merod` command's output:

```yaml
capture:
  author_secret: '^Secret: +([0-9a-f]{64})$'
```

## Why core needs it

core's `delegated-authorship` e2e currently **hardcodes a device secret and credential** as a fixture. That fixture never runs `merod account sign-cert`, so it cannot catch a change in how a credential is *produced* — and the rewrite that introduced it removed the only coverage that path had.

With `capture`, the scenario mints a device live against a node's own account root and drops the fixture. That is the only route to fully-live material: the root private key never crosses the admin API by design, so merobox cannot mint a certificate itself and the offline CLI is the only way in.

## Checked

93 unit tests pass, `black --check` clean. `0.6.65` is the current release, hence `0.6.66`.